### PR TITLE
Add key sealing and unsealing APIs

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -58,7 +58,28 @@ func makeDefaultEKTemplate() *tpm2.Public {
 		Unique: tpm2.PublicIDU{Data: make(tpm2.PublicKeyRSA, 256)}}
 }
 
+func makeDefaultSRKTemplate() *tpm2.Public {
+	return &tpm2.Public{
+		Type:    tpm2.ObjectTypeRSA,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrUserWithAuth | tpm2.AttrNoDA |
+			tpm2.AttrRestricted | tpm2.AttrDecrypt,
+		Params: tpm2.PublicParamsU{
+			Data: &tpm2.RSAParams{
+				Symmetric: tpm2.SymDefObject{
+					Algorithm: tpm2.SymObjectAlgorithmAES,
+					KeyBits:   tpm2.SymKeyBitsU{Data: uint16(128)},
+					Mode:      tpm2.SymModeU{Data: tpm2.SymModeCFB}},
+				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
+				KeyBits:  2048,
+				Exponent: 0}},
+		Unique: tpm2.PublicIDU{Data: make(tpm2.PublicKeyRSA, 256)}}
+}
+
 var (
 	// Default RSA2048 EK template, see section B.3.3 of "TCG EK Credential Profile For TPM Family 2.0; Level 0", Version 2.1, Revision 13, 10 December 2018
 	ekTemplate = makeDefaultEKTemplate()
+
+	// srkTemplate is the default RSA2048 SRK template, see section 7.5.1 of "TCG TPM v2.0 Provisioning Guidance", version 1.0, revision 1.0, 15 March 2017.
+	srkTemplate = makeDefaultSRKTemplate()
 )

--- a/errors.go
+++ b/errors.go
@@ -40,6 +40,9 @@ var (
 	// the TPM exits lockout mode, the key will need to be recovered via a mechanism that is independent of
 	// the TPM (eg, a recovery key)
 	ErrTPMLockout = errors.New("the TPM is in DA lockout mode")
+
+	// ErrPinFail is returned from SealedKeyObject.UnsealFromTPM if the provided PIN is incorrect.
+	ErrPinFail = errors.New("the provided PIN is incorrect")
 )
 
 // TPMResourceExistsError is returned from any function that creates a persistent TPM resource if a resource already exists
