### PR TITLE
Alias staticPolicyData and dynamicPolicyData in export_test.go

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -59,9 +59,7 @@ var PerformPinChange = performPinChange
 var ReadAndValidateLockNVIndexPublic = readAndValidateLockNVIndexPublic
 var ReadDynamicPolicyCounter = readDynamicPolicyCounter
 
-type DynamicPolicyData struct {
-	*dynamicPolicyData
-}
+type DynamicPolicyData dynamicPolicyData
 
 type MockPolicyPCRParam struct {
 	PCR     int
@@ -69,20 +67,10 @@ type MockPolicyPCRParam struct {
 	Digests tpm2.DigestList
 }
 
-type StaticPolicyData struct {
-	*staticPolicyData
-}
+type StaticPolicyData staticPolicyData
 
 func AppendRootCAHash(h []byte) {
 	rootCAHashes = append(rootCAHashes, h)
-}
-
-func AsDynamicPolicyData(in *dynamicPolicyData) *DynamicPolicyData {
-	return &DynamicPolicyData{in}
-}
-
-func AsStaticPolicyData(in *staticPolicyData) *StaticPolicyData {
-	return &StaticPolicyData{in}
 }
 
 func InitTPMConnection(t *TPMConnection) error {

--- a/policy_test.go
+++ b/policy_test.go
@@ -865,7 +865,7 @@ func TestExecutePolicy(t *testing.T) {
 		}
 
 		if prepare != nil {
-			prepare(AsStaticPolicyData(staticPolicyData), AsDynamicPolicyData(dynamicPolicyData))
+			prepare((*StaticPolicyData)(staticPolicyData), (*DynamicPolicyData)(dynamicPolicyData))
 		}
 
 		session, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, data.alg)


### PR DESCRIPTION
This provides aliases of staticPolicyData and dynamicPolicyData, exported for testing, rather than the unnecessary structs that are currently exported.