### PR TITLE
Support compound authorization policies with more than 8 conditions

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -48,10 +48,12 @@ var (
 )
 
 var ComputeDynamicPolicy = computeDynamicPolicy
+var ComputePolicyORData = computePolicyORData
 var ComputeStaticPolicy = computeStaticPolicy
 var CreatePinNVIndex = createPinNVIndex
 var CreatePublicAreaForRSASigningKey = createPublicAreaForRSASigningKey
 var EnsureLockNVIndex = ensureLockNVIndex
+var ExecutePolicyORAssertions = executePolicyORAssertions
 var ExecutePolicySession = executePolicySession
 var IncrementDynamicPolicyCounter = incrementDynamicPolicyCounter
 var LockAccessToSealedKeysUntilTPMReset = lockAccessToSealedKeysUntilTPMReset

--- a/utils.go
+++ b/utils.go
@@ -150,3 +150,13 @@ func createPublicAreaForRSASigningKey(key *rsa.PublicKey) *tpm2.Public {
 				Exponent:  uint32(key.E)}},
 		Unique: tpm2.PublicIDU{Data: tpm2.PublicKeyRSA(key.N.Bytes())}}
 }
+
+// digestListContains indicates whether the specified digest is present in the list of digests.
+func digestListContains(list tpm2.DigestList, digest tpm2.Digest) bool {
+	for _, d := range list {
+		if bytes.Equal(d, digest) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
TPM2_PolicyOR only supports 8 conditions, but merging all TPM2_PolicyPCR assertions in to a single assertion makes it more likely that we may generate compound authorization policies with more than 8 conditions in some more complex transient cases. This adds support for more than 8 conditions.