### PR TITLE
Add LockAccessToSealedKeys API

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -57,7 +57,6 @@ var (
 	IncrementDynamicPolicyCounter            = incrementDynamicPolicyCounter
 	IsDynamicPolicyDataError                 = isDynamicPolicyDataError
 	IsStaticPolicyDataError                  = isStaticPolicyDataError
-	LockAccessToSealedKeysUntilTPMReset      = lockAccessToSealedKeysUntilTPMReset
 	LockNVIndexAttrs                         = lockNVIndexAttrs
 	MakeDefaultEKTemplate                    = makeDefaultEKTemplate
 	MakeDefaultSRKTemplate                   = makeDefaultSRKTemplate

--- a/policy.go
+++ b/policy.go
@@ -836,17 +836,25 @@ func LockAccessToSealedKeys(tpm *TPMConnection) error {
 		return xerrors.Errorf("cannot obtain handles from TPM: %w", err)
 	}
 	if len(handles) == 0 || handles[0] != lockNVHandle {
-		// Not provisioned, so no keys to protect.
+		// Not provisioned, so no keys created by this package can be unsealed by this TPM
 		return nil
 	}
 	lock, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
 	if err != nil {
 		return xerrors.Errorf("cannot obtain context for lock NV index: %w", err)
 	}
+	lockPublic, _, err := tpm.NVReadPublic(lock, session.IncludeAttrs(tpm2.AttrAudit))
+	if err != nil {
+		return xerrors.Errorf("cannot read public area of lock NV index: %w", err)
+	}
+	if lockPublic.Attrs != lockNVIndexAttrs|tpm2.AttrNVWritten {
+		// Definitely not an index created by us, so no keys created by this package can be unsealed by this TPM.
+		return nil
+	}
 	if err := tpm.NVReadLock(lock, lock, session); err != nil {
-		if tpm2.IsTPMHandleError(err, tpm2.ErrorAttributes, tpm2.CommandNVReadLock, 2) {
-			// Not provisioned with a valid lock NV index, so no keys created by this package can
-			// be unsealed on this TPM anyway.
+		if isAuthFailError(err, tpm2.CommandNVReadLock, 1) {
+			// The index has an authorization value, so it wasn't created by this package and no keys created by this package can be unsealed
+			// by this TPM.
 			return nil
 		}
 		return xerrors.Errorf("cannot lock NV index for reading: %w", err)

--- a/policy.go
+++ b/policy.go
@@ -822,11 +822,15 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 	return nil
 }
 
-// lockAccessToSealedKeysUntilTPMReset locks access to sealed key objects created by this package until the next TPM restart
-// or TPM reset (aka, Startup(CLEAR)). This works by enabling the read lock bit for a well-known NV index. The static authorization
-// policy of sealed key objects created by this package contain a TPM2_PolicyNV assertion on this index, which will fail once the
-// read lock bit has been enabled.
-func lockAccessToSealedKeysUntilTPMReset(tpm *tpm2.TPMContext, session tpm2.SessionContext) error {
+// LockAccessToSealedKeys locks access to keys sealed by this package until the next TPM restart (equivalent to eg, system resume
+// from suspend-to-disk) or TPM reset (equivalent to booting after a system restart). This works for all keys sealed by this package
+// regardless of their PCR protection profile.
+//
+// On success, subsequent calls to SealedKeyObject.UnsealFromTPM will fail with a ErrSealedKeyAccessLocked error until the next TPM
+// restart or TPM reset.
+func LockAccessToSealedKeys(tpm *TPMConnection) error {
+	session := tpm.HmacSession()
+
 	handles, err := tpm.GetCapabilityHandles(lockNVHandle, 1, session.IncludeAttrs(tpm2.AttrAudit))
 	if err != nil {
 		return xerrors.Errorf("cannot obtain handles from TPM: %w", err)

--- a/policy_test.go
+++ b/policy_test.go
@@ -2458,7 +2458,7 @@ func TestExecutePolicy(t *testing.T) {
 	})
 }
 
-func TestLockAccessToSealedKeysUntilTPMReset(t *testing.T) {
+func TestLockAccessToSealedKeys(t *testing.T) {
 	tpm, tcti := openTPMSimulatorForTesting(t)
 	defer closeTPM(t, tpm)
 
@@ -2538,8 +2538,8 @@ func TestLockAccessToSealedKeysUntilTPMReset(t *testing.T) {
 				t.Errorf("Unexpected digests")
 			}
 
-			if err := LockAccessToSealedKeysUntilTPMReset(tpm.TPMContext, tpm.HmacSession()); err != nil {
-				t.Errorf("LockAccessToSealedKeysUntilTPMReset failed: %v", err)
+			if err := LockAccessToSealedKeys(tpm); err != nil {
+				t.Errorf("LockAccessToSealedKeys failed: %v", err)
 			}
 
 			if err := tpm.PolicyRestart(policySession); err != nil {

--- a/policy_test.go
+++ b/policy_test.go
@@ -2562,3 +2562,52 @@ func TestLockAccessToSealedKeys(t *testing.T) {
 		}()
 	}
 }
+
+func TestLockAccessToSealedKeysUnprovisioned(t *testing.T) {
+	tpm := openTPMForTesting(t)
+	defer closeTPM(t, tpm)
+
+	run := func(t *testing.T) {
+		if err := LockAccessToSealedKeys(tpm); err != nil {
+			t.Errorf("LockAccessToSealedKeys failed: %v", err)
+		}
+	}
+
+	t.Run("NoNVIndex", func(t *testing.T) {
+		// Test with no NV index defined.
+		undefineLockNVIndices(t, tpm)
+		run(t)
+	})
+
+	t.Run("UnrelatedNVIndex/1", func(t *testing.T) {
+		// Test with a NV index defined that has the wrong attributes.
+		undefineLockNVIndices(t, tpm)
+		public := tpm2.NVPublic{
+			Index:   LockNVHandle,
+			NameAlg: tpm2.HashAlgorithmSHA256,
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVOwnerWrite | tpm2.AttrNVOwnerRead),
+			Size:    8}
+		index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &public, nil)
+		if err != nil {
+			t.Fatalf("NVDefineSpace failed: %v", err)
+		}
+		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+		run(t)
+	})
+
+	t.Run("UnrelatedNVIndex/2", func(t *testing.T) {
+		// Test with a NV index defined with the expected attributes, but with a non-empty authorization value.
+		undefineLockNVIndices(t, tpm)
+		public := tpm2.NVPublic{
+			Index:   LockNVHandle,
+			NameAlg: tpm2.HashAlgorithmSHA256,
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVReadStClear),
+			Size:    0}
+		index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), []byte("foo"), &public, nil)
+		if err != nil {
+			t.Fatalf("NVDefineSpace failed: %v", err)
+		}
+		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+		run(t)
+	})
+}

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -212,13 +212,9 @@ func TestUnsealErrorHandling(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
 
-		err := run(t, tpm, func(keyFile, policyUpdateFile string) {
-			lockIndex, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-			if err != nil {
-				t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
-			}
-			if err := tpm.NVReadLock(lockIndex, lockIndex, nil); err != nil {
-				t.Errorf("NVReadLock failed: %v", err)
+		err := run(t, tpm, func(_, _ string) {
+			if err := LockAccessToSealedKeys(tpm); err != nil {
+				t.Errorf("LockAccessToSealedKeys failed: %v", err)
 			}
 		})
 		if err != ErrSealedKeyAccessLocked {


### PR DESCRIPTION
This API is called to prevent access to any keys sealed by this package
until the next TPM restart or TPM reset. It works with any key sealed by
this package, regardless of the PCR protection policy.