### PR TITLE
Add AddSystemdEFIStubProfile API

### DIFF
--- a/sdefistub_policy.go
+++ b/sdefistub_policy.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/chrisccoulson/go-tpm2"
+	"github.com/chrisccoulson/tcglog-parser"
+
+	"golang.org/x/xerrors"
+)
+
+// SystemdEFIStubProfileParams provides the parameters to AddSystemdEFIStubProfile.
+type SystemdEFIStubProfileParams struct {
+	PCRAlgorithm   tpm2.HashAlgorithmId
+	PCRIndex       int      // The PCR that the systemd EFI stub measures the kernel commandline to
+	KernelCmdlines []string // The set of kernel commandlines to generate PCR digests for
+}
+
+// AddSystemdEFIStubProfile adds the systemd EFI linux loader stub profile to the PCR protection profile, in order to generate a
+// PCR policy that restricts access to a key to a defined set of kernel commandlines when booting a linux kernel using the systemd
+// EFI stub.
+//
+// The PCR index that the EFI stub measures the kernel commandline too can be specified via the PCRIndex field of params.
+//
+// The permitted set of kernel commandlines can be specified via the KernelCmdlines field of params.
+func AddSystemdEFIStubProfile(profile *PCRProtectionProfile, params *SystemdEFIStubProfileParams) error {
+	if profile == nil {
+		return errors.New("no profile supported")
+	}
+	if params == nil {
+		return errors.New("no params provided")
+	}
+
+	if len(params.KernelCmdlines) == 0 {
+		return errors.New("no kernel commandlines specified")
+	}
+
+	var subProfiles []*PCRProtectionProfile
+	for _, cmdline := range params.KernelCmdlines {
+		event := tcglog.SystemdEFIStubEventData{Str: cmdline}
+		var buf bytes.Buffer
+		if err := event.EncodeMeasuredBytes(&buf); err != nil {
+			return xerrors.Errorf("cannot encode kernel commandline event: %w", err)
+		}
+
+		h := params.PCRAlgorithm.NewHash()
+		buf.WriteTo(h)
+
+		subProfiles = append(subProfiles, NewPCRProtectionProfile().ExtendPCR(params.PCRAlgorithm, params.PCRIndex, h.Sum(nil)))
+	}
+
+	profile.AddProfileOR(subProfiles...)
+	return nil
+}