@@ -85,4 +88,15 @@ type TPMVerificationError struct {
 
 func (e TPMVerificationError) Error() string {
 	return fmt.Sprintf("cannot verify that the TPM is the device for which the supplied EK certificate was issued: %s", e.msg)
+}
+
+// InvalidKeyFileError indicates that the provided key data file is invalid. This error may also be returned in some
+// scenarious where the TPM is incorrectly provisioned, but it isn't possible to determine whether the error is with
+// the provisioning status or because the key data file is invalid.
+type InvalidKeyFileError struct {
+	msg string
+}
+
+func (e InvalidKeyFileError) Error() string {
+	return fmt.Sprintf("invalid key data file: %s", e.msg)
 }

--- a/errors.go
+++ b/errors.go
@@ -41,8 +41,8 @@ var (
 	// the TPM (eg, a recovery key)
 	ErrTPMLockout = errors.New("the TPM is in DA lockout mode")
 
-	// ErrPinFail is returned from SealedKeyObject.UnsealFromTPM if the provided PIN is incorrect.
-	ErrPinFail = errors.New("the provided PIN is incorrect")
+	// ErrPINFail is returned from SealedKeyObject.UnsealFromTPM if the provided PIN is incorrect.
+	ErrPINFail = errors.New("the provided PIN is incorrect")
 
 	// ErrSealedKeyAccessLocked is returned from SealedKeyObject.UnsealFromTPM if the sealed key object cannot be unsealed until the
 	// next TPM reset or restart.

--- a/errors.go
+++ b/errors.go
@@ -43,6 +43,10 @@ var (
 
 	// ErrPinFail is returned from SealedKeyObject.UnsealFromTPM if the provided PIN is incorrect.
 	ErrPinFail = errors.New("the provided PIN is incorrect")
+
+	// ErrSealedKeyAccessLocked is returned from SealedKeyObject.UnsealFromTPM if the sealed key object cannot be unsealed until the
+	// next TPM reset or restart.
+	ErrSealedKeyAccessLocked = errors.New("cannot access the sealed key object until the next TPM reset or restart")
 )
 
 // TPMResourceExistsError is returned from any function that creates a persistent TPM resource if a resource already exists

--- a/export_test.go
+++ b/export_test.go
@@ -215,7 +215,7 @@ func NewDynamicPolicyComputeParams(key *rsa.PrivateKey, signAlg tpm2.HashAlgorit
 		policyCount:          policyCount}
 }
 
-func NewStaticPolicyComputeParams(key *rsa.PublicKey, pinIndexPub *tpm2.NVPublic, pinIndexAuthPolicies tpm2.DigestList, lockIndexName tpm2.Name) *staticPolicyComputeParams {
+func NewStaticPolicyComputeParams(key *tpm2.Public, pinIndexPub *tpm2.NVPublic, pinIndexAuthPolicies tpm2.DigestList, lockIndexName tpm2.Name) *staticPolicyComputeParams {
 	return &staticPolicyComputeParams{key: key, pinIndexPub: pinIndexPub, pinIndexAuthPolicies: pinIndexAuthPolicies, lockIndexName: lockIndexName}
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -55,6 +55,8 @@ var (
 	ExecutePolicySession                     = executePolicySession
 	IdentifyInitialOSLaunchVerificationEvent = identifyInitialOSLaunchVerificationEvent
 	IncrementDynamicPolicyCounter            = incrementDynamicPolicyCounter
+	IsDynamicPolicyDataError                 = isDynamicPolicyDataError
+	IsStaticPolicyDataError                  = isStaticPolicyDataError
 	LockAccessToSealedKeysUntilTPMReset      = lockAccessToSealedKeysUntilTPMReset
 	LockNVIndexAttrs                         = lockNVIndexAttrs
 	MakeDefaultEKTemplate                    = makeDefaultEKTemplate

--- a/keydata.go
+++ b/keydata.go
@@ -360,7 +360,7 @@ func readAndValidateKeyData(tpm *tpm2.TPMContext, keyFile, keyPolicyUpdateFile i
 
 	pinNVPublic, err := validateKeyData(tpm, data, policyUpdateData, session)
 	if err != nil {
-		return nil, nil, nil, xerrors.Errorf("key data validation failed: %w", err)
+		return nil, nil, nil, xerrors.Errorf("cannot validate key data: %w", err)
 	}
 
 	return data, policyUpdateData, pinNVPublic, nil

--- a/keydata.go
+++ b/keydata.go
@@ -1,0 +1,402 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+
+	"github.com/chrisccoulson/go-tpm2"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/sys"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	currentVersion            uint32 = 0
+	keyDataHeader             uint32 = 0x55534b24
+	keyPolicyUpdateDataHeader uint32 = 0x55534b50
+)
+
+// AuthMode corresponds to an authentication mechanism.
+type AuthMode uint8
+
+const (
+	AuthModeNone AuthMode = iota
+	AuthModePIN
+)
+
+// keyPolicyUpdateData corresponds to the private part of a sealed key object that is required in order to create new dynamic
+// authorization policies.
+type keyPolicyUpdateData struct {
+	Data struct {
+		AuthKey []byte
+	}
+	CreationData   *tpm2.CreationData
+	CreationTicket *tpm2.TkCreation
+}
+
+// keyData corresponds to the part of a sealed key object that contains the TPM sealed object and associated metadata required
+// for executing authorization policy assertions.
+type keyData struct {
+	KeyPrivate        tpm2.Private
+	KeyPublic         *tpm2.Public
+	AuthModeHint      AuthMode
+	StaticPolicyData  *staticPolicyData
+	DynamicPolicyData *dynamicPolicyData
+}
+
+// readKeyPolicyUpdateData deserializes keyPolicyUpdateData from the provided io.Reader.
+func readKeyPolicyUpdateData(buf io.Reader) (*keyPolicyUpdateData, error) {
+	var header uint32
+	var version uint32
+	if err := tpm2.UnmarshalFromReader(buf, &header, &version); err != nil {
+		return nil, xerrors.Errorf("cannot unmarshal header and version number: %w", err)
+	}
+
+	if header != keyPolicyUpdateDataHeader {
+		return nil, fmt.Errorf("unexpected header (%d)", header)
+	}
+	if version != currentVersion {
+		return nil, fmt.Errorf("unexpected version number (%d)", version)
+	}
+
+	var d keyPolicyUpdateData
+	if err := tpm2.UnmarshalFromReader(buf, &d); err != nil {
+		return nil, xerrors.Errorf("cannot unmarshal key data: %w", err)
+	}
+
+	return &d, nil
+}
+
+// write serializes keyPolicyUpdateData to the provided io.Writer.
+func (d *keyPolicyUpdateData) write(buf io.Writer) error {
+	return tpm2.MarshalToWriter(buf, keyPolicyUpdateDataHeader, currentVersion, d)
+}
+
+type keyFileError struct {
+	err error
+}
+
+func (e keyFileError) Error() string {
+	return e.err.Error()
+}
+
+func (e keyFileError) Unwrap() error {
+	return e.err
+}
+
+func isKeyFileError(err error) bool {
+	var e keyFileError
+	return xerrors.As(err, &e)
+}
+
+// readKeyData deserializes keyData from the provided io.Reader.
+func readKeyData(buf io.Reader) (*keyData, error) {
+	var header uint32
+	var version uint32
+	if err := tpm2.UnmarshalFromReader(buf, &header, &version); err != nil {
+		return nil, keyFileError{xerrors.Errorf("cannot unmarshal header and version number: %w", err)}
+	}
+
+	if header != keyDataHeader {
+		return nil, keyFileError{fmt.Errorf("unexpected header (%d)", header)}
+	}
+	if version != currentVersion {
+		return nil, keyFileError{fmt.Errorf("unexpected version number (%d)", version)}
+	}
+
+	var d keyData
+	if err := tpm2.UnmarshalFromReader(buf, &d); err != nil {
+		return nil, keyFileError{xerrors.Errorf("cannot unmarshal key data: %w", err)}
+	}
+
+	return &d, nil
+}
+
+// load loads the TPM sealed object associated with this keyData in to the storage hierarchy of the TPM, and returns the newly
+// created tpm2.ResourceContext.
+func (d *keyData) load(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
+	srkContext, err := tpm.CreateResourceContextFromTPM(srkHandle)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
+	}
+
+	keyContext, err := tpm.Load(srkContext, d.KeyPrivate, d.KeyPublic, session)
+	if err != nil {
+		invalidObject := false
+		switch {
+		case tpm2.IsTPMParameterError(err, tpm2.AnyErrorCode, tpm2.CommandLoad, tpm2.AnyParameterIndex):
+			invalidObject = true
+		case tpm2.IsTPMError(err, tpm2.ErrorSensitive, tpm2.CommandLoad):
+			invalidObject = true
+		}
+		if invalidObject {
+			return nil, keyFileError{errors.New("cannot load sealed key object in to TPM: bad sealed key object or TPM owner changed")}
+		}
+		return nil, xerrors.Errorf("cannot load sealed key object in to TPM: %w", err)
+	}
+
+	return keyContext, nil
+}
+
+// write serializes keyData in to the provided io.Writer.
+func (d *keyData) write(buf io.Writer) error {
+	return tpm2.MarshalToWriter(buf, keyDataHeader, currentVersion, d)
+}
+
+// writeToFileAtomic serializes keyData and writes it atomically to the file at the specified path.
+func (d *keyData) writeToFileAtomic(dest string) error {
+	f, err := osutil.NewAtomicFile(dest, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
+	if err != nil {
+		return xerrors.Errorf("cannot create new atomic file: %w", err)
+	}
+	defer f.Cancel()
+
+	if err := tpm2.MarshalToWriter(f, keyDataHeader, currentVersion, d); err != nil {
+		return xerrors.Errorf("cannot marshal key data to temporary file: %w", err)
+	}
+
+	if err := f.Commit(); err != nil {
+		return xerrors.Errorf("cannot atomically replace file: %w", err)
+	}
+
+	return nil
+}
+
+// validateKeyData performs some correctness checking on the provided keyData and keyPolicyUpdateData. On success, it returns the validated
+// public area for the PIN NV index.
+func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyPolicyUpdateData, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
+	srkContext, err := tpm.CreateResourceContextFromTPM(srkHandle)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
+	}
+
+	// Perform some initial checks on the sealed data object's public area
+	if data.KeyPublic.Type != tpm2.ObjectTypeKeyedHash {
+		return nil, keyFileError{errors.New("sealed key object has the wrong type")}
+	}
+	if data.KeyPublic.Attrs != (tpm2.AttrFixedTPM | tpm2.AttrFixedParent) {
+		return nil, keyFileError{errors.New("sealed key object has the wrong attributes")}
+	}
+
+	// Load the sealed data object in to the TPM for integrity checking
+	keyContext, err := tpm.Load(srkContext, data.KeyPrivate, data.KeyPublic, session)
+	if err != nil {
+		invalidObject := false
+		switch {
+		case tpm2.IsTPMParameterError(err, tpm2.AnyErrorCode, tpm2.CommandLoad, tpm2.AnyParameterIndex):
+			invalidObject = true
+		case tpm2.IsTPMError(err, tpm2.ErrorSensitive, tpm2.CommandLoad):
+			invalidObject = true
+		}
+		if invalidObject {
+			return nil, keyFileError{errors.New("cannot load sealed key object in to TPM: bad sealed key object or TPM owner changed")}
+		}
+		return nil, xerrors.Errorf("cannot load sealed key object in to TPM: %w", err)
+	}
+	// It's loaded ok, so we know that the private and public parts are consistent.
+	defer tpm.FlushContext(keyContext)
+
+	lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create context for lock NV index: %v", err)
+	}
+	lockIndexPub, err := readAndValidateLockNVIndexPublic(tpm, lockIndex, session)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot determine if NV index at 0x%08x is global lock index: %w", lockNVHandle, err)
+	}
+	if lockIndexPub == nil {
+		return nil, xerrors.Errorf("NV index at 0x%08x is not a valid global lock index", lockNVHandle)
+	}
+
+	// Obtain a ResourceContext for the PIN NV index. Go-tpm2 calls TPM2_NV_ReadPublic twice here. The second time is with a session, and
+	// there is also verification that the returned public area is for the specified handle so that we know that the returned
+	// ResourceContext corresponds to an actual entity on the TPM at PinIndexHandle.
+	if data.StaticPolicyData.PinIndexHandle.Type() != tpm2.HandleTypeNVIndex {
+		return nil, keyFileError{errors.New("PIN NV index handle is invalid")}
+	}
+	pinIndex, err := tpm.CreateResourceContextFromTPM(data.StaticPolicyData.PinIndexHandle, session.IncludeAttrs(tpm2.AttrAudit))
+	if err != nil {
+		if tpm2.IsResourceUnavailableError(err, data.StaticPolicyData.PinIndexHandle) {
+			return nil, keyFileError{errors.New("PIN NV index is unavailable")}
+		}
+		return nil, xerrors.Errorf("cannot create context for PIN NV index: %w", err)
+	}
+
+	authKeyName, err := data.StaticPolicyData.AuthPublicKey.Name()
+	if err != nil {
+		return nil, keyFileError{xerrors.Errorf("cannot compute name of dynamic authorization policy key: %w", err)}
+	}
+	if data.StaticPolicyData.AuthPublicKey.Type != tpm2.ObjectTypeRSA {
+		return nil, keyFileError{errors.New("public area of dynamic authorization policy signing key has the wrong type")}
+	}
+
+	// Make sure that the static authorization policy data is consistent with the sealed key object's policy.
+	trial, err := tpm2.ComputeAuthPolicy(data.KeyPublic.NameAlg)
+	if err != nil {
+		return nil, keyFileError{xerrors.Errorf("cannot determine if static authorization policy matches sealed key object: %w", err)}
+	}
+	trial.PolicyAuthorize(nil, authKeyName)
+	trial.PolicySecret(pinIndex.Name(), nil)
+	trial.PolicyNV(lockIndex.Name(), nil, 0, tpm2.OpEq)
+
+	if !bytes.Equal(trial.GetDigest(), data.KeyPublic.AuthPolicy) {
+		return nil, keyFileError{errors.New("the sealed key object's authorization policy is inconsistent with the associatedc metadata or persistent TPM resources")}
+	}
+
+	pinIndexPublic, _, err := tpm.NVReadPublic(pinIndex, session.IncludeAttrs(tpm2.AttrAudit))
+	if err != nil {
+		return nil, xerrors.Errorf("cannot read public area of PIN NV index: %w", err)
+	}
+
+	expectedPinIndexAuthPolicies, err := computePinNVIndexPostInitAuthPolicies(pinIndexPublic.NameAlg, authKeyName)
+	if err != nil {
+		return nil, keyFileError{xerrors.Errorf("cannot determine if PIN NV index has a valid authorization policy: %w", err)}
+	}
+	if len(data.StaticPolicyData.PinIndexAuthPolicies)-1 != len(expectedPinIndexAuthPolicies) {
+		return nil, keyFileError{errors.New("unexpected number of OR policy digests for PIN NV index")}
+	}
+	for i, expected := range expectedPinIndexAuthPolicies {
+		if !bytes.Equal(expected, data.StaticPolicyData.PinIndexAuthPolicies[i+1]) {
+			return nil, keyFileError{errors.New("unexpected OR policy digest for PIN NV index")}
+		}
+	}
+
+	trial, _ = tpm2.ComputeAuthPolicy(pinIndexPublic.NameAlg)
+	trial.PolicyOR(data.StaticPolicyData.PinIndexAuthPolicies)
+	if !bytes.Equal(pinIndexPublic.AuthPolicy, trial.GetDigest()) {
+		return nil, keyFileError{errors.New("PIN NV index has unexpected authorization policy")}
+	}
+
+	// At this point, we know that the sealed object is an object with an authorization policy created by this package and with
+	// matching static metadata and persistent TPM resources.
+
+	if policyUpdateData == nil {
+		// If we weren't passed a private data structure, we're done.
+		return pinIndexPublic, nil
+	}
+
+	// Verify that the private data structure is bound to the key data structure.
+	h := data.KeyPublic.NameAlg.NewHash()
+	if err := tpm2.MarshalToWriter(h, policyUpdateData.CreationData); err != nil {
+		panic(fmt.Sprintf("cannot marshal creation data: %v", err))
+	}
+
+	if _, _, err := tpm.CertifyCreation(nil, keyContext, nil, h.Sum(nil), nil, policyUpdateData.CreationTicket, nil,
+		session.IncludeAttrs(tpm2.AttrAudit)); err != nil {
+		if tpm2.IsTPMParameterError(err, tpm2.ErrorTicket, tpm2.CommandCertifyCreation, 4) {
+			return nil, keyFileError{errors.New("key data file and dynamic authorization policy update data file mismatch: invalid creation ticket")}
+		}
+		return nil, xerrors.Errorf("cannot validate creation data for sealed data object: %w", err)
+	}
+
+	h = crypto.SHA256.New()
+	if err := tpm2.MarshalToWriter(h, &policyUpdateData.Data); err != nil {
+		panic(fmt.Sprintf("cannot marshal dynamic authorization policy update data: %v", err))
+	}
+
+	if !bytes.Equal(h.Sum(nil), policyUpdateData.CreationData.OutsideInfo) {
+		return nil, keyFileError{errors.New("key data file and dynamic authorization policy update data file mismatch: digest doesn't match creation data")}
+	}
+
+	authKey, err := x509.ParsePKCS1PrivateKey(policyUpdateData.Data.AuthKey)
+	if err != nil {
+		return nil, keyFileError{xerrors.Errorf("cannot parse dynamic authorization policy signing key: %w", err)}
+	}
+
+	authPublicKey := rsa.PublicKey{
+		N: new(big.Int).SetBytes(data.StaticPolicyData.AuthPublicKey.Unique.RSA()),
+		E: int(data.StaticPolicyData.AuthPublicKey.Params.RSADetail().Exponent)}
+	if authKey.PublicKey.E != authPublicKey.E || authKey.PublicKey.N.Cmp(authPublicKey.N) != 0 {
+		return nil, keyFileError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
+	}
+
+	return pinIndexPublic, nil
+}
+
+// readAndValidateKeyData will deserialize keyData and keyPolicyUpdateData from the provided io.Readers and then perform some correctness
+// checking. On success, it returns the keyData, keyPolicyUpdateData and the validated public area of the PIN NV index.
+func readAndValidateKeyData(tpm *tpm2.TPMContext, keyFile, keyPolicyUpdateFile io.Reader, session tpm2.SessionContext) (*keyData, *keyPolicyUpdateData, *tpm2.NVPublic, error) {
+	// Read the key data
+	data, err := readKeyData(keyFile)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot read key data: %w", err)
+	}
+
+	var policyUpdateData *keyPolicyUpdateData
+	if keyPolicyUpdateFile != nil {
+		var err error
+		policyUpdateData, err = readKeyPolicyUpdateData(keyPolicyUpdateFile)
+		if err != nil {
+			return nil, nil, nil, xerrors.Errorf("cannot read dynamic policy authorization data: %w", err)
+		}
+	}
+
+	pinNVPublic, err := validateKeyData(tpm, data, policyUpdateData, session)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("key data validation failed: %w", err)
+	}
+
+	return data, policyUpdateData, pinNVPublic, nil
+}
+
+// SealedKeyObject corresponds to a sealed key data file and exists to provide access to some read only operations on the underlying
+// file without having to read and deserialize the key data file more than once.
+type SealedKeyObject struct {
+	data *keyData
+}
+
+// AuthMode2F indicates the 2nd-factor authentication type for this sealed key object.
+func (k *SealedKeyObject) AuthMode2F() AuthMode {
+	return k.data.AuthModeHint
+}
+
+// PINIndexHandle indicates the handle of the NV index used for PIN support for this sealed key object.
+func (k *SealedKeyObject) PINIndexHandle() tpm2.Handle {
+	return k.data.StaticPolicyData.PinIndexHandle
+}
+
+// LoadSealedKeyObject loads a sealed key data file created by SealKeyToTPM from the specified path. If the file cannot be opened,
+// a wrapped *os.PathError error is returned. If the key data file cannot be deserialized successfully, a InvalidKeyFileError error
+// will be returned.
+func LoadSealedKeyObject(path string) (*SealedKeyObject, error) {
+	// Open the key data file
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot open key data file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := readKeyData(f)
+	if err != nil {
+		return nil, InvalidKeyFileError{err.Error()}
+	}
+
+	return &SealedKeyObject{data: data}, nil
+}

--- a/keydata.go
+++ b/keydata.go
@@ -197,11 +197,13 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
 	}
 
+	sealedKeyTemplate := makeSealedKeyTemplate()
+
 	// Perform some initial checks on the sealed data object's public area
