### PR TITLE
Fix TestProvisionWithInvalidEkCert failure

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -38,9 +38,8 @@ const (
 	defaultSessionHashAlgorithm tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
 )
 
-var (
-	// Default RSA2048 EK template, see section B.3.3 of "TCG EK Credential Profile For TPM Family 2.0; Level 0", Version 2.1, Revision 13, 10 December 2018
-	ekTemplate = &tpm2.Public{
+func makeDefaultEKTemplate() *tpm2.Public {
+	return &tpm2.Public{
 		Type:    tpm2.ObjectTypeRSA,
 		NameAlg: tpm2.HashAlgorithmSHA256,
 		Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrAdminWithPolicy | tpm2.AttrRestricted |
@@ -57,4 +56,9 @@ var (
 				KeyBits:  2048,
 				Exponent: 0}},
 		Unique: tpm2.PublicIDU{Data: make(tpm2.PublicKeyRSA, 256)}}
+}
+
+var (
+	// Default RSA2048 EK template, see section B.3.3 of "TCG EK Credential Profile For TPM Family 2.0; Level 0", Version 2.1, Revision 13, 10 December 2018
+	ekTemplate = makeDefaultEKTemplate()
 )

--- a/constants.go
+++ b/constants.go
@@ -40,7 +40,7 @@ const (
 
 var (
 	// Default RSA2048 EK template, see section B.3.3 of "TCG EK Credential Profile For TPM Family 2.0; Level 0", Version 2.1, Revision 13, 10 December 2018
-	ekTemplate = tpm2.Public{
+	ekTemplate = &tpm2.Public{
 		Type:    tpm2.ObjectTypeRSA,
 		NameAlg: tpm2.HashAlgorithmSHA256,
 		Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrAdminWithPolicy | tpm2.AttrRestricted |

--- a/export_test.go
+++ b/export_test.go
@@ -37,6 +37,7 @@ const (
 var (
 	EkTemplate                     = ekTemplate
 	LockNVIndexAttrs               = lockNVIndexAttrs
+	MakeDefaultEKTemplate	       = makeDefaultEKTemplate
 	OidExtensionSubjectAltName     = oidExtensionSubjectAltName
 	OidTcgAttributeTpmManufacturer = oidTcgAttributeTpmManufacturer
 	OidTcgAttributeTpmModel        = oidTcgAttributeTpmModel

--- a/export_test.go
+++ b/export_test.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	EkTemplate                     = ekTemplate
+	EkTemplate                     = &ekTemplate
 	LockNVIndexAttrs               = lockNVIndexAttrs
 	OidExtensionSubjectAltName     = oidExtensionSubjectAltName
 	OidTcgAttributeTpmManufacturer = oidTcgAttributeTpmManufacturer

--- a/export_test.go
+++ b/export_test.go
@@ -62,7 +62,7 @@ func AppendRootCAHash(h []byte) {
 	rootCAHashes = append(rootCAHashes, h)
 }
 
-func MockEKTemplate(mock *tpm2.Public) (func()) {
+func MockEKTemplate(mock *tpm2.Public) (restore func()) {
 	orig := ekTemplate
 	ekTemplate = mock
 	return func() {

--- a/export_test.go
+++ b/export_test.go
@@ -21,6 +21,8 @@ package secboot
 
 import (
 	"io"
+
+	"github.com/chrisccoulson/go-tpm2"
 )
 
 const (
@@ -33,7 +35,7 @@ const (
 )
 
 var (
-	EkTemplate                     = &ekTemplate
+	EkTemplate                     = ekTemplate
 	LockNVIndexAttrs               = lockNVIndexAttrs
 	OidExtensionSubjectAltName     = oidExtensionSubjectAltName
 	OidTcgAttributeTpmManufacturer = oidTcgAttributeTpmManufacturer
@@ -57,4 +59,12 @@ func InitTPMConnection(t *TPMConnection) error {
 
 func AppendRootCAHash(h []byte) {
 	rootCAHashes = append(rootCAHashes, h)
+}
+
+func MockEKTemplate(mock *tpm2.Public) (func()) {
+	orig := ekTemplate
+	ekTemplate = mock
+	return func() {
+		ekTemplate = orig
+	}
 }

--- a/provisioning.go
+++ b/provisioning.go
@@ -203,7 +203,7 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte)
 	}
 
 	// Provision an endorsement key
-	if _, err := provisionPrimaryKey(tpm.TPMContext, tpm.EndorsementHandleContext(), &ekTemplate, ekHandle, session); err != nil {
+	if _, err := provisionPrimaryKey(tpm.TPMContext, tpm.EndorsementHandleContext(), ekTemplate, ekHandle, session); err != nil {
 		var tpmErr *tpm2.TPMError
 		switch {
 		case xerrors.As(err, &tpmErr) && tpmErr.Command == tpm2.CommandEvictControl:

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -551,10 +551,27 @@ func TestProvisionWithInvalidEkCert(t *testing.T) {
 	clearTPMWithPlatformAuth(t, tpm)
 
 	// Temporarily modify the public template so that ProvisionTPM generates a primary key that doesn't match the EK cert
-	EkTemplate.Unique.RSA()[0] = 0xff
-	defer func() {
-		EkTemplate.Unique.RSA()[0] = 0x00
-	}()
+	mockEkTemplateUnique := make(tpm2.PublicKeyRSA, 256)
+	mockEkTemplateUnique[0] = 0xff
+
+	restore := MockEKTemplate(&tpm2.Public{
+		Type:    tpm2.ObjectTypeRSA,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrAdminWithPolicy | tpm2.AttrRestricted |
+			tpm2.AttrDecrypt,
+		AuthPolicy: []byte{0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xb3, 0xf8, 0x1a, 0x90, 0xcc, 0x8d, 0x46, 0xa5, 0xd7, 0x24, 0xfd, 0x52, 0xd7,
+			0x6e, 0x06, 0x52, 0x0b, 0x64, 0xf2, 0xa1, 0xda, 0x1b, 0x33, 0x14, 0x69, 0xaa},
+		Params: tpm2.PublicParamsU{
+			Data: &tpm2.RSAParams{
+				Symmetric: tpm2.SymDefObject{
+					Algorithm: tpm2.SymObjectAlgorithmAES,
+					KeyBits:   tpm2.SymKeyBitsU{Data: uint16(128)},
+					Mode:      tpm2.SymModeU{Data: tpm2.SymModeCFB}},
+				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
+				KeyBits:  2048,
+				Exponent: 0}},
+		Unique: tpm2.PublicIDU{Data: mockEkTemplateUnique}})
+	defer restore()
 
 	err := ProvisionTPM(tpm, ProvisionModeFull, nil)
 	if err == nil {

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -551,26 +551,9 @@ func TestProvisionWithInvalidEkCert(t *testing.T) {
 	clearTPMWithPlatformAuth(t, tpm)
 
 	// Temporarily modify the public template so that ProvisionTPM generates a primary key that doesn't match the EK cert
-	mockEkTemplateUnique := make(tpm2.PublicKeyRSA, 256)
-	mockEkTemplateUnique[0] = 0xff
-
-	restore := MockEKTemplate(&tpm2.Public{
-		Type:    tpm2.ObjectTypeRSA,
-		NameAlg: tpm2.HashAlgorithmSHA256,
-		Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrAdminWithPolicy | tpm2.AttrRestricted |
-			tpm2.AttrDecrypt,
-		AuthPolicy: []byte{0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xb3, 0xf8, 0x1a, 0x90, 0xcc, 0x8d, 0x46, 0xa5, 0xd7, 0x24, 0xfd, 0x52, 0xd7,
-			0x6e, 0x06, 0x52, 0x0b, 0x64, 0xf2, 0xa1, 0xda, 0x1b, 0x33, 0x14, 0x69, 0xaa},
-		Params: tpm2.PublicParamsU{
-			Data: &tpm2.RSAParams{
-				Symmetric: tpm2.SymDefObject{
-					Algorithm: tpm2.SymObjectAlgorithmAES,
-					KeyBits:   tpm2.SymKeyBitsU{Data: uint16(128)},
-					Mode:      tpm2.SymModeU{Data: tpm2.SymModeCFB}},
-				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
-				KeyBits:  2048,
-				Exponent: 0}},
-		Unique: tpm2.PublicIDU{Data: mockEkTemplateUnique}})
+	ekTemplate := MakeDefaultEKTemplate()
+	ekTemplate.Unique.RSA()[0] = 0xff
+	restore := MockEKTemplate(ekTemplate)
 	defer restore()
 
 	err := ProvisionTPM(tpm, ProvisionModeFull, nil)

--- a/tpm.go
+++ b/tpm.go
@@ -130,7 +130,7 @@ func createTransientEk(tpm *tpm2.TPMContext) (tpm2.ResourceContext, error) {
 	}
 	defer tpm.FlushContext(session)
 
-	ek, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, &ekTemplate, nil, nil, session)
+	ek, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, ekTemplate, nil, nil, session)
 	return ek, err
 }
 
@@ -275,7 +275,7 @@ func (t *TPMConnection) init() error {
 		// If we don't have a verified EK certificate and ek is a persistent object, just do a sanity check that the public area returned
 		// from the TPM has the expected properties. If it doesn't, then attempt to create a transient EK with the provided authorization
 		// value.
-		if ok, err := isObjectPrimaryKeyWithTemplate(t.TPMContext, t.EndorsementHandleContext(), ek, &ekTemplate, nil); err != nil {
+		if ok, err := isObjectPrimaryKeyWithTemplate(t.TPMContext, t.EndorsementHandleContext(), ek, ekTemplate, nil); err != nil {
 			return xerrors.Errorf("cannot determine if object is a primary key in the endorsement hierarchy: %w", err)
 		} else if !ok {
 			transientEk, err := createTransientEk(t.TPMContext)

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -171,7 +171,7 @@ func createTestCA() ([]byte, crypto.PrivateKey, error) {
 }
 
 func createTestEkCert(tpm *tpm2.TPMContext, caCert []byte, caKey crypto.PrivateKey) ([]byte, error) {
-	ekContext, pub, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, &EkTemplate, nil, nil, nil)
+	ekContext, pub, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, EkTemplate, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create EK: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestConnectToDefaultTPM(t *testing.T) {
 			tpm := connectAndClear(t)
 			defer closeTPM(t, tpm)
 
-			primary, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, &EkTemplate, nil, nil, nil)
+			primary, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, EkTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}
@@ -366,7 +366,7 @@ func TestConnectToDefaultTPM(t *testing.T) {
 				t.Fatalf("PolicySecret failed: %v", err)
 			}
 
-			priv, pub, _, _, _, err := tpm.Create(primary, nil, &EkTemplate, nil, nil, sessionContext)
+			priv, pub, _, _, _, err := tpm.Create(primary, nil, EkTemplate, nil, nil, sessionContext)
 			if err != nil {
 				t.Fatalf("Create failed: %v", err)
 			}
@@ -634,7 +634,7 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 
 			// This produces a primary key that doesn't match the certificate created in TestMain
 			sensitive := tpm2.SensitiveCreate{Data: []byte("foo")}
-			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, &EkTemplate, nil, nil, nil)
+			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, EkTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}
@@ -657,7 +657,7 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 
 			// This produces a primary key that doesn't match the certificate created in TestMain
 			sensitive := tpm2.SensitiveCreate{Data: []byte("foo")}
-			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, &EkTemplate, nil, nil, nil)
+			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, EkTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}
@@ -685,7 +685,7 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 
 			// This produces a primary key that doesn't match the certificate created in TestMain
 			sensitive := tpm2.SensitiveCreate{Data: []byte("foo")}
-			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, &EkTemplate, nil, nil, nil)
+			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, EkTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}


### PR DESCRIPTION
--- FAIL: TestProvisionWithInvalidEkCert (4.06s)
provisioning_test.go:561: ProvisionTPM should have returned an error

The intention of the test is for it to temporarily modify the template used for
creating the endorsement key, but this fails in go 1.10 because the template
exported to the test is a copy of the one that ProvisionTPM uses.