--- a/sdefistub_policy.go
+++ b/sdefistub_policy.go
@@ -31,9 +31,16 @@ import (
 
 // SystemdEFIStubProfileParams provides the parameters to AddSystemdEFIStubProfile.
 type SystemdEFIStubProfileParams struct {
-	PCRAlgorithm   tpm2.HashAlgorithmId
-	PCRIndex       int      // The PCR that the systemd EFI stub measures the kernel commandline to
-	KernelCmdlines []string // The set of kernel commandlines to generate PCR digests for
+	// PCRAlgorithm is the algorithm for which to compute PCR digests for. TPMs compliant with the "TCG PC Client Platform TPM Profile
+	// (PTP) Specification" Level 00, Revision 01.03 v22, May 22 2017 are required to support tpm2.HashAlgorithmSHA1 and
+	// tpm2.HashAlgorithmSHA256. Support for other digest algorithms is optional.
+	PCRAlgorithm tpm2.HashAlgorithmId
+
+	// PCRIndex is the PCR that the systemd EFI stub measures the kernel commandline to.
+	PCRIndex int
+
+	// KernelCmdlines is the set of kernel commandlines to add to the PCR profile.
+	KernelCmdlines []string
 }
 
 // AddSystemdEFIStubProfile adds the systemd EFI linux loader stub profile to the PCR protection profile, in order to generate a
@@ -42,7 +49,7 @@ type SystemdEFIStubProfileParams struct {
 //
 // The PCR index that the EFI stub measures the kernel commandline too can be specified via the PCRIndex field of params.
 //
-// The permitted set of kernel commandlines can be specified via the KernelCmdlines field of params.
+// The set of kernel commandlines to add to the PCRProtectionProfile is specified via the KernelCmdlines field of params.
 func AddSystemdEFIStubProfile(profile *PCRProtectionProfile, params *SystemdEFIStubProfileParams) error {
 	if profile == nil {
 		return errors.New("no profile supported")

--- a/sdefistub_policy.go
+++ b/sdefistub_policy.go
@@ -51,13 +51,6 @@ type SystemdEFIStubProfileParams struct {
 //
 // The set of kernel commandlines to add to the PCRProtectionProfile is specified via the KernelCmdlines field of params.
 func AddSystemdEFIStubProfile(profile *PCRProtectionProfile, params *SystemdEFIStubProfileParams) error {
-	if profile == nil {
-		return errors.New("no profile supported")
-	}
-	if params == nil {
-		return errors.New("no params provided")
-	}
-
 	if params.PCRIndex < 0 {
 		return errors.New("invalid PCR index")
 	}

--- a/sdefistub_policy.go
+++ b/sdefistub_policy.go
@@ -58,6 +58,9 @@ func AddSystemdEFIStubProfile(profile *PCRProtectionProfile, params *SystemdEFIS
 		return errors.New("no params provided")
 	}
 
+	if params.PCRIndex < 0 {
+		return errors.New("invalid PCR index")
+	}
 	if len(params.KernelCmdlines) == 0 {
 		return errors.New("no kernel commandlines specified")
 	}

--- a/sdefistub_policy_test.go
+++ b/sdefistub_policy_test.go
@@ -1,0 +1,149 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/chrisccoulson/go-tpm2"
+	. "github.com/snapcore/secboot"
+)
+
+func TestAddSystemdEFIStubProfile(t *testing.T) {
+	for _, data := range []struct {
+		desc    string
+		initial *PCRProtectionProfile
+		params  SystemdEFIStubProfileParams
+		values  []tpm2.PCRValues
+	}{
+		{
+			desc: "UC20",
+			params: SystemdEFIStubProfileParams{
+				PCRAlgorithm: tpm2.HashAlgorithmSHA256,
+				PCRIndex:     12,
+				KernelCmdlines: []string{
+					"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run",
+					"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover",
+				},
+			},
+			values: []tpm2.PCRValues{
+				{
+					tpm2.HashAlgorithmSHA256: {
+						12: decodeHexString(t, "fc433eaf039c6261f496a2a5bf2addfd8ff1104b0fc98af3fe951517e3bde824"),
+					},
+				},
+				{
+					tpm2.HashAlgorithmSHA256: {
+						12: decodeHexString(t, "b3a29076eeeae197ae721c254da40480b76673038045305cfa78ec87421c4eea"),
+					},
+				},
+			},
+		},
+		{
+			desc: "SHA1",
+			params: SystemdEFIStubProfileParams{
+				PCRAlgorithm: tpm2.HashAlgorithmSHA1,
+				PCRIndex:     12,
+				KernelCmdlines: []string{
+					"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run",
+					"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover",
+				},
+			},
+			values: []tpm2.PCRValues{
+				{
+					tpm2.HashAlgorithmSHA1: {
+						12: decodeHexString(t, "eb6312b7db70fe16206c162326e36b2fcda74b68"),
+					},
+				},
+				{
+					tpm2.HashAlgorithmSHA1: {
+						12: decodeHexString(t, "bd612bea9efa582fcbfae97973c89b163756fe0b"),
+					},
+				},
+			},
+		},
+		{
+			desc: "Classic",
+			params: SystemdEFIStubProfileParams{
+				PCRAlgorithm: tpm2.HashAlgorithmSHA256,
+				PCRIndex:     8,
+				KernelCmdlines: []string{
+					"root=/dev/mapper/vgubuntu-root ro quiet splash vt.handoff=7",
+				},
+			},
+			values: []tpm2.PCRValues{
+				{
+					tpm2.HashAlgorithmSHA256: {
+						8: decodeHexString(t, "74fe9080b798f9220c18d0fcdd0ccb82d50ce2a317bc6cdaa2d8715d02d0efbe"),
+					},
+				},
+			},
+		},
+		{
+			desc: "WithInitialProfile",
+			initial: func() *PCRProtectionProfile {
+				return NewPCRProtectionProfile().
+					AddPCRValue(tpm2.HashAlgorithmSHA256, 7, makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo")).
+					AddPCRValue(tpm2.HashAlgorithmSHA256, 8, makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar"))
+			}(),
+			params: SystemdEFIStubProfileParams{
+				PCRAlgorithm: tpm2.HashAlgorithmSHA256,
+				PCRIndex:     8,
+				KernelCmdlines: []string{
+					"root=/dev/mapper/vgubuntu-root ro quiet splash vt.handoff=7",
+				},
+			},
+			values: []tpm2.PCRValues{
+				{
+					tpm2.HashAlgorithmSHA256: {
+						7: makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo"),
+						8: decodeHexString(t, "3d39c0db757b47b484006003724d990403d533044ed06e8798ab374bd73f32dc"),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(data.desc, func(t *testing.T) {
+			profile := data.initial
+			if profile == nil {
+				profile = NewPCRProtectionProfile()
+			}
+			if err := AddSystemdEFIStubProfile(profile, &data.params); err != nil {
+				t.Fatalf("AddSystemdEFIStubProfile failed: %v", err)
+			}
+			values, err := profile.ComputePCRValues(nil)
+			if err != nil {
+				t.Fatalf("ComputePCRValues failed: %v", err)
+			}
+			if !reflect.DeepEqual(values, data.values) {
+				t.Errorf("ComputePCRValues returned unexpected values")
+				for i, v := range values {
+					t.Logf("Value %d:", i)
+					for alg := range v {
+						for pcr := range v[alg] {
+							t.Logf(" PCR%d,%v: %x", pcr, alg, v[alg][pcr])
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The AddSystemdEFIStubProfile API enables the creation of a PCR policy that
seals a key to a permitted set of kernel commandlines when booting a
system using systemd's EFI stub loader.