-	if data.KeyPublic.Type != tpm2.ObjectTypeKeyedHash {
+	if data.KeyPublic.Type != sealedKeyTemplate.Type {
 		return nil, keyFileError{errors.New("sealed key object has the wrong type")}
 	}
-	if data.KeyPublic.Attrs != (tpm2.AttrFixedTPM | tpm2.AttrFixedParent) {
+	if data.KeyPublic.Attrs != sealedKeyTemplate.Attrs {
 		return nil, keyFileError{errors.New("sealed key object has the wrong attributes")}
 	}
 

--- a/keydata.go
+++ b/keydata.go
@@ -229,10 +229,10 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 	}
 	lockIndexPub, err := readAndValidateLockNVIndexPublic(tpm, lockIndex, session)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot determine if NV index at 0x%08x is global lock index: %w", lockNVHandle, err)
+		return nil, xerrors.Errorf("cannot determine if NV index at %v is global lock index: %w", lockNVHandle, err)
 	}
 	if lockIndexPub == nil {
-		return nil, xerrors.Errorf("NV index at 0x%08x is not a valid global lock index", lockNVHandle)
+		return nil, xerrors.Errorf("NV index at %v is not a valid global lock index", lockNVHandle)
 	}
 
 	// Obtain a ResourceContext for the PIN NV index. Go-tpm2 calls TPM2_NV_ReadPublic twice here. The second time is with a session, and
@@ -382,10 +382,10 @@ func (k *SealedKeyObject) PINIndexHandle() tpm2.Handle {
 	return k.data.StaticPolicyData.PinIndexHandle
 }
 
-// LoadSealedKeyObject loads a sealed key data file created by SealKeyToTPM from the specified path. If the file cannot be opened,
+// ReadSealedKeyObject loads a sealed key data file created by SealKeyToTPM from the specified path. If the file cannot be opened,
 // a wrapped *os.PathError error is returned. If the key data file cannot be deserialized successfully, a InvalidKeyFileError error
 // will be returned.
-func LoadSealedKeyObject(path string) (*SealedKeyObject, error) {
+func ReadSealedKeyObject(path string) (*SealedKeyObject, error) {
 	// Open the key data file
 	f, err := os.Open(path)
 	if err != nil {

--- a/policy.go
+++ b/policy.go
@@ -793,9 +793,9 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 	if err != nil {
 		if tpm2.IsTPMParameterError(err, tpm2.AnyErrorCode, tpm2.CommandVerifySignature, 2) {
 			// dynamicInput.AuthorizedPolicySignature is invalid.
-			return dynamicPolicyDataError{errors.New("dynamic authorization policy signature verification failed")}
+			return dynamicPolicyDataError{errors.New("cannot verify dynamic authorization policy signature")}
 		}
-		return xerrors.Errorf("dynamic authorization policy signature verification failed: %w", err)
+		return xerrors.Errorf("cannot verify dynamic authorization policy signature: %w", err)
 	}
 
 	if err := tpm.PolicyAuthorize(policySession, dynamicInput.AuthorizedPolicy, nil, authorizeKey.Name(), authorizeTicket); err != nil {

--- a/policy_test.go
+++ b/policy_test.go
@@ -539,6 +539,7 @@ duwzA18V2dm66mFx1NcqfNyRUbclhN26KAaRnTDQrAaxFIgoO+Xm
 	if err != nil {
 		t.Fatalf("ParsePKCS1PrivateKey failed: %v", err)
 	}
+	publicKey := CreatePublicAreaForRSASigningKey(&key.PublicKey)
 
 	// Generate an authorization policy for the PIN NV index public area below. For the purposes of this test, these digests could really
 	// be anything, although the ones here do actually correspond to valid authorization policies - the first one is for initialization
@@ -587,7 +588,7 @@ duwzA18V2dm66mFx1NcqfNyRUbclhN26KAaRnTDQrAaxFIgoO+Xm
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
-			dataout, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(&key.PublicKey, pinIndexPub, pinIndexAuthPolicies, lockName))
+			dataout, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(publicKey, pinIndexPub, pinIndexAuthPolicies, lockName))
 			if err != nil {
 				t.Fatalf("ComputeStaticPolicy failed: %v", err)
 			}
@@ -1236,7 +1237,7 @@ func TestExecutePolicy(t *testing.T) {
 			pinIndexAuthPoliciesCopy = append(pinIndexAuthPoliciesCopy, c)
 		}
 
-		staticPolicyData, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(&key.PublicKey, pinIndexPub, pinIndexAuthPoliciesCopy, lockIndex.Name()))
+		staticPolicyData, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(CreatePublicAreaForRSASigningKey(&key.PublicKey), pinIndexPub, pinIndexAuthPoliciesCopy, lockIndex.Name()))
 		if err != nil {
 			t.Fatalf("ComputeStaticPolicy failed: %v", err)
 		}
@@ -2450,7 +2451,7 @@ func TestLockAccessToSealedKeysUntilTPMReset(t *testing.T) {
 	}
 	defer undefineNVSpace(t, tpm, pinIndex, tpm.OwnerHandleContext())
 
-	staticPolicyData, policy, err := ComputeStaticPolicy(tpm2.HashAlgorithmSHA256, NewStaticPolicyComputeParams(&key.PublicKey, pinIndexPub, pinIndexAuthPolicies, lockIndex.Name()))
+	staticPolicyData, policy, err := ComputeStaticPolicy(tpm2.HashAlgorithmSHA256, NewStaticPolicyComputeParams(keyPublic, pinIndexPub, pinIndexAuthPolicies, lockIndex.Name()))
 	if err != nil {
 		t.Fatalf("ComputeStaticPolicy failed: %v", err)
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -2153,7 +2153,7 @@ func TestExecutePolicy(t *testing.T) {
 		})
 		// Even though this error is caused by broken static metadata, we get a dynamicPolicyDataError error because the signature
 		// verification fails. Validation with validateKeyData will detect the real issue though.
-		if !IsDynamicPolicyDataError(err) || err.Error() != "dynamic authorization policy signature verification failed" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot verify dynamic authorization policy signature" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -2206,7 +2206,7 @@ func TestExecutePolicy(t *testing.T) {
 			}
 			d.AuthorizedPolicySignature.Signature.RSAPSS().Sig = tpm2.PublicKeyRSA(sig)
 		})
-		if !IsDynamicPolicyDataError(err) || err.Error() != "dynamic authorization policy signature verification failed" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot verify dynamic authorization policy signature" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -1555,10 +1555,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, nil)
-		if IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
-			t.Fatalf("Expected an error")
-		}
-		if err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1598,10 +1595,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "xxx",
 				},
 			}}, nil)
-		if IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
-			t.Fatalf("Expected an error")
-		}
-		if err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1737,10 +1731,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, nil)
-		if IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
-			t.Fatalf("Expected an error")
-		}
-		if err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1856,7 +1847,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, nil)
-		if !tpm2.IsTPMError(err, tpm2.ErrorPolicy, tpm2.CommandPolicyNV) || IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "the dynamic authorization policy has been revoked" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1944,10 +1935,7 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			s.PinIndexHandle = tpm2.Handle(0x40ffffff)
 		})
-		if !IsStaticPolicyDataError(err) || IsDynamicPolicyDataError(err) {
-			t.Fatalf("Expected an error")
-		}
-		if err.Error() != "invalid handle type for PIN NV index" {
+		if !IsStaticPolicyDataError(err) || err.Error() != "invalid handle type for PIN NV index" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1988,7 +1976,7 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			s.PinIndexHandle += 1
 		})
-		if !tpm2.IsResourceUnavailableError(err, pinIndex.Handle()+1) || !IsStaticPolicyDataError(err) || IsDynamicPolicyDataError(err) {
+		if !IsStaticPolicyDataError(err) || err.Error() != "no PIN NV index found" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -2030,7 +2018,7 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			s.PinIndexAuthPolicies[len(s.PinIndexAuthPolicies)-1] = make(tpm2.Digest, len(s.PinIndexAuthPolicies[0]))
 		})
-		if !tpm2.IsTPMParameterError(err, tpm2.ErrorValue, tpm2.CommandPolicyOR, 1) || !IsStaticPolicyDataError(err) || IsDynamicPolicyDataError(err) {
+		if !IsStaticPolicyDataError(err) || err.Error() != "authorization policy metadata for PIN NV index is invalid" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -2072,7 +2060,7 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			s.PinIndexAuthPolicies[0] = make(tpm2.Digest, len(s.PinIndexAuthPolicies[0]))
 		})
-		if !tpm2.IsTPMSessionError(err, tpm2.ErrorPolicyFail, tpm2.CommandPolicyNV, 1) || !IsStaticPolicyDataError(err) || IsDynamicPolicyDataError(err) {
+		if !IsStaticPolicyDataError(err) || err.Error() != "invalid PIN NV index or associated authorization policy metadata" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -2114,10 +2102,8 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			s.AuthPublicKey.NameAlg = tpm2.HashAlgorithmId(tpm2.AlgorithmSM4)
 		})
-		if !IsStaticPolicyDataError(err) || IsDynamicPolicyDataError(err) {
-			t.Fatalf("Expected an error")
-		}
-		if err.Error() != "public area of dynamic authorization policy signature verification key has an unsupported name algorithm" {
+		if !IsStaticPolicyDataError(err) || err.Error() != "public area of dynamic authorization policy signature verification key has an "+
+			"unsupported name algorithm" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -2167,7 +2153,7 @@ func TestExecutePolicy(t *testing.T) {
 		})
 		// Even though this error is caused by broken static metadata, we get a dynamicPolicyDataError error because the signature
 		// verification fails. Validation with validateKeyData will detect the real issue though.
-		if !tpm2.IsTPMParameterError(err, tpm2.ErrorSignature, tpm2.CommandVerifySignature, 2) || IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "dynamic authorization policy signature verification failed" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -2175,7 +2161,60 @@ func TestExecutePolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("InvalidMetadata/DynamicPolicySignature", func(t *testing.T) {
+	t.Run("InvalidMetadata/DynamicPolicySignature/1", func(t *testing.T) {
+		// Test handling of the dynamic authorization signature being replaced (execution should fail).
+		expected, digest, err := run(t, &testData{
+			alg: tpm2.HashAlgorithmSHA256,
+			pcrValues: []tpm2.PCRValues{
+				{
+					tpm2.HashAlgorithmSHA256: {
+						7:  makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo", "bar"),
+						12: makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar", "foo"),
+					},
+				},
+			},
+			policyCount: policyCount,
+			pcrEvents: []pcrEvent{
+				{
+					index: 7,
+					data:  "foo",
+				},
+				{
+					index: 7,
+					data:  "bar",
+				},
+				{
+					index: 12,
+					data:  "bar",
+				},
+				{
+					index: 12,
+					data:  "foo",
+				},
+			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
+			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			if err != nil {
+				t.Fatalf("GenerateKey failed: %v", err)
+			}
+			alg := d.AuthorizedPolicySignature.Signature.RSAPSS().Hash
+			h := alg.NewHash()
+			h.Write(d.AuthorizedPolicy)
+
+			sig, err := rsa.SignPSS(rand.Reader, key, alg.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+			if err != nil {
+				t.Fatalf("SignPSS failed: %v", err)
+			}
+			d.AuthorizedPolicySignature.Signature.RSAPSS().Sig = tpm2.PublicKeyRSA(sig)
+		})
+		if !IsDynamicPolicyDataError(err) || err.Error() != "dynamic authorization policy signature verification failed" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if bytes.Equal(digest, expected) {
+			t.Errorf("Session digest shouldn't match policy digest")
+		}
+	})
+
+	t.Run("InvalidMetadata/DynamicPolicySignature/2", func(t *testing.T) {
 		// Test handling of the public area of the dynamic policy authorization key being replaced by one corresponding to a different key,
 		// and the authorized policy signature being replaced with a signature signed by the new key (execution should succeed, but the
 		// resulting session digest shouldn't match the computed policy digest)
@@ -2268,8 +2307,8 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			d.PolicyCount += 1
 		})
-		if !tpm2.IsTPMParameterError(err, tpm2.ErrorValue, tpm2.CommandPolicyAuthorize, 1) || IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
-			t.Errorf("Failed to execute policy session: %v", err)
+		if !IsDynamicPolicyDataError(err) || err.Error() != "the dynamic authorization policy is invalid" {
+			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
 			t.Errorf("Session digest shouldn't match policy digest")
@@ -2360,8 +2399,8 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			d.PCROrData[0].Next = 1000
 		})
-		if !tpm2.IsTPMParameterError(err, tpm2.ErrorValue, tpm2.CommandPolicyAuthorize, 1) || IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
-			t.Errorf("Failed to execute policy session: %v", err)
+		if !IsDynamicPolicyDataError(err) || err.Error() != "the dynamic authorization policy is invalid" {
+			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
 			t.Errorf("Session digest shouldn't match policy digest")
@@ -2410,8 +2449,8 @@ func TestExecutePolicy(t *testing.T) {
 			x := int32(-10)
 			d.PCROrData[0].Next = *(*uint32)(unsafe.Pointer(&x))
 		})
-		if !tpm2.IsTPMParameterError(err, tpm2.ErrorValue, tpm2.CommandPolicyAuthorize, 1) || IsStaticPolicyDataError(err) || !IsDynamicPolicyDataError(err) {
-			t.Errorf("Failed to execute policy session: %v", err)
+		if !IsDynamicPolicyDataError(err) || err.Error() != "the dynamic authorization policy is invalid" {
+			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
 			t.Errorf("Session digest shouldn't match policy digest")

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -689,13 +689,13 @@ func TestProvisionStatus(t *testing.T) {
 		t.Errorf("Unexpected status %d", status)
 	}
 
-	primary, _, _, _, _, err := tpm.CreatePrimary(tpm.OwnerHandleContext(), nil, &SrkTemplate, nil, nil, nil)
+	primary, _, _, _, _, err := tpm.CreatePrimary(tpm.OwnerHandleContext(), nil, SrkTemplate, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreatePrimary failed: %v", err)
 	}
 	defer flushContext(t, tpm, primary)
 
-	priv, pub, _, _, _, err := tpm.Create(primary, nil, &SrkTemplate, nil, nil, nil)
+	priv, pub, _, _, _, err := tpm.Create(primary, nil, SrkTemplate, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}

--- a/seal.go
+++ b/seal.go
@@ -107,7 +107,7 @@ type KeyCreationParams struct {
 //
 // The key will be protected with a PCR policy computed from the PCRProtectionProfile supplied via the PCRProfile field of the params
 // argument.
-func SealKeyToTPM(tpm *TPMConnection, keyPath, policyUpdatePath string, params *KeyCreationParams, key []byte) error {
+func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath string, params *KeyCreationParams) error {
 	// Check that the key is the correct length
 	if len(key) != 32 {
 		return fmt.Errorf("expected a key length of 256 bits (got %d)", len(key)*8)

--- a/seal.go
+++ b/seal.go
@@ -83,10 +83,10 @@ type KeyCreationParams struct {
 	// PCRProfile defines the profile used to generate a PCR protection policy for the newly created sealed key file.
 	PCRProfile *PCRProtectionProfile
 
-	// PinHandle is the handle at which to create a NV index for PIN support. The handle must be a valid NV index handle (MSO == 0x01)
+	// PINHandle is the handle at which to create a NV index for PIN support. The handle must be a valid NV index handle (MSO == 0x01)
 	// and the choice of handle should take in to consideration the reserved indices from the "Registry of reserved TPM 2.0 handles and
 	// localities" specification. It is recommended that the handle is in the block reserved for owner objects (0x01800000 - 0x01bfffff).
-	PinHandle tpm2.Handle
+	PINHandle tpm2.Handle
 }
 
 // SealKeyToTPM seals the supplied disk encryption key to the storage hierarchy of the TPM. The sealed key object and associated
@@ -108,7 +108,7 @@ type KeyCreationParams struct {
 // *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be returned if
 // either file cannot be created and opened for writing.
 //
-// This function will create a NV index at the handle specified by the PinHandle field of the params argument. If the handle is already
+// This function will create a NV index at the handle specified by the PINHandle field of the params argument. If the handle is already
 // in use, a TPMResourceExistsError error will be returned. In this case, the caller will need to either choose a different handle or
 // undefine the existing one. The handle must be a valid NV index handle (MSO == 0x01), and the choice of handle should take in to
 // consideration the reserved indices from the "Registry of reserved TPM 2.0 handles and localities" specification. It is recommended
@@ -206,10 +206,10 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 	}
 
 	// Create pin NV index
-	pinIndexPub, pinIndexAuthPolicies, err := createPinNVIndex(tpm.TPMContext, params.PinHandle, authKeyName, session)
+	pinIndexPub, pinIndexAuthPolicies, err := createPinNVIndex(tpm.TPMContext, params.PINHandle, authKeyName, session)
 	switch {
 	case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
-		return TPMResourceExistsError{params.PinHandle}
+		return TPMResourceExistsError{params.PINHandle}
 	case isAuthFailError(err, tpm2.CommandNVDefineSpace, 1):
 		return AuthFailError{tpm2.HandleOwner}
 	case err != nil:

--- a/seal.go
+++ b/seal.go
@@ -209,7 +209,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyPath, policyUpdatePath string, params *
 
 	// Compute the static policy - this never changes for the lifetime of this key file
 	staticPolicyData, authPolicy, err := computeStaticPolicy(sealedKeyNameAlg, &staticPolicyComputeParams{
-		key:                  &authKey.PublicKey,
+		key:                  authPublicKey,
 		pinIndexPub:          pinIndexPub,
 		pinIndexAuthPolicies: pinIndexAuthPolicies,
 		lockIndexName:        lockIndexName})

--- a/seal.go
+++ b/seal.go
@@ -1,0 +1,347 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/chrisccoulson/go-tpm2"
+
+	"golang.org/x/xerrors"
+)
+
+func computeSealedKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, alg, signAlg tpm2.HashAlgorithmId, authKey *rsa.PrivateKey,
+	countIndexPub *tpm2.NVPublic, countIndexAuthPolicies tpm2.DigestList, pcrProfile *PCRProtectionProfile,
+	session tpm2.SessionContext) (*dynamicPolicyData, error) {
+	// Obtain the count for the new dynamic authorization policy
+	nextPolicyCount, err := readDynamicPolicyCounter(tpm, countIndexPub, countIndexAuthPolicies, session)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot read dynamic policy counter: %w", err)
+	}
+	nextPolicyCount += 1
+
+	countIndexName, _ := countIndexPub.Name()
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute name of dynamic policy counter: %w", err)
+	}
+
+	// Compute PCR digests
+	pcrValues, err := pcrProfile.computePCRValues(tpm, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute PCR values from protection profile: %w", err)
+	}
+
+	// Use the PCR digests and NV index names to generate a single signed dynamic authorization policy digest
+	policyParams := dynamicPolicyComputeParams{
+		key:                  authKey,
+		signAlg:              signAlg,
+		pcrValues:            pcrValues,
+		policyCountIndexName: countIndexName,
+		policyCount:          nextPolicyCount}
+
+	policyData, err := computeDynamicPolicy(alg, &policyParams)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
+	}
+
+	return policyData, nil
+}
+
+// KeyCreationParams provides the arguments for SealKeyToTPM.
+type KeyCreationParams struct {
+	PinHandle tpm2.Handle // Handle at which to create a NV index for PIN support
+}
+
+// SealKeyToTPM seals the supplied disk encryption key to the storage hierarchy of the TPM. The sealed key object and associated
+// metadata that is required during early boot in order to unseal the key again and unlock the associated encrypted volume is written
+// to a file at the path specified by keyPath. Additional data that is required in order to update the authorization policy for the
+// sealed key is written to a file at the path specified by policyUpdatePath. This file must live inside the encrypted volume
+// protected by the sealed key.
+//
+// The supplied key must be 32 bytes long. An error will be returned if it isn't.
+//
+// This function requires knowledge of the authorization value for the storage hierarchy, which must be provided by calling
+// TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the provided authorization value is incorrect,
+// a AuthFailError error will be returned.
+//
+// If the TPM is not correctly provisioned, a ErrTPMProvisioning error will be returned. In this case, ProvisionTPM must be called
+// before proceeding.
+//
+// This function expects there to be no files at the specified paths. If either path references a file that already exists, a wrapped
+// *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be returned if
+// either file cannot be created and opened for writing.
+//
+// The caller is expected to provide a handle at which a NV index should be created via the PinHandle filed of the KeyCreationParams
+// struct. If the handle is already in use, a TPMResourceExistsError error will be returned. The handle must be a valid NV index
+// handle (MSO == 0x01), and the choice of handle should take in to consideration the reserved indices from the "Registry of reserved
+// TPM 2.0 handles and localities" specification. It is recommended that the handle is in the block reserved for owner objects
+// (0x01800000 - 0x01bfffff).
+//
+// The key will be protected with a PCR policy computed from the supplied PCRProtectionProfile.
+func SealKeyToTPM(tpm *TPMConnection, keyPath, policyUpdatePath string, params *KeyCreationParams, pcrProfile *PCRProtectionProfile, key []byte) error {
+	// Check that the key is the correct length
+	if len(key) != 32 {
+		return fmt.Errorf("expected a key length of 256 bits (got %d)", len(key)*8)
+	}
+
+	// Use the HMAC session created when the connection was opened rather than creating a new one.
+	session := tpm.HmacSession()
+
+	// Obtain a context for the SRK now. If we're called immediately after ProvisionTPM without closing the TPMConnection, we use the
+	// context cached by ProvisionTPM, which corresponds to the object provisioned. If not, we just unconditionally provision a new
+	// SRK as this function requires knowledge of the owner hierarchy authorization anyway. This way, we know that the primary key we
+	// seal to is good and future calls to ProvisionTPM won't provision an object that cannot unseal the key we protect.
+	srk := tpm.provisionedSrk
+	if srk == nil {
+		var err error
+		srk, err = provisionPrimaryKey(tpm.TPMContext, tpm.OwnerHandleContext(), srkTemplate, srkHandle, session)
+		switch {
+		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
+			return AuthFailError{tpm2.HandleOwner}
+		case err != nil:
+			return xerrors.Errorf("cannot provision storage root key: %w", err)
+		}
+	}
+
+	lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
+	switch {
+	case tpm2.IsResourceUnavailableError(err, lockNVHandle):
+		return ErrTPMProvisioning
+	case err != nil:
+		return xerrors.Errorf("cannot create context for lock NV index: %w", err)
+	}
+
+	lockIndexPub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session)
+	if err != nil {
+		return ErrTPMProvisioning
+	}
+	lockIndexName, err := lockIndexPub.Name()
+	if err != nil {
+		return xerrors.Errorf("cannot compute name of global lock NV index: %w", err)
+	}
+
+	succeeded := false
+
+	// Create destination files
+	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return xerrors.Errorf("cannot create key data file: %w", err)
+	}
+	defer func() {
+		keyFile.Close()
+		if succeeded {
+			return
+		}
+		os.Remove(keyPath)
+	}()
+
+	var policyUpdateFile *os.File
+	if policyUpdatePath != "" {
+		var err error
+		policyUpdateFile, err = os.OpenFile(policyUpdatePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err != nil {
+			return xerrors.Errorf("cannot create private data file: %w", err)
+		}
+		defer func() {
+			policyUpdateFile.Close()
+			if succeeded {
+				return
+			}
+			os.Remove(policyUpdatePath)
+		}()
+	}
+
+	// Create an asymmetric key for signing authorization policy updates, and authorizing dynamic authorization policy revocations.
+	authKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return xerrors.Errorf("cannot generate RSA key pair for signing dynamic authorization policies: %w", err)
+	}
+	authPublicKey := createPublicAreaForRSASigningKey(&authKey.PublicKey)
+	authKeyName, err := authPublicKey.Name()
+	if err != nil {
+		return xerrors.Errorf("cannot compute name of signing key for dynamic policy authorization: %w", err)
+	}
+
+	// Create pin NV index
+	pinIndexPub, pinIndexAuthPolicies, err := createPinNVIndex(tpm.TPMContext, params.PinHandle, authKeyName, session)
+	switch {
+	case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
+		return TPMResourceExistsError{params.PinHandle}
+	case isAuthFailError(err, tpm2.CommandNVDefineSpace, 1):
+		return AuthFailError{tpm2.HandleOwner}
+	case err != nil:
+		return xerrors.Errorf("cannot create new pin NV index: %w", err)
+	}
+	defer func() {
+		if succeeded {
+			return
+		}
+		index, err := tpm2.CreateNVIndexResourceContextFromPublic(pinIndexPub)
+		if err != nil {
+			return
+		}
+		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, session)
+	}()
+
+	sealedKeyNameAlg := tpm2.HashAlgorithmSHA256
+
+	// Compute the static policy - this never changes for the lifetime of this key file
+	staticPolicyData, authPolicy, err := computeStaticPolicy(sealedKeyNameAlg, &staticPolicyComputeParams{
+		key:                  &authKey.PublicKey,
+		pinIndexPub:          pinIndexPub,
+		pinIndexAuthPolicies: pinIndexAuthPolicies,
+		lockIndexName:        lockIndexName})
+	if err != nil {
+		return xerrors.Errorf("cannot compute static authorization policy: %w", err)
+	}
+
+	// Define the template for the sealed key object, using the computed policy digest
+	template := tpm2.Public{
+		Type:       tpm2.ObjectTypeKeyedHash,
+		NameAlg:    sealedKeyNameAlg,
+		Attrs:      tpm2.AttrFixedTPM | tpm2.AttrFixedParent,
+		AuthPolicy: authPolicy,
+		Params:     tpm2.PublicParamsU{Data: &tpm2.KeyedHashParams{Scheme: tpm2.KeyedHashScheme{Scheme: tpm2.KeyedHashSchemeNull}}}}
+	sensitive := tpm2.SensitiveCreate{Data: key}
+
+	// Have the digest of the private data recorded in the creation data for the sealed data object.
+	var policyUpdateData keyPolicyUpdateData
+	policyUpdateData.Data.AuthKey = x509.MarshalPKCS1PrivateKey(authKey)
+
+	h := crypto.SHA256.New()
+	if err := tpm2.MarshalToWriter(h, &policyUpdateData.Data); err != nil {
+		panic(fmt.Sprintf("cannot marshal dynamic authorization policy update data: %v", err))
+	}
+
+	// Now create the sealed key object. The command is integrity protected so if the object at the handle we expect the SRK to reside
+	// at has a different name (ie, if we're connected via a resource manager and somebody swapped the object with another one), this
+	// command will fail. We take advantage of parameter encryption here too.
+	priv, pub, creationData, _, creationTicket, err :=
+		tpm.Create(srk, &sensitive, &template, h.Sum(nil), nil, session.IncludeAttrs(tpm2.AttrCommandEncrypt))
+	if err != nil {
+		return xerrors.Errorf("cannot create sealed data object for key: %w", err)
+	}
+
+	policyUpdateData.CreationData = creationData
+	policyUpdateData.CreationTicket = creationTicket
+
+	// Create a dynamic authorization policy
+	dynamicPolicyData, err := computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, sealedKeyNameAlg, staticPolicyData.AuthPublicKey.NameAlg,
+		authKey, pinIndexPub, pinIndexAuthPolicies, pcrProfile, session)
+	if err != nil {
+		return err
+	}
+
+	// Marshal the entire object (sealed key object and auxiliary data) to disk
+	data := keyData{
+		KeyPrivate:        priv,
+		KeyPublic:         pub,
+		AuthModeHint:      AuthModeNone,
+		StaticPolicyData:  staticPolicyData,
+		DynamicPolicyData: dynamicPolicyData}
+
+	if err := data.write(keyFile); err != nil {
+		return xerrors.Errorf("cannot write key data file: %w", err)
+	}
+
+	if policyUpdateFile != nil {
+		// Marshal the private data to disk
+		if err := policyUpdateData.write(policyUpdateFile); err != nil {
+			return xerrors.Errorf("cannot write dynamic authorization policy update data file: %w", err)
+		}
+	}
+
+	if err := incrementDynamicPolicyCounter(tpm.TPMContext, pinIndexPub, pinIndexAuthPolicies, authKey,
+		data.StaticPolicyData.AuthPublicKey, session); err != nil {
+		return xerrors.Errorf("cannot increment dynamic policy counter: %w", err)
+	}
+
+	succeeded = true
+	return nil
+}
+
+// UpdateKeyPCRProtectionPolicy updates the PCR protection policy for the sealed key at the path specified by the keyPath argument
+// to the profile defined by the pcrProfile argument. In order to do this, the caller must also specify the path to the policy update
+// data file that was saved by SealKeyToTPM.
+//
+// If either file cannot be opened, a wrapped *os.PathError error will be returned.
+//
+// If either file cannot be deserialized correctly or validation of the files fails, a InvalidKeyFileError error will be returned.
+//
+// On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
+// computed from the supplied PCRProtectionProfile.
+func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath, policyUpdatePath string, pcrProfile *PCRProtectionProfile) error {
+	// Use the HMAC session created when the connection was opened rather than creating a new one.
+	session := tpm.HmacSession()
+
+	// Open the key data file
+	keyFile, err := os.Open(keyPath)
+	if err != nil {
+		return xerrors.Errorf("cannot open key data file: %w", err)
+	}
+	defer keyFile.Close()
+
+	// Open the policy update data file
+	policyUpdateFile, err := os.Open(policyUpdatePath)
+	if err != nil {
+		return xerrors.Errorf("cannot open private data file: %w", err)
+	}
+	defer policyUpdateFile.Close()
+
+	data, policyUpdateData, pinIndexPublic, err := readAndValidateKeyData(tpm.TPMContext, keyFile, policyUpdateFile, session)
+	if err != nil {
+		if isKeyFileError(err) {
+			return InvalidKeyFileError{err.Error()}
+		}
+		// FIXME: Turn the missing lock NV index in to ErrProvisioning
+		return xerrors.Errorf("cannot read and validate key data file: %w", err)
+	}
+
+	authKey, err := x509.ParsePKCS1PrivateKey(policyUpdateData.Data.AuthKey)
+	if err != nil {
+		return xerrors.Errorf("cannot parse authorization key: %w", err)
+	}
+
+	// Compute a new dynamic authorization policy
+	policyData, err := computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, data.KeyPublic.NameAlg, data.StaticPolicyData.AuthPublicKey.NameAlg,
+		authKey, pinIndexPublic, data.StaticPolicyData.PinIndexAuthPolicies, pcrProfile, session)
+	if err != nil {
+		return err
+	}
+
+	// Atomically update the key data file
+	data.DynamicPolicyData = policyData
+
+	if err := data.writeToFileAtomic(keyPath); err != nil {
+		return xerrors.Errorf("cannot write key data file: %v", err)
+	}
+
+	if err := incrementDynamicPolicyCounter(tpm.TPMContext, pinIndexPublic, data.StaticPolicyData.PinIndexAuthPolicies, authKey,
+		data.StaticPolicyData.AuthPublicKey, session); err != nil {
+		return xerrors.Errorf("cannot revoke old dynamic authorization policies: %w", err)
+	}
+
+	return nil
+}

--- a/seal_test.go
+++ b/seal_test.go
@@ -76,19 +76,19 @@ func TestSealKeyToTPM(t *testing.T) {
 	t.Run("BothFiles", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 	})
 
 	t.Run("NoPrivFile", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000})
+		run(t, tpm, false, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 	})
 
 	t.Run("DifferentPINHandle", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x0181fff0})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0})
 	})
 
 	t.Run("SealAfterProvision", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestSealKeyToTPM(t *testing.T) {
 		if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 			t.Errorf("Failed to provision TPM for test: %v", err)
 		}
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 	})
 
 	t.Run("NoSRK", func(t *testing.T) {
@@ -113,13 +113,13 @@ func TestSealKeyToTPM(t *testing.T) {
 			t.Errorf("EvictControl failed: %v", err)
 		}
 
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PinHandle: 0x01810000})
+		run(t, tpm, false, &KeyCreationParams{PINHandle: 0x01810000})
 	})
 }
 
@@ -151,7 +151,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		origPolicyUpdateFileInfo, _ := os.Stat(policyUpdateFile)
 		var pinIndex tpm2.ResourceContext
 		if params != nil {
-			pinIndex, _ = tpm.CreateResourceContextFromTPM(params.PinHandle)
+			pinIndex, _ = tpm.CreateResourceContextFromTPM(params.PINHandle)
 		}
 
 		err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, params)
@@ -163,7 +163,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Errorf("SealKeyToTPM created a key file")
 		}
 		if params != nil {
-			if index, err := tpm.CreateResourceContextFromTPM(params.PinHandle); err == nil && (pinIndex == nil || !bytes.Equal(pinIndex.Name(), index.Name())) {
+			if index, err := tpm.CreateResourceContextFromTPM(params.PINHandle); err == nil && (pinIndex == nil || !bytes.Equal(pinIndex.Name(), index.Name())) {
 				t.Errorf("SealKeyToTPM created a PIN NV index")
 			}
 		}
@@ -174,7 +174,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		key := make([]byte, 16)
 		rand.Read(key)
 
-		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000}, key)
+		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}, key)
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}
@@ -205,7 +205,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			resetHierarchyAuth(t, tpm, tpm.OwnerHandleContext())
 		}()
 
-		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000}, key)
+		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}, key)
 		if e, ok := err.(AuthFailError); !ok || e.Handle != tpm2.HandleOwner {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -231,7 +231,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}
 		}()
-		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000}, key); err != ErrTPMProvisioning {
+		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}, key); err != ErrTPMProvisioning {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
@@ -256,7 +256,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}
 		}()
-		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000}, key); err != ErrTPMProvisioning {
+		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}, key); err != ErrTPMProvisioning {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
@@ -271,7 +271,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("OpenFile failed: %v", err)
 		}
 		defer f.Close()
-		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000}, key)
+		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}, key)
 		var e *os.PathError
 		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keydata" || e.Err != syscall.EEXIST {
 			t.Errorf("Unexpected error: %v", err)
@@ -288,7 +288,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("OpenFile failed: %v", err)
 		}
 		defer f.Close()
-		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x01810000}, key)
+		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}, key)
 		var e *os.PathError
 		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keypolicyupdatedata" || e.Err != syscall.EEXIST {
 			t.Errorf("Unexpected error: %v", err)
@@ -306,7 +306,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("NVDefineSpace failed: %v", err)
 		}
 		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-		err = run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: public.Index}, key)
+		err = run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: public.Index}, key)
 		if e, ok := err.(TPMResourceExistsError); !ok || e.Handle != public.Index {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -321,7 +321,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			AddProfileOR(
 				NewPCRProtectionProfile(),
 				NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 8))
-		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PinHandle: 0x01810000}, key)
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PINHandle: 0x01810000}, key)
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}

--- a/seal_test.go
+++ b/seal_test.go
@@ -1,0 +1,291 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/chrisccoulson/go-tpm2"
+	. "github.com/snapcore/secboot"
+
+	"golang.org/x/xerrors"
+)
+
+func getTestPCRProfile() *PCRProtectionProfile {
+	return NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7)
+}
+
+func TestSealKeyToTPM(t *testing.T) {
+	func() {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+			t.Errorf("Failed to provision TPM for test: %v", err)
+		}
+	}()
+
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	run := func(t *testing.T, tpm *TPMConnection, withPolicyUpdateFile bool, params *KeyCreationParams) {
+		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPM_")
+		if err != nil {
+			t.Fatalf("Creating temporary directory failed: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		keyFile := tmpDir + "/keydata"
+		policyUpdateFile := ""
+		if withPolicyUpdateFile {
+			policyUpdateFile = tmpDir + "/keypolicyupdatedata"
+		}
+
+		if err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, params, getTestPCRProfile(), key); err != nil {
+			t.Errorf("SealKeyToTPM failed: %v", err)
+		}
+		defer undefineKeyNVSpace(t, tpm, keyFile)
+
+		if err := ValidateKeyDataFile(tpm.TPMContext, keyFile, policyUpdateFile, tpm.HmacSession()); err != nil {
+			t.Errorf("ValidateKeyDataFile failed: %v", err)
+		}
+	}
+
+	t.Run("BothFiles", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+		run(t, tpm, true, &KeyCreationParams{PinHandle: 0x01810000})
+	})
+
+	t.Run("NoPrivFile", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+		run(t, tpm, false, &KeyCreationParams{PinHandle: 0x01810000})
+	})
+
+	t.Run("DifferentPINHandle", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+		run(t, tpm, true, &KeyCreationParams{PinHandle: 0x0181fff0})
+	})
+
+	t.Run("SealAfterProvision", func(t *testing.T) {
+		// SealKeyToTPM behaves slightly different if called immediately after ProvisionTPM with the same TPMConnection
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+		if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+			t.Errorf("Failed to provision TPM for test: %v", err)
+		}
+		run(t, tpm, true, &KeyCreationParams{PinHandle: 0x01810000})
+	})
+
+	t.Run("NoSRK", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		srk, err := tpm.CreateResourceContextFromTPM(SrkHandle)
+		if err != nil {
+			t.Fatalf("No SRK: %v", err)
+		}
+		if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), srk, srk.Handle(), nil); err != nil {
+			t.Errorf("EvictControl failed: %v", err)
+		}
+
+		run(t, tpm, true, &KeyCreationParams{PinHandle: 0x01810000})
+	})
+}
+
+func TestSealKeyToTPMErrorHandling(t *testing.T) {
+	tpm := openTPMForTesting(t)
+	defer closeTPM(t, tpm)
+
+	if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+		t.Errorf("Failed to provision TPM for test: %v", err)
+	}
+
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	run := func(t *testing.T, tmpDir string, params *KeyCreationParams, pcrProfile *PCRProtectionProfile, key []byte) error {
+		if tmpDir == "" {
+			var err error
+			tmpDir, err = ioutil.TempDir("", "_TestSealKeyToTPMErrors_")
+			if err != nil {
+				t.Fatalf("Creating temporary directory failed: %v", err)
+			}
+		}
+		defer os.RemoveAll(tmpDir)
+
+		keyFile := tmpDir + "/keydata"
+		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
+
+		origKeyFileInfo, _ := os.Stat(keyFile)
+		origPolicyUpdateFileInfo, _ := os.Stat(policyUpdateFile)
+		pinIndex, _ := tpm.CreateResourceContextFromTPM(params.PinHandle)
+
+		err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, params, pcrProfile, key)
+
+		if fi, err := os.Stat(keyFile); err == nil && (origKeyFileInfo == nil || origKeyFileInfo.ModTime() != fi.ModTime()) {
+			t.Errorf("SealKeyToTPM created a key file")
+		}
+		if fi, err := os.Stat(policyUpdateFile); err == nil && (origPolicyUpdateFileInfo == nil || origPolicyUpdateFileInfo.ModTime() != fi.ModTime()) {
+			t.Errorf("SealKeyToTPM created a key file")
+		}
+		if index, err := tpm.CreateResourceContextFromTPM(params.PinHandle); err == nil && (pinIndex == nil || !bytes.Equal(pinIndex.Name(), index.Name())) {
+			t.Errorf("SealKeyToTPM created a PIN NV index")
+		}
+
+		return err
+	}
+
+	t.Run("InvalidKeyLength", func(t *testing.T) {
+		key := make([]byte, 16)
+		rand.Read(key)
+
+		err := run(t, "", &KeyCreationParams{PinHandle: 0x01810000}, getTestPCRProfile(), key)
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "expected a key length of 256 bits (got 128)" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("OwnerAuthFail", func(t *testing.T) {
+		setHierarchyAuthForTest(t, tpm, tpm.OwnerHandleContext())
+		tpm.OwnerHandleContext().SetAuthValue(nil)
+
+		defer func() {
+			tpm.OwnerHandleContext().SetAuthValue(testAuth)
+			resetHierarchyAuth(t, tpm, tpm.OwnerHandleContext())
+		}()
+
+		err := run(t, "", &KeyCreationParams{PinHandle: 0x01810000}, getTestPCRProfile(), key)
+		if e, ok := err.(AuthFailError); !ok || e.Handle != tpm2.HandleOwner {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("Provisioning/1", func(t *testing.T) {
+		index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
+		if err != nil {
+			t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
+		}
+		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, nil); err != nil {
+			t.Errorf("NVUndefineSpace failed: %v", err)
+		}
+		defer func() {
+			index, err := tpm.CreateResourceContextFromTPM(LockNVDataHandle)
+			if err != nil {
+				t.Errorf("CreateResourceContextFromTPM failed: %v", err)
+			}
+			if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, nil); err != nil {
+				t.Errorf("NVUndefineSpace failed: %v", err)
+			}
+			if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+				t.Errorf("Failed to re-provision TPM after test: %v", err)
+			}
+		}()
+		if err := run(t, "", &KeyCreationParams{PinHandle: 0x01810000}, getTestPCRProfile(), key); err != ErrTPMProvisioning {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("Provisioning/2", func(t *testing.T) {
+		index, err := tpm.CreateResourceContextFromTPM(LockNVDataHandle)
+		if err != nil {
+			t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
+		}
+		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, nil); err != nil {
+			t.Errorf("NVUndefineSpace failed: %v", err)
+		}
+		defer func() {
+			index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
+			if err != nil {
+				t.Errorf("CreateResourceContextFromTPM failed: %v", err)
+			}
+			if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, nil); err != nil {
+				t.Errorf("NVUndefineSpace failed: %v", err)
+			}
+			if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+				t.Errorf("Failed to re-provision TPM after test: %v", err)
+			}
+		}()
+		if err := run(t, "", &KeyCreationParams{PinHandle: 0x01810000}, getTestPCRProfile(), key); err != ErrTPMProvisioning {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("FileExists/1", func(t *testing.T) {
+		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPMErrors_")
+		if err != nil {
+			t.Fatalf("Creating temporary directory failed: %v", err)
+		}
+		f, err := os.OpenFile(tmpDir+"/keydata", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err != nil {
+			t.Fatalf("OpenFile failed: %v", err)
+		}
+		defer f.Close()
+		err = run(t, tmpDir, &KeyCreationParams{PinHandle: 0x01810000}, getTestPCRProfile(), key)
+		var e *os.PathError
+		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keydata" || e.Err != syscall.EEXIST {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("FileExists/2", func(t *testing.T) {
+		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPMErrors_")
+		if err != nil {
+			t.Fatalf("Creating temporary directory failed: %v", err)
+		}
+		f, err := os.OpenFile(tmpDir+"/keypolicyupdatedata", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err != nil {
+			t.Fatalf("OpenFile failed: %v", err)
+		}
+		defer f.Close()
+		err = run(t, tmpDir, &KeyCreationParams{PinHandle: 0x01810000}, getTestPCRProfile(), key)
+		var e *os.PathError
+		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keypolicyupdatedata" || e.Err != syscall.EEXIST {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("PinNVIndexExists", func(t *testing.T) {
+		public := tpm2.NVPublic{
+			Index:   0x0181ffff,
+			NameAlg: tpm2.HashAlgorithmSHA256,
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVAuthRead),
+			Size:    0}
+		index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &public, nil)
+		if err != nil {
+			t.Fatalf("NVDefineSpace failed: %v", err)
+		}
+		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+		err = run(t, "", &KeyCreationParams{PinHandle: public.Index}, getTestPCRProfile(), key)
+		if e, ok := err.(TPMResourceExistsError); !ok || e.Handle != public.Index {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+}

--- a/seal_test.go
+++ b/seal_test.go
@@ -311,4 +311,22 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
+
+	t.Run("InvalidPCRProfile", func(t *testing.T) {
+		key := make([]byte, 32)
+		rand.Read(key)
+
+		pcrProfile := NewPCRProtectionProfile().
+			AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7).
+			AddProfileOR(
+				NewPCRProtectionProfile(),
+				NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 8))
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PinHandle: 0x01810000}, key)
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "cannot compute dynamic authorization policy: not all combinations of PCR values contain a complete set of values" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
 }

--- a/seal_test.go
+++ b/seal_test.go
@@ -63,7 +63,7 @@ func TestSealKeyToTPM(t *testing.T) {
 			policyUpdateFile = tmpDir + "/keypolicyupdatedata"
 		}
 
-		if err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, params, key); err != nil {
+		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, params); err != nil {
 			t.Errorf("SealKeyToTPM failed: %v", err)
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)
@@ -145,7 +145,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		origPolicyUpdateFileInfo, _ := os.Stat(policyUpdateFile)
 		pinIndex, _ := tpm.CreateResourceContextFromTPM(params.PinHandle)
 
-		err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, params, key)
+		err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, params)
 
 		if fi, err := os.Stat(keyFile); err == nil && (origKeyFileInfo == nil || origKeyFileInfo.ModTime() != fi.ModTime()) {
 			t.Errorf("SealKeyToTPM created a key file")

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -98,9 +98,9 @@ func undefineNVSpace(t *testing.T, tpm *TPMConnection, context, authHandle tpm2.
 }
 
 func undefineKeyNVSpace(t *testing.T, tpm *TPMConnection, path string) {
-	k, err := LoadSealedKeyObject(path)
+	k, err := ReadSealedKeyObject(path)
 	if err != nil {
-		t.Fatalf("LoadSealedKeyObject failed: %v", err)
+		t.Fatalf("ReadSealedKeyObject failed: %v", err)
 	}
 	rc, err := tpm.CreateResourceContextFromTPM(k.PINIndexHandle())
 	if err != nil {

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -57,6 +57,8 @@ var (
 	testEkCert []byte
 
 	testEncodedEkCertChain []byte
+
+	testAuth = []byte("1234")
 )
 
 func decodeHexString(t *testing.T, s string) []byte {
@@ -74,11 +76,37 @@ func flushContext(t *testing.T, tpm *TPMConnection, context tpm2.HandleContext) 
 	}
 }
 
+// Set the hierarchy auth to testAuth. Fatal on failure
+func setHierarchyAuthForTest(t *testing.T, tpm *TPMConnection, hierarchy tpm2.ResourceContext) {
+	if err := tpm.HierarchyChangeAuth(hierarchy, tpm2.Auth(testAuth), nil); err != nil {
+		t.Fatalf("HierarchyChangeAuth failed: %v", err)
+	}
+}
+
+// Reset the hierarchy auth to nil.
+func resetHierarchyAuth(t *testing.T, tpm *TPMConnection, hierarchy tpm2.ResourceContext) {
+	if err := tpm.HierarchyChangeAuth(hierarchy, nil, nil); err != nil {
+		t.Errorf("HierarchyChangeAuth failed: %v", err)
+	}
+}
+
 // Undefine a NV index set by a test. Fails the test if it doesn't succeed.
 func undefineNVSpace(t *testing.T, tpm *TPMConnection, context, authHandle tpm2.ResourceContext) {
 	if err := tpm.NVUndefineSpace(authHandle, context, nil); err != nil {
 		t.Errorf("NVUndefineSpace failed: %v", err)
 	}
+}
+
+func undefineKeyNVSpace(t *testing.T, tpm *TPMConnection, path string) {
+	k, err := LoadSealedKeyObject(path)
+	if err != nil {
+		t.Fatalf("LoadSealedKeyObject failed: %v", err)
+	}
+	rc, err := tpm.CreateResourceContextFromTPM(k.PINIndexHandle())
+	if err != nil {
+		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
+	}
+	undefineNVSpace(t, tpm, rc, tpm.OwnerHandleContext())
 }
 
 func openTPMSimulatorForTesting(t *testing.T) (*TPMConnection, *tpm2.TctiMssim) {

--- a/unseal.go
+++ b/unseal.go
@@ -39,10 +39,10 @@ import (
 // the sealed object is associated with another TPM owner (the TPM has been cleared since the sealed key data file was created with
 // SealKeyToTPM), or because the TPM object at the persistent handle reserved for the storage root key has a public area that looks
 // like a valid storage root key but it was created with the wrong template. This latter case is really caused by an incorrectly
-// provisioning TPM, but it isn't possible to detect this. A subsequent call to SealKeyToTPM will rectify this.
+// provisioned TPM, but it isn't possible to detect this. A subsequent call to SealKeyToTPM or ProvisionTPM will rectify this.
 //
-// If the TPM's current PCR values don't match the PCR protection policy for this key file, a InvalidKeyFileError error will be
-// returned.
+// If the TPM's current PCR values are not consistent with the PCR protection policy for this key file, a InvalidKeyFileError error
+// will be returned.
 //
 // If any of the metadata in this key file is invalid, a InvalidKeyFileError error will be returned.
 //

--- a/unseal.go
+++ b/unseal.go
@@ -26,7 +26,7 @@ import (
 )
 
 // UnsealFromTPM will load the TPM sealed object in to the TPM and attempt to unseal it, returning the cleartext key on success.
-// If a PIN has been set, the correct PIN must be provided via the pin argument. If the wrong PIN is provided, a ErrPinFail error
+// If a PIN has been set, the correct PIN must be provided via the pin argument. If the wrong PIN is provided, a ErrPINFail error
 // will be returned, and the TPM's dictionary attack counter will be incremented.
 //
 // If the TPM's dictionary attack logic has been triggered, a ErrTPMLockout error will be returned.
@@ -57,7 +57,7 @@ import (
 // If the metadata for the updatable part of the key file's authorization policy is not consistent with the approved policy, then a
 // InvalidKeyFileError error will be returned.
 //
-// If the provided PIN is incorrect, then a ErrPinFail error will be returned and the TPM's dictionary attack counter will be
+// If the provided PIN is incorrect, then a ErrPINFail error will be returned and the TPM's dictionary attack counter will be
 // incremented.
 //
 // If access to sealed key objects created by this package is disallowed until the next TPM reset or TPM restart, then a
@@ -131,7 +131,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 		case isStaticPolicyDataError(err):
 			return nil, InvalidKeyFileError{err.Error()}
 		case isAuthFailError(err, tpm2.CommandPolicySecret, 1):
-			return nil, ErrPinFail
+			return nil, ErrPINFail
 		case tpm2.IsResourceUnavailableError(err, lockNVHandle):
 			return nil, ErrTPMProvisioning
 		case tpm2.IsTPMError(err, tpm2.ErrorNVLocked, tpm2.CommandPolicyNV):

--- a/unseal.go
+++ b/unseal.go
@@ -1,0 +1,159 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"github.com/chrisccoulson/go-tpm2"
+
+	"golang.org/x/xerrors"
+)
+
+// UnsealFromTPM will load the TPM sealed object in to the TPM and attempt to unseal it, returning the cleartext key on success.
+// If a PIN has been set, the correct PIN must be provided via the pin argument. If the wrong PIN is provided, a ErrPinFail error
+// will be returned, and the TPM's dictionary attack counter will be incremented.
+//
+// If the TPM's dictionary attack logic has been triggered, a ErrTPMLockout error will be returned.
+//
+// If the TPM is not provisioned correctly, then a ErrTPMProvisioning error will be returned. In this case, ProvisionTPM should be
+// called to attempt to resolve this.
+//
+// If the TPM sealed object cannot be loaded in to the TPM for reasons other than the lack of a storage root key, then a
+// InvalidKeyFileError error will be returned. This could be caused because the sealed object data is invalid in some way, or because
+// the sealed object is associated with another TPM owner (the TPM has been cleared since the sealed key data file was created with
+// SealKeyToTPM), or because the TPM object at the persistent handle reserved for the storage root key has a public area that looks
+// like a valid storage root key but it was created with the wrong template. This latter case is really caused by an incorrectly
+// provisioning TPM, but it isn't possible to detect this. A subsequent call to SealKeyToTPM will rectify this.
+//
+// If the TPM's current PCR values don't match the PCR protection policy for this key file, a InvalidKeyFileError error will be
+// returned.
+//
+// If any of the metadata in this key file is invalid, a InvalidKeyFileError error will be returned.
+//
+// If the TPM is missing any persistent resources associated with this key file, then a InvalidKeyFileError error will be returned.
+//
+// If the key file has been superceded (eg, by a call to UpdateKeyPCRProtectionPolicy), then a InvalidKeyFileError error will be
+// returned.
+//
+// If the signature of the updatable part of the key file's authorization policy is invalid, then a InvalidKeyFileError error will
+// be returned.
+//
+// If the metadata for the updatable part of the key file's authorization policy is not consistent with the approved policy, then a
+// InvalidKeyFileError error will be returned.
+//
+// If the provided PIN is incorrect, then a ErrPinFail error will be returned and the TPM's dictionary attack counter will be
+// incremented.
+//
+// TODO: Locked access error.
+//
+// If the authorization policy check fails during unsealing, then a InvalidKeyFileError error will be returned. Note that this
+// condition can also occur as the result of an incorrectly provisioned TPM, which will be detected during a subsequent call to
+// SealKeyToTPM.
+//
+// On success, the unsealed cleartext key is returned. If the lock argument is true, then subsequent access to all sealed key
+// objects created by this package will be denied until the next TPM reset or TPM restart.
+func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock bool) ([]byte, error) {
+	// Check if the TPM is in lockout mode
+	props, err := tpm.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot fetch properties from TPM: %w", err)
+	}
+
+	if tpm2.PermanentAttributes(props[0].Value)&tpm2.AttrInLockout > 0 {
+		return nil, ErrTPMLockout
+	}
+
+	// Use the HMAC session created when the connection was opened for parameter encryption rather than creating a new one.
+	hmacSession := tpm.HmacSession()
+
+	// Load the key data
+	key, err := k.data.load(tpm.TPMContext, hmacSession)
+	switch {
+	case isKeyFileError(err):
+		// A keyFileError can be as a result of an improperly provisioned TPM - detect if the object at srkHandle is a valid primary key
+		// with the correct attributes. If it's not, then it's definitely a provisioning error. If it is, then it could still be a
+		// provisioning error because we don't know if the object was created with the same template that ProvisionTPM uses. In that case,
+		// we'll just assume an invalid key file
+		srk, err2 := tpm.CreateResourceContextFromTPM(srkHandle)
+		switch {
+		case tpm2.IsResourceUnavailableError(err2, srkHandle):
+			return nil, ErrTPMProvisioning
+		case err2 != nil:
+			return nil, xerrors.Errorf("cannot create context for SRK: %w", err2)
+		}
+		ok, err2 := isObjectPrimaryKeyWithTemplate(tpm.TPMContext, tpm.OwnerHandleContext(), srk, srkTemplate, tpm.HmacSession())
+		switch {
+		case err2 != nil:
+			return nil, xerrors.Errorf("cannot determine if object at 0x%08x is a primary key in the storage hierarchy: %w", srkHandle, err2)
+		case !ok:
+			return nil, ErrTPMProvisioning
+		}
+		// This is probably a broken key file, but it could still be a provisioning error because we don't know if the SRK object was
+		// created with the same template that ProvisionTPM uses.
+		return nil, InvalidKeyFileError{err.Error()}
+	case tpm2.IsResourceUnavailableError(err, srkHandle):
+		return nil, ErrTPMProvisioning
+	case err != nil:
+		return nil, err
+	}
+	defer tpm.FlushContext(key)
+
+	// Begin and execute policy session
+	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, k.data.KeyPublic.NameAlg)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot start policy session: %w", err)
+	}
+	defer tpm.FlushContext(policySession)
+
+	if err := executePolicySession(tpm.TPMContext, policySession, k.data.StaticPolicyData, k.data.DynamicPolicyData, pin, hmacSession); err != nil {
+		err = xerrors.Errorf("cannot execute authorization policy assertions: %w", err)
+		switch {
+		case isDynamicPolicyDataError(err):
+			// TODO: Add a separate error for this
+			return nil, InvalidKeyFileError{err.Error()}
+		case isKeyFileError(err):
+			return nil, InvalidKeyFileError{err.Error()}
+		case isAuthFailError(err, tpm2.CommandPolicySecret, 1):
+			return nil, ErrPinFail
+		case tpm2.IsResourceUnavailableError(err, lockNVHandle):
+			return nil, ErrTPMProvisioning
+		case tpm2.IsTPMError(err, tpm2.ErrorNVLocked, tpm2.CommandPolicyNV):
+			// TODO: Add a separate error for this
+			return nil, err
+		}
+		return nil, err
+	}
+
+	// Unseal
+	keyData, err := tpm.Unseal(key, policySession, hmacSession.IncludeAttrs(tpm2.AttrResponseEncrypt))
+	switch {
+	case tpm2.IsTPMSessionError(err, tpm2.ErrorPolicyFail, tpm2.CommandUnseal, 1):
+		return nil, InvalidKeyFileError{"the authorization policy check failed during unsealing"}
+	case err != nil:
+		return nil, xerrors.Errorf("cannot unseal key: %w", err)
+	}
+
+	if lock {
+		if err := lockAccessToSealedKeysUntilTPMReset(tpm.TPMContext, hmacSession); err != nil {
+			return nil, xerrors.Errorf("cannot lock sealed key object from further access: %v", err)
+		}
+	}
+
+	return keyData, nil
+}

--- a/unseal.go
+++ b/unseal.go
@@ -123,7 +123,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 	defer tpm.FlushContext(policySession)
 
 	if err := executePolicySession(tpm.TPMContext, policySession, k.data.StaticPolicyData, k.data.DynamicPolicyData, pin, hmacSession); err != nil {
-		err = xerrors.Errorf("cannot execute authorization policy assertions: %w", err)
+		err = xerrors.Errorf("cannot complete authorization policy assertions: %w", err)
 		switch {
 		case isDynamicPolicyDataError(err):
 			// TODO: Add a separate error for this

--- a/unseal.go
+++ b/unseal.go
@@ -67,9 +67,8 @@ import (
 // condition can also occur as the result of an incorrectly provisioned TPM, which will be detected during a subsequent call to
 // SealKeyToTPM.
 //
-// On success, the unsealed cleartext key is returned. If the lock argument is true, then subsequent access to all sealed key
-// objects created by this package will be denied until the next TPM reset or TPM restart.
-func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock bool) ([]byte, error) {
+// On success, the unsealed cleartext key is returned.
+func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) ([]byte, error) {
 	// Check if the TPM is in lockout mode
 	props, err := tpm.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1)
 	if err != nil {
@@ -147,12 +146,6 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 		return nil, InvalidKeyFileError{"the authorization policy check failed during unsealing"}
 	case err != nil:
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
-	}
-
-	if lock {
-		if err := lockAccessToSealedKeysUntilTPMReset(tpm.TPMContext, hmacSession); err != nil {
-			return nil, xerrors.Errorf("cannot lock sealed key object from further access: %v", err)
-		}
 	}
 
 	return keyData, nil

--- a/unseal.go
+++ b/unseal.go
@@ -60,7 +60,8 @@ import (
 // If the provided PIN is incorrect, then a ErrPinFail error will be returned and the TPM's dictionary attack counter will be
 // incremented.
 //
-// TODO: Locked access error.
+// If access to sealed key objects created by this package is disallowed until the next TPM reset or TPM restart, then a
+// ErrSealedKeyAccessLocked error will be returned.
 //
 // If the authorization policy check fails during unsealing, then a InvalidKeyFileError error will be returned. Note that this
 // condition can also occur as the result of an incorrectly provisioned TPM, which will be detected during a subsequent call to
@@ -134,8 +135,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 		case tpm2.IsResourceUnavailableError(err, lockNVHandle):
 			return nil, ErrTPMProvisioning
 		case tpm2.IsTPMError(err, tpm2.ErrorNVLocked, tpm2.CommandPolicyNV):
-			// TODO: Add a separate error for this
-			return nil, err
+			return nil, ErrSealedKeyAccessLocked
 		}
 		return nil, err
 	}

--- a/unseal.go
+++ b/unseal.go
@@ -128,7 +128,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 		case isDynamicPolicyDataError(err):
 			// TODO: Add a separate error for this
 			return nil, InvalidKeyFileError{err.Error()}
-		case isKeyFileError(err):
+		case isStaticPolicyDataError(err):
 			return nil, InvalidKeyFileError{err.Error()}
 		case isAuthFailError(err, tpm2.CommandPolicySecret, 1):
 			return nil, ErrPinFail

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -179,8 +179,8 @@ func TestUnsealErrorHandling(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}
-		if err.Error() != "invalid key data file: cannot execute authorization policy assertions: cannot complete OR assertions: current "+
-			"session digest not found in policy data" {
+		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot complete authorization policy "+
+			"assertions: cannot complete OR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
@@ -194,9 +194,8 @@ func TestUnsealErrorHandling(t *testing.T) {
 				t.Fatalf("UpdateKeyPCRProtectionPolicy failed: %v", err)
 			}
 		})
-		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot execute authorization policy "+
-			"assertions: dynamic authorization policy revocation check failed: TPM returned an error whilst executing command "+
-			"TPM_CC_PolicyNV: TPM_RC_POLICY (policy failure in math operation or an invalid authPolicy value)" {
+		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot complete authorization policy "+
+			"assertions: the dynamic authorization policy has been revoked" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -60,7 +60,7 @@ func TestUnsealWithNo2FA(t *testing.T) {
 			t.Fatalf("ReadSealedKeyObject failed: %v", err)
 		}
 
-		keyUnsealed, err := k.UnsealFromTPM(tpm, "", false)
+		keyUnsealed, err := k.UnsealFromTPM(tpm, "")
 		if err != nil {
 			t.Fatalf("UnsealFromTPM failed: %v", err)
 		}
@@ -109,7 +109,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 
 		fn(keyFile, policyUpdateFile)
 
-		_, err = k.UnsealFromTPM(tpm, "", false)
+		_, err = k.UnsealFromTPM(tpm, "")
 		return err
 	}
 

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -51,7 +51,7 @@ func TestUnsealWithNo2FA(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, key, keyFile, "", &testCreationParams); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer undefineKeyNVSpace(t, tpm, keyFile)
@@ -89,7 +89,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 		keyFile := tmpDir + "/keydata"
 		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
 
-		if err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, &testCreationParams, key); err != nil {
+		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, &testCreationParams); err != nil {
 			t.Fatalf("SealKeyToTPM failed: %v", err)
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -1,0 +1,204 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/chrisccoulson/go-tpm2"
+	. "github.com/snapcore/secboot"
+)
+
+var testCreationParams = KeyCreationParams{PinHandle: 0x0181fff0}
+
+func TestUnsealWithNo2FA(t *testing.T) {
+	tpm := openTPMForTesting(t)
+	defer closeTPM(t, tpm)
+
+	if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+		t.Fatalf("Failed to provision TPM for test: %v", err)
+	}
+
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	tmpDir, err := ioutil.TempDir("", "_TestUnsealWithNo2FA_")
+	if err != nil {
+		t.Fatalf("Creating temporary directory failed: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	keyFile := tmpDir + "/keydata"
+
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, getTestPCRProfile(), key); err != nil {
+		t.Fatalf("SealKeyToTPM failed: %v", err)
+	}
+	defer undefineKeyNVSpace(t, tpm, keyFile)
+
+	k, err := LoadSealedKeyObject(keyFile)
+	if err != nil {
+		t.Fatalf("LoadSealedKeyObject failed: %v", err)
+	}
+
+	keyUnsealed, err := k.UnsealFromTPM(tpm, "", false)
+	if err != nil {
+		t.Fatalf("UnsealFromTPM failed: %v", err)
+	}
+
+	if !bytes.Equal(key, keyUnsealed) {
+		t.Errorf("TPM returned the wrong key")
+	}
+}
+
+func TestUnsealErrorHandling(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	run := func(t *testing.T, tpm *TPMConnection, fn func(string, string)) error {
+		if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+			t.Errorf("ProvisionTPM failed: %v", err)
+		}
+
+		tmpDir, err := ioutil.TempDir("", "_TestUnsealErrorHandling_")
+		if err != nil {
+			t.Fatalf("Creating temporary directory failed: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		keyFile := tmpDir + "/keydata"
+		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
+
+		if err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, &testCreationParams, getTestPCRProfile(), key); err != nil {
+			t.Fatalf("SealKeyToTPM failed: %v", err)
+		}
+		defer undefineKeyNVSpace(t, tpm, keyFile)
+
+		k, err := LoadSealedKeyObject(keyFile)
+		if err != nil {
+			t.Fatalf("LoadSealedKeyObject failed: %v", err)
+		}
+
+		fn(keyFile, policyUpdateFile)
+
+		_, err = k.UnsealFromTPM(tpm, "", false)
+		return err
+	}
+
+	t.Run("TPMLockout", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		err := run(t, tpm, func(_, _ string) {
+			// Put the TPM in DA lockout mode
+			if err := tpm.DictionaryAttackParameters(tpm.LockoutHandleContext(), 0, 7200, 86400, nil); err != nil {
+				t.Errorf("DictionaryAttackParameters failed: %v", err)
+			}
+		})
+		if err != ErrTPMLockout {
+			t.Errorf("Unexepcted error: %v", err)
+		}
+	})
+
+	t.Run("NoSRK", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		err := run(t, tpm, func(_, _ string) {
+			srk, err := tpm.CreateResourceContextFromTPM(SrkHandle)
+			if err != nil {
+				t.Fatalf("No SRK: %v", err)
+			}
+			if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), srk, srk.Handle(), nil); err != nil {
+				t.Errorf("EvictControl failed: %v", err)
+			}
+		})
+		if err != ErrTPMProvisioning {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("InvalidSRK", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		err := run(t, tpm, func(_, _ string) {
+			srk, err := tpm.CreateResourceContextFromTPM(SrkHandle)
+			if err != nil {
+				t.Fatalf("No SRK: %v", err)
+			}
+			if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), srk, srk.Handle(), nil); err != nil {
+				t.Errorf("EvictControl failed: %v", err)
+			}
+			srkTemplate := MakeDefaultSRKTemplate()
+			srkTemplate.Unique.RSA()[0] = 0xff
+			srkTransient, _, _, _, _, err := tpm.CreatePrimary(tpm.OwnerHandleContext(), nil, srkTemplate, nil, nil, nil)
+			if err != nil {
+				t.Fatalf("CreatePrimary failed: %v", err)
+			}
+			defer flushContext(t, tpm, srkTransient)
+			if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), srkTransient, SrkHandle, nil); err != nil {
+				t.Errorf("EvictControl failed: %v", err)
+			}
+		})
+		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot load sealed key object in to TPM: bad "+
+			"sealed key object or TPM owner changed" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("IncorrectPCRProfile", func(t *testing.T) {
+		tpm, _ := openTPMSimulatorForTesting(t)
+		defer closeTPM(t, tpm)
+
+		err := run(t, tpm, func(_, _ string) {
+			if _, err := tpm.PCREvent(tpm.PCRHandleContext(7), tpm2.Event("foo"), nil); err != nil {
+				t.Errorf("PCREvent failed: %v", err)
+			}
+		})
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "invalid key data file: cannot execute authorization policy assertions: cannot complete OR assertions: current "+
+			"session digest not found in policy data" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("RevokedPolicy", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		err := run(t, tpm, func(keyFile, policyUpdateFile string) {
+			if err := UpdateKeyPCRProtectionPolicy(tpm, keyFile, policyUpdateFile, getTestPCRProfile()); err != nil {
+				t.Fatalf("UpdateKeyPCRProtectionPolicy failed: %v", err)
+			}
+		})
+		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot execute authorization policy "+
+			"assertions: dynamic authorization policy revocation check failed: TPM returned an error whilst executing command "+
+			"TPM_CC_PolicyNV: TPM_RC_POLICY (policy failure in math operation or an invalid authPolicy value)" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+}

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/snapcore/secboot"
 )
 
-var testCreationParams = KeyCreationParams{PinHandle: 0x0181fff0}
+var testCreationParams = KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x0181fff0}
 
 func TestUnsealWithNo2FA(t *testing.T) {
 	tpm := openTPMForTesting(t)
@@ -51,7 +51,7 @@ func TestUnsealWithNo2FA(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, getTestPCRProfile(), key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer undefineKeyNVSpace(t, tpm, keyFile)
@@ -89,7 +89,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 		keyFile := tmpDir + "/keydata"
 		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
 
-		if err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, &testCreationParams, getTestPCRProfile(), key); err != nil {
+		if err := SealKeyToTPM(tpm, keyFile, policyUpdateFile, &testCreationParams, key); err != nil {
 			t.Fatalf("SealKeyToTPM failed: %v", err)
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -56,9 +56,9 @@ func TestUnsealWithNo2FA(t *testing.T) {
 	}
 	defer undefineKeyNVSpace(t, tpm, keyFile)
 
-	k, err := LoadSealedKeyObject(keyFile)
+	k, err := ReadSealedKeyObject(keyFile)
 	if err != nil {
-		t.Fatalf("LoadSealedKeyObject failed: %v", err)
+		t.Fatalf("ReadSealedKeyObject failed: %v", err)
 	}
 
 	keyUnsealed, err := k.UnsealFromTPM(tpm, "", false)
@@ -94,9 +94,9 @@ func TestUnsealErrorHandling(t *testing.T) {
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)
 
-		k, err := LoadSealedKeyObject(keyFile)
+		k, err := ReadSealedKeyObject(keyFile)
 		if err != nil {
-			t.Fatalf("LoadSealedKeyObject failed: %v", err)
+			t.Fatalf("ReadSealedKeyObject failed: %v", err)
 		}
 
 		fn(keyFile, policyUpdateFile)

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -201,4 +201,21 @@ func TestUnsealErrorHandling(t *testing.T) {
 		}
 	})
 
+	t.Run("SealedKeyAccessLocked", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		err := run(t, tpm, func(keyFile, policyUpdateFile string) {
+			lockIndex, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
+			if err != nil {
+				t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
+			}
+			if err := tpm.NVReadLock(lockIndex, lockIndex, nil); err != nil {
+				t.Errorf("NVReadLock failed: %v", err)
+			}
+		})
+		if err != ErrSealedKeyAccessLocked {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
 }

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -71,11 +71,11 @@ func TestUnsealWithNo2FA(t *testing.T) {
 	}
 
 	t.Run("SimplePCRProfile", func(t *testing.T) {
-		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x0181fff0})
+		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0})
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {
-		run(t, &KeyCreationParams{PinHandle: 0x0181fff0})
+		run(t, &KeyCreationParams{PINHandle: 0x0181fff0})
 	})
 }
 
@@ -97,7 +97,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 		keyFile := tmpDir + "/keydata"
 		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
 
-		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PinHandle: 0x0181fff0}); err != nil {
+		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0}); err != nil {
 			t.Fatalf("SealKeyToTPM failed: %v", err)
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)


### PR DESCRIPTION
This adds SealKeyToTPM for creating a new sealed TPM object,
UpdateKeyPCRProtectionPolicy for making changes to the PCR protection
policy for an existing key, and SealedKeyObject.UnsealFromTPM for accessing
a secret sealed with SealKeyToTPM.