### PR TITLE
Add ActivateVolume helper APIs for activating LUKS volumes

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -362,16 +362,17 @@ func makeActivateOptions(in []string) ([]string, error) {
 	return append(out, "tries=1"), nil
 }
 
-// ActivateWithTPMSealedKeyOptions provides options to ActivateVolumeWIthTPMSealedKey.
+// ActivateWithTPMSealedKeyOptions provides options to ActivateVolumeWtthTPMSealedKey.
 type ActivateWithTPMSealedKeyOptions struct {
-	// PINTries specifies the maximum number of times that unsealing with a PIN should be attempted. Setting this to zero disables
-	// unsealing with a PIN - in this case, an error will be returned if the sealed key object indicates that a PIN has been set.
-	// Attempts to unseal with a PIN will stop if the TPM enters dictionary attack lockout mode before this limit is reached.
+	// PINTries specifies the maximum number of times that unsealing with a PIN should be attempted before failing with an error and
+	// falling back to activating with the recovery key if RecoveryKeyTries is greater than zero. Setting this to zero disables unsealing
+	// with a PIN - in this case, an error will be returned if the sealed key object indicates that a PIN has been set. Attempts to
+	// unseal with a PIN will stop if the TPM enters dictionary attack lockout mode before this limit is reached.
 	PINTries int
 
-	// RecoveryKeyTries specifies the maximum number of times that activation with the fallback recovery key should be attempted,
-	// if activation with the TPM sealed key fails. Setting this to zero will disable attempts to activate with the fallback recovery
-	// key.
+	// RecoveryKeyTries specifies the maximum number of times that activation with the fallback recovery key should be attempted
+	// if activation with the TPM sealed key fails, before failing with an error. Setting this to zero will disable attempts to activate
+	// with the fallback recovery key.
 	RecoveryKeyTries int
 
 	// ActivateOptions provides a mechanism to pass additional options to systemd-cryptsetup.
@@ -455,8 +456,13 @@ func ActivateVolumeWithTPMSealedKey(tpm *TPMConnection, volumeName, sourceDevice
 	return true, nil
 }
 
+// ActivateWithRecoveryKeyOptions provides options to ActivateVolumeWithRecoveryKey.
 type ActivateWithRecoveryKeyOptions struct {
-	Tries           int
+	// Tries specifies the maximum number of times that activation with the fallback recovery key should be attempted before failing
+	// with an error.
+	Tries int
+
+	// ActivateOptions provides a mechanism to pass additional options to systemd-cryptsetup.
 	ActivateOptions []string
 }
 

--- a/crypt.go
+++ b/crypt.go
@@ -85,7 +85,7 @@ func activate(volumeName, sourceDevicePath string, key []byte, options []string)
 		return f.Name(), nil
 	}()
 	if err != nil {
-		return xerrors.Errorf("error saving key for systemd-cryptsetup: %w", err)
+		return xerrors.Errorf("cannot temporarily save key for systemd-cryptsetup: %w", err)
 	}
 	defer os.Remove(keyFilePath)
 

--- a/crypt.go
+++ b/crypt.go
@@ -411,9 +411,9 @@ type ActivateWithTPMSealedKeyOptions struct {
 // error will be returned. In this case, activation with either the TPM sealed key or the fallback recovery key will not be attempted.
 //
 // If activation with the TPM sealed key fails, a *ActivateWithTPMSealedKeyError error will be returned, even if the subsequent
-// fallback recovery activation is successful. In this case, the RecoveryErr field of the returned error will be nil, and the TPMErr
-// field will contain the original error. If activation with the fallback recovery key also fails, the RecoveryErr field of the
-// returned error will also contain details of the error encountered during recovery key activation.
+// fallback recovery activation is successful. In this case, the RecoveryKeyUsageErr field of the returned error will be nil, and the
+// TPMErr field will contain the original error. If activation with the fallback recovery key also fails, the RecoveryKeyUsageErr
+// field of the returned error will also contain details of the error encountered during recovery key activation.
 //
 // If the volume is successfully activated, either with the TPM sealed key or the fallback recovery key, this function returns true.
 // If it is not successfully activated, then this function returns false.

--- a/crypt.go
+++ b/crypt.go
@@ -1,0 +1,488 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
+)
+
+const userKeyring = -4
+
+var (
+	runDir                = "/run"
+	systemdCryptsetupPath = "/lib/systemd/systemd-cryptsetup"
+)
+
+type execError struct {
+	path string
+	err  error
+}
+
+func (e *execError) Error() string {
+	return fmt.Sprintf("%s failed: %s", e.path, e.err)
+}
+
+func (e *execError) Unwrap() error {
+	return e.err
+}
+
+func wrapExecError(cmd *exec.Cmd, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &execError{path: cmd.Path, err: err}
+}
+
+func isExecError(err error, path string) bool {
+	var e *execError
+	return xerrors.As(err, &e) && e.path == path
+}
+
+func activate(volumeName, sourceDevicePath string, key []byte, options []string) error {
+	keyFilePath, err := func() (string, error) {
+		f, err := ioutil.TempFile(runDir, filepath.Base(os.Args[0])+".")
+		if err != nil {
+			return "", xerrors.Errorf("cannot create temporary file: %w", err)
+		}
+		defer f.Close()
+		if err := f.Chmod(0600); err != nil {
+			return "", err
+		}
+		if _, err := f.Write(key); err != nil {
+			return "", xerrors.Errorf("cannot write key to file: %w", err)
+		}
+		return f.Name(), nil
+	}()
+	if err != nil {
+		return xerrors.Errorf("error saving key for systemd-cryptsetup: %w", err)
+	}
+	defer os.Remove(keyFilePath)
+
+	cmd := exec.Command(systemdCryptsetupPath, "attach", volumeName, sourceDevicePath, keyFilePath, strings.Join(options, ","))
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "SYSTEMD_LOG_TARGET=console")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return xerrors.Errorf("cannot create stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return xerrors.Errorf("cannot create stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	done := make(chan bool, 2)
+	go func() {
+		rd := bufio.NewScanner(stdout)
+		for rd.Scan() {
+			fmt.Printf("systemd-cryptsetup: %s\n", rd.Text())
+		}
+		done <- true
+	}()
+	go func() {
+		rd := bufio.NewScanner(stderr)
+		for rd.Scan() {
+			fmt.Fprintf(os.Stderr, "systemd-cryptsetup: %s\n", rd.Text())
+		}
+		done <- true
+	}()
+	for i := 0; i < 2; i++ {
+		<-done
+	}
+
+	return wrapExecError(cmd, cmd.Wait())
+}
+
+func askPassword(sourceDevicePath, msg string) (string, error) {
+	cmd := exec.Command(
+		"systemd-ask-password",
+		"--icon", "drive-harddisk",
+		"--id", filepath.Base(os.Args[0])+":"+sourceDevicePath,
+		msg)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return "", wrapExecError(cmd, err)
+	}
+	result, err := out.ReadString('\n')
+	if err != nil {
+		return "", xerrors.Errorf("cannot read result from systemd-ask-password: %w", err)
+	}
+	return strings.TrimRight(result, "\n"), nil
+}
+
+func getPassword(sourceDevicePath, description string, reader io.Reader) (string, error) {
+	if reader != nil {
+		scanner := bufio.NewScanner(reader)
+		switch {
+		case scanner.Scan():
+			return scanner.Text(), nil
+		case scanner.Err() != nil:
+			return "", xerrors.Errorf("cannot obtain %s from scanner: %w", description, scanner.Err())
+		}
+	}
+	return askPassword(sourceDevicePath, "Please enter the "+description+" for disk "+sourceDevicePath+":")
+}
+
+func decodeRecoveryKey(passphrase string) ([]byte, error) {
+	// The recovery key should be provided as 8 groups of 5 base-10 digits, with each 5 digits being converted to a 2-byte number to
+	// make a 16-byte key.
+	var key bytes.Buffer
+	for len(passphrase) > 0 {
+		if len(passphrase) < 5 {
+			return nil, errors.New("incorrectly formatted (insufficient characters)")
+		}
+		x, err := strconv.ParseUint(passphrase[0:5], 10, 16)
+		if err != nil {
+			return nil, errors.New("incorrectly formatted (invalid base-10 number)")
+		}
+		binary.Write(&key, binary.LittleEndian, uint16(x))
+
+		// Move to the next 5 digits
+		passphrase = passphrase[5:]
+		// Permit each set of 5 digits to be separated by '-', but don't allow the recovery key to end or begin with one.
+		if len(passphrase) > 1 && passphrase[0] == '-' {
+			passphrase = passphrase[1:]
+		}
+	}
+	return key.Bytes(), nil
+}
+
+// RecoveryReason indicates the reason that a volume had to be activated with the fallback recovery key instead of the TPM sealed key.
+type RecoveryReason uint8
+
+const (
+	// RecoveryReasonUnexpectedError indicates that a volume had to be activated with the fallback recovery key because an unexpected
+	// error was encountered during activation with the TPM sealed key.
+	RecoveryReasonUnexpectedError RecoveryReason = iota + 1
+
+	// RecoveryReasonRequested indicates that a volume was activated with the fallback recovery key via the ActivateVolumeWithRecoveryKey
+	// API.
+	RecoveryReasonRequested
+
+	// RecoveryReasonTPMLockout indicates that a volume had to be activated with the fallback recovery key because the TPM is in
+	// dictionary attack lockout mode.
+	RecoveryReasonTPMLockout
+
+	// RecoveryReasonTPMProvisioningError indicates that a volume had to be activated with the fallback recovery key because the TPM is
+	// not correctly provisioned.
+	RecoveryReasonTPMProvisioningError
+
+	// RecoveryReasonInvalidKeyFile indicates that a volume had to be activated with the fallback recovery key because the TPM sealed key
+	// file is invalid. Note that attempts to resolve this by creating a new file with SealKeyToTPM may indicate that the TPM is also not
+	// correctly provisioned.
+	RecoveryReasonInvalidKeyFile
+
+	// RecoveryReasonPINFail indicates that a volume had to be activated with the fallback recovery key because the correct PIN was not
+	// provided.
+	RecoveryReasonPINFail
+)
+
+func activateWithRecoveryKey(volumeName, sourceDevicePath string, keyReader io.Reader, tries int, reason RecoveryReason, activateOptions []string) error {
+	if tries == 0 {
+		return errors.New("no recovery key tries permitted")
+	}
+
+	var lastErr error
+
+	for ; tries > 0; tries-- {
+		lastErr = nil
+
+		r := keyReader
+		keyReader = nil
+
+		passphrase, err := getPassword(sourceDevicePath, "recovery key", r)
+		if err != nil {
+			return xerrors.Errorf("cannot obtain recovery key: %w", err)
+		}
+
+		key, err := decodeRecoveryKey(passphrase)
+		if err != nil {
+			lastErr = xerrors.Errorf("cannot decode recovery key: %w", err)
+			continue
+		}
+
+		if err := activate(volumeName, sourceDevicePath, key, activateOptions); err != nil {
+			err = xerrors.Errorf("cannot activate volume: %w", err)
+			var e *exec.ExitError
+			if !xerrors.As(err, &e) {
+				return err
+			}
+			lastErr = err
+			continue
+		}
+
+		if _, err := unix.AddKey("user", fmt.Sprintf("%s:%s:reason=%d", filepath.Base(os.Args[0]), volumeName, reason), key, userKeyring); err != nil {
+			lastErr = xerrors.Errorf("cannot add recovery key to user keyring: %w", err)
+		}
+		break
+	}
+
+	return lastErr
+}
+
+func unsealKeyFromTPM(tpm *TPMConnection, k *SealedKeyObject, pin string) ([]byte, error) {
+	key, err := k.UnsealFromTPM(tpm, pin)
+	if err == ErrTPMProvisioning {
+		// ErrTPMProvisioning in this context might indicate that there isn't a valid persistent SRK. Have a go at creating one now and then
+		// retrying the unseal operation - if the previous SRK was evicted, the TPM owner hasn't changed and the storage hierarchy still
+		// has a null authorization value, then this will allow us to unseal the key without requiring any type of manual recovery. If the
+		// storage hierarchy has a non-null authorization value, ProvionTPM will fail. If the TPM owner has changed, ProvisionTPM might
+		// succeed, but UnsealFromTPM will fail with InvalidKeyFileError when retried.
+		if pErr := ProvisionTPM(tpm, ProvisionModeWithoutLockout, nil); pErr == nil {
+			key, err = k.UnsealFromTPM(tpm, pin)
+		}
+	}
+	return key, err
+}
+
+var requiresPinErr = errors.New("no PIN tries permitted when a PIN is required")
+
+type lockAccessError struct {
+	err error
+}
+
+func (e lockAccessError) Error() string {
+	return e.err.Error()
+}
+
+func (e lockAccessError) Unwrap() error {
+	return e.err
+}
+
+func isLockAccessError(err error) bool {
+	var e lockAccessError
+	return xerrors.As(err, &e)
+}
+
+func activateWithTPMKey(tpm *TPMConnection, volumeName, sourceDevicePath, keyPath string, pinReader io.Reader, pinTries int, lock bool, activateOptions []string) error {
+	var lockErr error
+	key, err := func() ([]byte, error) {
+		defer func() {
+			if !lock {
+				return
+			}
+			lockErr = LockAccessToSealedKeys(tpm)
+		}()
+
+		k, err := ReadSealedKeyObject(keyPath)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot read sealed key object: %w", err)
+		}
+
+		switch {
+		case pinTries == 0 && k.AuthMode2F() == AuthModePIN:
+			return nil, requiresPinErr
+		case pinTries == 0:
+			pinTries = 1
+		}
+
+		var key []byte
+
+		for ; pinTries > 0; pinTries-- {
+			var pin string
+			if k.AuthMode2F() == AuthModePIN {
+				r := pinReader
+				pinReader = nil
+				pin, err = getPassword(sourceDevicePath, "PIN", r)
+				if err != nil {
+					return nil, xerrors.Errorf("cannot obtain PIN: %w", err)
+				}
+			}
+
+			key, err = unsealKeyFromTPM(tpm, k, pin)
+			if err != nil && (err != ErrPINFail || k.AuthMode2F() != AuthModePIN) {
+				break
+			}
+		}
+
+		if err != nil {
+			return nil, xerrors.Errorf("cannot unseal key: %w", err)
+		}
+		return key, nil
+	}()
+
+	switch {
+	case lockErr != nil:
+		return lockAccessError{err}
+	case err != nil:
+		return err
+	}
+
+	if err := activate(volumeName, sourceDevicePath, key, activateOptions); err != nil {
+		return xerrors.Errorf("cannot activate volume: %w", err)
+	}
+
+	return nil
+}
+
+func makeActivateOptions(in []string) ([]string, error) {
+	var out []string
+	for _, o := range in {
+		if strings.HasPrefix(o, "tries=") {
+			return nil, errors.New("cannot specify the \"tries=\" option for systemd-cryptsetup")
+		}
+		out = append(out, o)
+	}
+	return append(out, "tries=1"), nil
+}
+
+// ActivateWithTPMSealedKeyOptions provides options to ActivateVolumeWIthTPMSealedKey.
+type ActivateWithTPMSealedKeyOptions struct {
+	// PINTries specifies the maximum number of times that unsealing with a PIN should be attempted. Setting this to zero disables
+	// unsealing with a PIN - in this case, an error will be returned if the sealed key object indicates that a PIN has been set.
+	// Attempts to unseal with a PIN will stop if the TPM enters dictionary attack lockout mode before this limit is reached.
+	PINTries int
+
+	// RecoveryKeyTries specifies the maximum number of times that activation with the fallback recovery key should be attempted,
+	// if activation with the TPM sealed key fails. Setting this to zero will disable attempts to activate with the fallback recovery
+	// key.
+	RecoveryKeyTries int
+
+	// ActivateOptions provides a mechanism to pass additional options to systemd-cryptsetup.
+	ActivateOptions []string
+
+	// LockSealedKeyAccess controls whether LockAccessToSealedKeys should be called after unsealing the TPM sealed key. It is called if
+	// this is set to true, and not called if this is set to false.
+	LockSealedKeyAccess bool
+}
+
+// ActivateVolumeWithTPMSealedKey attempts to activate the LUKS encrypted volume at sourceDevicePath and create a mapping with the
+// name volumeName, using the TPM sealed key object at the specified keyPath. This makes use of systemd-cryptsetup.
+//
+// If the TPM sealed key object has a PIN defined, then this function will use systemd-ask-password to request it. If pinReader is not
+// nil, then an attempt to read the PIN from this will be made instead by reading all characters until the first newline. The PINTries
+// field of options defines how many attempts should be made to obtain the correct PIN before failing.
+//
+// The ActivateOptions field of options can be used to specify additional options to pass to systemd-cryptsetup.
+//
+// If the LockSealedKeyAccess field of options is true, then this function will call LockAccessToSealedKeys after unsealing the key
+// and before activating the LUKS volume.
+//
+// If activation with the TPM sealed key object fails, this function will attempt to activate it with the fallback recovery key
+// instead. The fallback recovery key will be requested using systemd-ask-password. The RecoveryKeyTries field of options specifies
+// how many attempts should be made to activate the volume with the recovery key before failing. If this is set to 0, then no attempts
+// will be made to activate the encrypted volume with the fallback recovery key. If activation with the recovery key is successful,
+// the recovery key will be added to the root user keyring in the kernel with a description of the format
+// "<argv[0]>:<volumeName>:reason=<reason>" where reason is an integer that describes the recovery reason - see the RecoveryReason
+// type.
+//
+// If either the PINTries or RecoveryKeyTries fields of options are less than zero, an error will be returned. If the ActivateOptions
+// field of options contains the "tries=" option, then an error will be returned. This option cannot be used with this function.
+//
+// If the LockSealedKeyAccess field of options is true and the call to LockAccessToSealedKeys fails, a LockAccessToSealedKeysError
+// error will be returned. In this case, activation with either the TPM sealed key or the fallback recovery key will not be attempted.
+//
+// If activation with the TPM sealed key fails, a *ActivateWithTPMSealedKeyError error will be returned, even if the subsequent
+// fallback recovery activation is successful. In this case, the RecoveryErr field of the returned error will be nil, and the TPMErr
+// field will contain the original error. If activation with the fallback recovery key also fails, the RecoveryErr field of the
+// returned error will also contain details of the error encountered during recovery key activation.
+//
+// If the volume is successfully activated, either with the TPM sealed key or the fallback recovery key, this function returns true.
+// If it is not successfully activated, then this function returns false.
+func ActivateVolumeWithTPMSealedKey(tpm *TPMConnection, volumeName, sourceDevicePath, keyPath string, pinReader io.Reader, options *ActivateWithTPMSealedKeyOptions) (bool, error) {
+	if options.PINTries < 0 {
+		return false, errors.New("invalid PINTries")
+	}
+	if options.RecoveryKeyTries < 0 {
+		return false, errors.New("invalid RecoveryKeyTries")
+	}
+
+	activateOptions, err := makeActivateOptions(options.ActivateOptions)
+	if err != nil {
+		return false, err
+	}
+
+	if err := activateWithTPMKey(tpm, volumeName, sourceDevicePath, keyPath, pinReader, options.PINTries, options.LockSealedKeyAccess, activateOptions); err != nil {
+		reason := RecoveryReasonUnexpectedError
+		switch {
+		case isLockAccessError(err):
+			return false, LockAccessToSealedKeysError(err.Error())
+		case xerrors.Is(err, ErrTPMLockout):
+			reason = RecoveryReasonTPMLockout
+		case xerrors.Is(err, ErrTPMProvisioning):
+			reason = RecoveryReasonTPMProvisioningError
+		case isInvalidKeyFileError(err):
+			reason = RecoveryReasonInvalidKeyFile
+		case xerrors.Is(err, requiresPinErr):
+			reason = RecoveryReasonPINFail
+		case xerrors.Is(err, ErrPINFail):
+			reason = RecoveryReasonPINFail
+		case isExecError(err, systemdCryptsetupPath):
+			// systemd-cryptsetup only provides 2 exit codes - success or fail - so we don't know the reason it failed yet. If activation
+			// with the recovery key is successful, then it's safe to assume that it failed because the key unsealed from the TPM is incorrect.
+			reason = RecoveryReasonInvalidKeyFile
+		}
+		rErr := activateWithRecoveryKey(volumeName, sourceDevicePath, nil, options.RecoveryKeyTries, reason, activateOptions)
+		return rErr == nil, &ActivateWithTPMSealedKeyError{err, rErr}
+	}
+
+	return true, nil
+}
+
+type ActivateWithRecoveryKeyOptions struct {
+	Tries           int
+	ActivateOptions []string
+}
+
+// ActivateVolumeWithRecoveryKey attempts to activate the LUKS encrypted volume at sourceDevicePath and create a mapping with the
+// name volumeName, using the fallback recovery key. This makes use of systemd-cryptsetup.
+//
+// This function will use systemd-ask-password to request the recovery key. If keyReader is not nil, then an attempt to read the key
+// from this will be made instead by reading all characters until the first newline. The Tries field of options defines how many
+// attempts should be made to activate the volume with the recovery key before failing.
+//
+// The ActivateOptions field of options can be used to specify additional options to pass to systemd-cryptsetup.
+//
+// If activation with the recovery key is successful, the recovery key will be added to the root user keyring in the kernel with a
+// description of the format "<argv[0]>:<volumeName>:reason=2".
+//
+// If the Tries field of options is less than zero, an error will be returned. If the ActivateOptions field of options contains the
+// "tries=" option, then an error will be returned. This option cannot be used with this function.
+func ActivateVolumeWithRecoveryKey(volumeName, sourceDevicePath string, keyReader io.Reader, options *ActivateWithRecoveryKeyOptions) error {
+	if options.Tries < 0 {
+		return errors.New("invalid Tries")
+	}
+
+	activateOptions, err := makeActivateOptions(options.ActivateOptions)
+	if err != nil {
+		return err
+	}
+
+	return activateWithRecoveryKey(volumeName, sourceDevicePath, keyReader, options.Tries, RecoveryReasonRequested, activateOptions)
+}

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -148,7 +148,7 @@ fi
 	})
 }
 
-func (ctb *cryptTestBase) checkRecoveryKeyKeyringEntry(c *C, reason RecoveryReason) {
+func (ctb *cryptTestBase) checkRecoveryKeyKeyringEntry(c *C, reason RecoveryKeyUsageReason) {
 	id, err := unix.KeyctlSearch(userKeyring, "user", fmt.Sprintf("%s:data:reason=%d", filepath.Base(os.Args[0]), reason), 0)
 	c.Check(err, IsNil)
 
@@ -295,7 +295,7 @@ type testActivateVolumeWithTPMSealedKeyErrorHandlingData struct {
 	activateOptions    []string
 	passphraseAttempts []string
 	success            bool
-	recoveryReason     RecoveryReason
+	recoveryReason     RecoveryKeyUsageReason
 	errChecker         Checker
 	errCheckerArgs     []interface{}
 }
@@ -354,7 +354,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
 		recoveryKeyTries:   1,
 		passphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
 		success:            true,
-		recoveryReason:     RecoveryReasonTPMLockout,
+		recoveryReason:     RecoveryKeyUsageReasonTPMLockout,
 		errChecker:         ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is in DA lockout mode\\) but " +
 			"activation with recovery key was successful"},
@@ -378,7 +378,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
 			strings.Join(s.recoveryKeyAscii, "-"),
 		},
 		success:        true,
-		recoveryReason: RecoveryReasonTPMProvisioningError,
+		recoveryReason: RecoveryKeyUsageReasonTPMProvisioningError,
 		errChecker:     ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is not correctly " +
 			"provisioned\\) but activation with recovery key was successful"},
@@ -395,7 +395,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
 		recoveryKeyTries:   1,
 		passphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
 		success:            true,
-		recoveryReason:     RecoveryReasonInvalidKeyFile,
+		recoveryReason:     RecoveryKeyUsageReasonInvalidKeyFile,
 		errChecker:         ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() +
 			" failed: exit status 1\\) but activation with recovery key was successful"},
@@ -476,7 +476,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 		recoveryKeyTries:   1,
 		passphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
 		success:            true,
-		recoveryReason:     RecoveryReasonInvalidKeyFile,
+		recoveryReason:     RecoveryKeyUsageReasonInvalidKeyFile,
 		errChecker:         ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data file: cannot complete " +
 			"authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data\\) but " +
@@ -525,7 +525,7 @@ func (s *cryptSuite) testActivateVolumeWithRecoveryKey(c *C, data *testActivateV
 	}
 
 	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyKeyringEntry(c, RecoveryReasonRequested)
+	s.checkRecoveryKeyKeyringEntry(c, RecoveryKeyUsageReasonRequested)
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKey1(c *C) {
@@ -631,7 +631,7 @@ func (s *cryptSuite) testActivateVolumeWithRecoveryKeyUsingKeyReader(c *C, data 
 	}
 
 	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyKeyringEntry(c, RecoveryReasonRequested)
+	s.checkRecoveryKeyKeyringEntry(c, RecoveryKeyUsageReasonRequested)
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader1(c *C) {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1,0 +1,738 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chrisccoulson/go-tpm2"
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/snapd/testutil"
+
+	"golang.org/x/sys/unix"
+
+	. "gopkg.in/check.v1"
+)
+
+type cryptTestBase struct {
+	recoveryKey      []byte
+	recoveryKeyAscii []string
+
+	dir string
+
+	passwordFile            string
+	expectedTpmKeyFile      string
+	expectedRecoveryKeyFile string
+
+	mockSdAskPassword *testutil.MockCmd
+	mockSdCryptsetup  *testutil.MockCmd
+}
+
+func (ctb *cryptTestBase) setUpSuiteBase(c *C) {
+	ctb.recoveryKey = make([]byte, 16)
+	rand.Read(ctb.recoveryKey)
+
+	for i := 0; i < len(ctb.recoveryKey)/2; i++ {
+		x := binary.LittleEndian.Uint16(ctb.recoveryKey[i*2:])
+		ctb.recoveryKeyAscii = append(ctb.recoveryKeyAscii, fmt.Sprintf("%05d", x))
+	}
+}
+
+func (ctb *cryptTestBase) setUpTestBase(c *C, bt *testutil.BaseTest) {
+	ctb.dir = c.MkDir()
+	bt.AddCleanup(MockRunDir(ctb.dir))
+
+	ctb.passwordFile = filepath.Join(ctb.dir, "password")
+	ctb.expectedTpmKeyFile = filepath.Join(ctb.dir, "expectedtpmkey")
+	ctb.expectedRecoveryKeyFile = filepath.Join(ctb.dir, "expectedrecoverykey")
+
+	sdAskPasswordBottom := `
+head -1 %[1]s
+sed -i -e '1,1d' %[1]s
+`
+	ctb.mockSdAskPassword = testutil.MockCommand(c, "systemd-ask-password", fmt.Sprintf(sdAskPasswordBottom, ctb.passwordFile))
+	bt.AddCleanup(ctb.mockSdAskPassword.Restore)
+
+	sdCryptsetupBottom := `
+if ! cmp -s "$4" "%[1]s"; then
+	if ! cmp -s "$4" "%[2]s"; then
+		exit 1
+	fi
+fi
+`
+	ctb.mockSdCryptsetup = testutil.MockCommand(c, c.MkDir()+"/systemd-cryptsetup", fmt.Sprintf(sdCryptsetupBottom, ctb.expectedTpmKeyFile, ctb.expectedRecoveryKeyFile))
+	bt.AddCleanup(ctb.mockSdCryptsetup.Restore)
+	bt.AddCleanup(MockSystemdCryptsetupPath(ctb.mockSdCryptsetup.Exe()))
+
+	c.Assert(ioutil.WriteFile(ctb.expectedRecoveryKeyFile, ctb.recoveryKey, 0644), IsNil)
+
+	getUserKeyringKeys := func() (out []int) {
+		n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, -4, nil, 0)
+		c.Assert(err, IsNil)
+		buf := make([]byte, n)
+		_, err = unix.KeyctlBuffer(unix.KEYCTL_READ, -4, buf, 0)
+		c.Assert(err, IsNil)
+
+		for len(buf) > 0 {
+			id := int(binary.LittleEndian.Uint32(buf[0:4]))
+			buf = buf[4:]
+			out = append(out, id)
+		}
+		return
+	}
+	startKeys := getUserKeyringKeys()
+
+	bt.AddCleanup(func() {
+		for kid := range getUserKeyringKeys() {
+			found := false
+			for skid := range startKeys {
+				if skid == kid {
+					found = true
+					break
+				}
+			}
+			if found {
+				continue
+			}
+			_, err := unix.KeyctlInt(unix.KEYCTL_UNLINK, kid, -4, 0, 0)
+			c.Check(err, IsNil)
+		}
+	})
+}
+
+type cryptTPMTestBase struct {
+	cryptTestBase
+
+	tpmKey  []byte
+	keyFile string
+}
+
+func (ctb *cryptTPMTestBase) setUpSuiteBase(c *C) {
+	ctb.cryptTestBase.setUpSuiteBase(c)
+	ctb.tpmKey = make([]byte, 32)
+	rand.Read(ctb.tpmKey)
+}
+
+func (ctb *cryptTPMTestBase) setUpTestBase(c *C, ttb *tpmTestBase) {
+	ctb.cryptTestBase.setUpTestBase(c, &ttb.BaseTest)
+
+	c.Assert(ProvisionTPM(ttb.tpm, ProvisionModeFull, nil), IsNil)
+
+	dir := c.MkDir()
+	ctb.keyFile = dir + "/keydata"
+
+	pinHandle := tpm2.Handle(0x0181fff0)
+	c.Assert(SealKeyToTPM(ttb.tpm, ctb.tpmKey, ctb.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: pinHandle}), IsNil)
+	pinIndex, err := ttb.tpm.CreateResourceContextFromTPM(pinHandle)
+	c.Assert(err, IsNil)
+	ttb.addCleanupNVSpace(c, ttb.tpm.OwnerHandleContext(), pinIndex)
+
+	c.Assert(ioutil.WriteFile(ctb.expectedTpmKeyFile, ctb.tpmKey, 0644), IsNil)
+}
+
+type cryptTPMSuite struct {
+	tpmTestBase
+	cryptTPMTestBase
+}
+
+var _ = Suite(&cryptTPMSuite{})
+
+func (s *cryptTPMSuite) SetUpSuite(c *C) {
+	s.cryptTPMTestBase.setUpSuiteBase(c)
+}
+
+func (s *cryptTPMSuite) SetUpTest(c *C) {
+	s.tpmTestBase.SetUpTest(c)
+	s.cryptTPMTestBase.setUpTestBase(c, &s.tpmTestBase)
+}
+
+type testActivateVolumeWithTPMSealedKeyNo2FAData struct {
+	volumeName       string
+	sourceDevicePath string
+	pinTries         int
+	recoveryKeyTries int
+	activateOptions  []string
+}
+
+func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyNo2FA(c *C, data *testActivateVolumeWithTPMSealedKeyNo2FAData) {
+	options := ActivateWithTPMSealedKeyOptions{PINTries: data.pinTries, RecoveryKeyTries: data.recoveryKeyTries, ActivateOptions: data.activateOptions}
+	success, err := ActivateVolumeWithTPMSealedKey(s.tpm, data.volumeName, data.sourceDevicePath, s.keyFile, nil, &options)
+	c.Check(success, Equals, true)
+	c.Check(err, IsNil)
+
+	c.Check(len(s.mockSdAskPassword.Calls()), Equals, 0)
+	c.Assert(len(s.mockSdCryptsetup.Calls()), Equals, 1)
+	c.Assert(len(s.mockSdCryptsetup.Calls()[0]), Equals, 6)
+
+	c.Check(s.mockSdCryptsetup.Calls()[0][0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", data.volumeName, data.sourceDevicePath})
+	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]*")
+	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, strings.Join(append(data.activateOptions, "tries=1"), ","))
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA1(c *C) {
+	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA2(c *C) {
+	// Test with a non-zero PINTries when a PIN isn't set.
+	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		pinTries:         1,
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA3(c *C) {
+	// Test with a non-zero RecoveryKeyTries.
+	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		recoveryKeyTries: 1,
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA4(c *C) {
+	// Test with extra options for systemd-cryptsetup.
+	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		activateOptions:  []string{"foo=bar", "baz"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA5(c *C) {
+	// Test with a different volume name / device path.
+	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
+		volumeName:       "foo",
+		sourceDevicePath: "/dev/vda2",
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA6(c *C) {
+	// Test that ActivateVolumeWithTPMSealedKey creates a SRK when it can, rather than fallback back to the recovery key.
+	srk, err := s.tpm.CreateResourceContextFromTPM(SrkHandle)
+	c.Assert(err, IsNil)
+	_, err = s.tpm.EvictControl(s.tpm.OwnerHandleContext(), srk, srk.Handle(), nil)
+	c.Assert(err, IsNil)
+
+	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+	})
+}
+
+type testActivateVolumeWithTPMSealedKeyErrorHandlingData struct {
+	pinTries           int
+	recoveryKeyTries   int
+	activateOptions    []string
+	passphraseAttempts []string
+	success            bool
+	recoveryReason     RecoveryReason
+	errChecker         Checker
+	errCheckerArgs     []interface{}
+}
+
+func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, data *testActivateVolumeWithTPMSealedKeyErrorHandlingData) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.passphraseAttempts, "\n")+"\n"), 0644), IsNil)
+
+	options := ActivateWithTPMSealedKeyOptions{PINTries: data.pinTries, RecoveryKeyTries: data.recoveryKeyTries, ActivateOptions: data.activateOptions}
+	success, err := ActivateVolumeWithTPMSealedKey(s.tpm, "data", "/dev/sda1", s.keyFile, nil, &options)
+	c.Check(err, data.errChecker, data.errCheckerArgs...)
+	c.Check(success, Equals, data.success)
+
+	if !data.success {
+		return
+	}
+
+	id, err := unix.KeyctlSearch(-4, "user", fmt.Sprintf("%s:data:reason=%d", filepath.Base(os.Args[0]), data.recoveryReason), 0)
+	c.Check(err, IsNil)
+	buf := make([]byte, 16)
+	n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, id, buf, 0)
+	c.Check(err, IsNil)
+	c.Check(n, Equals, 16)
+	c.Check(buf, DeepEquals, s.recoveryKey)
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
+	// Test with an invalid value for PINTries.
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		pinTries:       -1,
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"invalid PINTries"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling2(c *C) {
+	// Test with an invalid value for RecoveryKeyTries.
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		recoveryKeyTries: -1,
+		errChecker:       ErrorMatches,
+		errCheckerArgs:   []interface{}{"invalid RecoveryKeyTries"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling3(c *C) {
+	// Test that adding "tries=" to ActivateOptions fails.
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		activateOptions: []string{"tries=2"},
+		errChecker:      ErrorMatches,
+		errCheckerArgs:  []interface{}{"cannot specify the \"tries=\" option for systemd-cryptsetup"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
+	// Test that recovery fallback works with the TPM in DA lockout mode.
+	c.Assert(s.tpm.DictionaryAttackParameters(s.tpm.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
+	defer func() {
+		c.Check(ProvisionTPM(s.tpm, ProvisionModeFull, nil), IsNil)
+	}()
+
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		recoveryKeyTries:   1,
+		passphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		success:            true,
+		recoveryReason:     RecoveryReasonTPMLockout,
+		errChecker:         ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is in DA lockout mode\\) but " +
+			"activation with recovery key was successful"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
+	// Test that recovery fallback works when there is no SRK and a new one can't be created.
+	srk, err := s.tpm.CreateResourceContextFromTPM(SrkHandle)
+	c.Assert(err, IsNil)
+	_, err = s.tpm.EvictControl(s.tpm.OwnerHandleContext(), srk, srk.Handle(), nil)
+	c.Assert(err, IsNil)
+	s.setHierarchyAuth(c, tpm2.HandleOwner)
+	s.tpm.OwnerHandleContext().SetAuthValue(nil)
+	defer s.tpm.OwnerHandleContext().SetAuthValue(testAuth)
+
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		recoveryKeyTries: 2,
+		passphraseAttempts: []string{
+			"00000-00000-00000-00000-00000-00000-00000-00000",
+			strings.Join(s.recoveryKeyAscii, "-"),
+		},
+		success:        true,
+		recoveryReason: RecoveryReasonTPMProvisioningError,
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is not correctly " +
+			"provisioned\\) but activation with recovery key was successful"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
+	// Test that recovery fallback works when the unsealed key is incorrect.
+	incorrectKey := make([]byte, 32)
+	rand.Read(incorrectKey)
+	c.Assert(ioutil.WriteFile(s.expectedTpmKeyFile, incorrectKey, 0644), IsNil)
+
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		recoveryKeyTries:   1,
+		passphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		success:            true,
+		recoveryReason:     RecoveryReasonInvalidKeyFile,
+		errChecker:         ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() +
+			" failed: exit status 1\\) but activation with recovery key was successful"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling7(c *C) {
+	// Test that activation fails if RecoveryKeyTries is zero.
+	c.Assert(s.tpm.DictionaryAttackParameters(s.tpm.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
+	defer func() {
+		c.Check(ProvisionTPM(s.tpm, ProvisionModeFull, nil), IsNil)
+	}()
+
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		success:    false,
+		errChecker: ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is in DA lockout mode\\) " +
+			"and activation with recovery key failed \\(no recovery key tries permitted\\)"},
+	})
+}
+
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
+	// Test that activation fails if the wrong recovery key is provided.
+	c.Assert(s.tpm.DictionaryAttackParameters(s.tpm.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
+	defer func() {
+		c.Check(ProvisionTPM(s.tpm, ProvisionModeFull, nil), IsNil)
+	}()
+
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		recoveryKeyTries:   1,
+		passphraseAttempts: []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
+		success:            false,
+		errChecker:         ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is in DA lockout mode\\) " +
+			"and activation with recovery key failed \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 1\\)"},
+	})
+}
+
+type cryptTPMSimulatorSuite struct {
+	tpmSimulatorTestBase
+	cryptTPMTestBase
+}
+
+var _ = Suite(&cryptTPMSimulatorSuite{})
+
+func (s *cryptTPMSimulatorSuite) SetUpSuite(c *C) {
+	s.cryptTPMTestBase.setUpSuiteBase(c)
+}
+
+func (s *cryptTPMSimulatorSuite) SetUpTest(c *C) {
+	s.tpmSimulatorTestBase.SetUpTest(c)
+	s.resetTPMSimulator(c)
+	s.cryptTPMTestBase.setUpTestBase(c, &s.tpmTestBase)
+}
+
+func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, data *testActivateVolumeWithTPMSealedKeyErrorHandlingData) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.passphraseAttempts, "\n")+"\n"), 0644), IsNil)
+
+	options := ActivateWithTPMSealedKeyOptions{PINTries: data.pinTries, RecoveryKeyTries: data.recoveryKeyTries, ActivateOptions: data.activateOptions}
+	success, err := ActivateVolumeWithTPMSealedKey(s.tpm, "data", "/dev/sda1", s.keyFile, nil, &options)
+	c.Check(err, data.errChecker, data.errCheckerArgs...)
+	c.Check(success, Equals, data.success)
+
+	if !data.success {
+		return
+	}
+
+	id, err := unix.KeyctlSearch(-4, "user", fmt.Sprintf("%s:data:reason=%d", filepath.Base(os.Args[0]), data.recoveryReason), 0)
+	c.Check(err, IsNil)
+	buf := make([]byte, 16)
+	n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, id, buf, 0)
+	c.Check(err, IsNil)
+	c.Check(n, Equals, 16)
+	c.Check(buf, DeepEquals, s.recoveryKey)
+}
+
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
+	// Test that recovery fallback works when the sealed key authorization policy is wrong.
+	_, err := s.tpm.PCREvent(s.tpm.PCRHandleContext(7), []byte("foo"), nil)
+	c.Assert(err, IsNil)
+
+	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
+		recoveryKeyTries:   1,
+		passphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		success:            true,
+		recoveryReason:     RecoveryReasonInvalidKeyFile,
+		errChecker:         ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data file: cannot complete " +
+			"authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data\\) but " +
+			"activation with recovery key was successful"},
+	})
+}
+
+type cryptSuite struct {
+	testutil.BaseTest
+	cryptTestBase
+}
+
+var _ = Suite(&cryptSuite{})
+
+func (s *cryptSuite) SetUpSuite(c *C) {
+	s.cryptTestBase.setUpSuiteBase(c)
+}
+
+func (s *cryptSuite) SetUpTest(c *C) {
+	s.cryptTestBase.setUpTestBase(c, &s.BaseTest)
+}
+
+type testActivateVolumeWithRecoveryKeyData struct {
+	volumeName                 string
+	sourceDevicePath           string
+	tries                      int
+	activateOptions            []string
+	recoveryPassphraseAttempts []string
+	sdCryptsetupCalls          int
+}
+
+func (s *cryptSuite) testActivateVolumeWithRecoveryKey(c *C, data *testActivateVolumeWithRecoveryKeyData) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.recoveryPassphraseAttempts, "\n")+"\n"), 0644), IsNil)
+
+	options := ActivateWithRecoveryKeyOptions{Tries: data.tries, ActivateOptions: data.activateOptions}
+	c.Assert(ActivateVolumeWithRecoveryKey(data.volumeName, data.sourceDevicePath, nil, &options), IsNil)
+
+	c.Check(len(s.mockSdAskPassword.Calls()), Equals, len(data.recoveryPassphraseAttempts))
+
+	c.Check(len(s.mockSdCryptsetup.Calls()), Equals, data.sdCryptsetupCalls)
+	for _, call := range s.mockSdCryptsetup.Calls() {
+		c.Assert(len(call), Equals, 6)
+		c.Check(call[0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", data.volumeName, data.sourceDevicePath})
+		c.Check(call[4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]*")
+		c.Check(call[5], Equals, strings.Join(append(data.activateOptions, "tries=1"), ","))
+	}
+
+	kid, err := unix.KeyctlSearch(-4, "user", filepath.Base(os.Args[0])+":data:reason=2", 0)
+	c.Assert(err, IsNil)
+
+	buf := make([]byte, 16)
+	n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, kid, buf, 0)
+	c.Assert(err, IsNil)
+	c.Check(buf, DeepEquals, s.recoveryKey)
+	c.Check(n, Equals, 16)
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey1(c *C) {
+	// Test with a recovery key which is entered with a hyphen between each group of 5 digits.
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		tries:            1,
+		recoveryPassphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		sdCryptsetupCalls:          1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey2(c *C) {
+	// Test with a recovery key which is entered without a hyphen between each group of 5 digits.
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		tries:            1,
+		recoveryPassphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "")},
+		sdCryptsetupCalls:          1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey3(c *C) {
+	// Test that activation succeeds when the correct recovery key is provided on the second attempt.
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		tries:            2,
+		recoveryPassphraseAttempts: []string{
+			"00000-00000-00000-00000-00000-00000-00000-00000",
+			strings.Join(s.recoveryKeyAscii, "-"),
+		},
+		sdCryptsetupCalls: 2,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey4(c *C) {
+	// Test that activation succeeds when the correct recovery key is provided on the second attempt, and the first
+	// attempt is badly formatted.
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		tries:            2,
+		recoveryPassphraseAttempts: []string{
+			"1234",
+			strings.Join(s.recoveryKeyAscii, "-"),
+		},
+		sdCryptsetupCalls: 1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey5(c *C) {
+	// Test with additional options passed to systemd-cryptsetup.
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		volumeName:                 "data",
+		sourceDevicePath:           "/dev/sda1",
+		tries:                      1,
+		activateOptions:            []string{"foo", "bar"},
+		recoveryPassphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		sdCryptsetupCalls:          1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey6(c *C) {
+	// Test with a different volume name / device path.
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		volumeName:       "foo",
+		sourceDevicePath: "/dev/vdb2",
+		tries:            1,
+		recoveryPassphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		sdCryptsetupCalls:          1,
+	})
+}
+
+type testActivateVolumeWithRecoveryKeyUsingKeyReaderData struct {
+	tries                      int
+	recoveryKeyFileContents    string
+	recoveryPassphraseAttempts []string
+	sdCryptsetupCalls          int
+}
+
+func (s *cryptSuite) testActivateVolumeWithRecoveryKeyUsingKeyReader(c *C, data *testActivateVolumeWithRecoveryKeyUsingKeyReaderData) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.recoveryPassphraseAttempts, "\n")+"\n"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(s.dir, "keyfile"), []byte(data.recoveryKeyFileContents), 0644), IsNil)
+
+	r, err := os.Open(filepath.Join(s.dir, "keyfile"))
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	options := ActivateWithRecoveryKeyOptions{Tries: data.tries}
+	c.Assert(ActivateVolumeWithRecoveryKey("data", "/dev/sda1", r, &options), IsNil)
+
+	c.Check(len(s.mockSdAskPassword.Calls()), Equals, len(data.recoveryPassphraseAttempts))
+
+	c.Check(len(s.mockSdCryptsetup.Calls()), Equals, data.sdCryptsetupCalls)
+	for _, call := range s.mockSdCryptsetup.Calls() {
+		c.Assert(len(call), Equals, 6)
+		c.Check(call[0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", "data", "/dev/sda1"})
+		c.Check(call[4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]*")
+		c.Check(call[5], Equals, "tries=1")
+	}
+
+	kid, err := unix.KeyctlSearch(-4, "user", fmt.Sprintf("%s:data:reason=%d", filepath.Base(os.Args[0]), RecoveryReasonRequested), 0)
+	c.Assert(err, IsNil)
+
+	buf := make([]byte, 16)
+	n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, kid, buf, 0)
+	c.Assert(err, IsNil)
+	c.Check(buf, DeepEquals, s.recoveryKey)
+	c.Check(n, Equals, 16)
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader1(c *C) {
+	// Test with the correct recovery key supplied via a io.Reader, with a hyphen separating each group of 5 digits.
+	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
+		tries: 1,
+		recoveryKeyFileContents: strings.Join(s.recoveryKeyAscii, "-") + "\n",
+		sdCryptsetupCalls:       1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader2(c *C) {
+	// Test with the correct recovery key supplied via a io.Reader, without a hyphen separating each group of 5 digits.
+	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
+		tries: 1,
+		recoveryKeyFileContents: strings.Join(s.recoveryKeyAscii, "") + "\n",
+		sdCryptsetupCalls:       1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader3(c *C) {
+	// Test with the correct recovery key supplied via a io.Reader when the key doesn't end in a newline.
+	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
+		tries: 1,
+		recoveryKeyFileContents: strings.Join(s.recoveryKeyAscii, "-"),
+		sdCryptsetupCalls:       1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader4(c *C) {
+	// Test that falling back to requesting a recovery key works if the one provided by the io.Reader is incorrect.
+	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
+		tries: 2,
+		recoveryKeyFileContents:    "00000-00000-00000-00000-00000-00000-00000-00000\n",
+		recoveryPassphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		sdCryptsetupCalls:          2,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader5(c *C) {
+	// Test that falling back to requesting a recovery key works if the one provided by the io.Reader is badly formatted.
+	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
+		tries: 2,
+		recoveryKeyFileContents:    "5678\n",
+		recoveryPassphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		sdCryptsetupCalls:          1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader6(c *C) {
+	// Test that falling back to requesting a recovery key works if the provided io.Reader is backed by an empty buffer.
+	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
+		tries: 1,
+		recoveryPassphraseAttempts: []string{strings.Join(s.recoveryKeyAscii, "-")},
+		sdCryptsetupCalls:          1,
+	})
+}
+
+type testActivateVolumeWithRecoveryKeyErrorHandlingData struct {
+	tries                      int
+	activateOptions            []string
+	recoveryPassphraseAttempts []string
+	errChecker                 Checker
+	errCheckerArgs             []interface{}
+}
+
+func (s *cryptSuite) testActivateVolumeWithRecoveryKeyErrorHandling(c *C, data *testActivateVolumeWithRecoveryKeyErrorHandlingData) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.recoveryPassphraseAttempts, "\n")+"\n"), 0644), IsNil)
+
+	options := ActivateWithRecoveryKeyOptions{Tries: data.tries, ActivateOptions: data.activateOptions}
+	c.Check(ActivateVolumeWithRecoveryKey("data", "/dev/sda1", nil, &options), data.errChecker, data.errCheckerArgs...)
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling1(c *C) {
+	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
+		tries:          -1,
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"invalid Tries"},
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling2(c *C) {
+	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
+		tries:          0,
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"no recovery key tries permitted"},
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling3(c *C) {
+	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
+		tries:           1,
+		activateOptions: []string{"tries=2"},
+		errChecker:      ErrorMatches,
+		errCheckerArgs:  []interface{}{"cannot specify the \"tries=\" option for systemd-cryptsetup"},
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling4(c *C) {
+	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
+		tries: 1,
+		recoveryPassphraseAttempts: []string{"00000-1234"},
+		errChecker:                 ErrorMatches,
+		errCheckerArgs:             []interface{}{"cannot decode recovery key: incorrectly formatted \\(insufficient characters\\)"},
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling5(c *C) {
+	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
+		tries: 1,
+		recoveryPassphraseAttempts: []string{"00000-123bc"},
+		errChecker:                 ErrorMatches,
+		errCheckerArgs:             []interface{}{"cannot decode recovery key: incorrectly formatted \\(invalid base-10 number\\)"},
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling6(c *C) {
+	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
+		tries: 1,
+		recoveryPassphraseAttempts: []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
+		errChecker:                 ErrorMatches,
+		errCheckerArgs:             []interface{}{"cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 1"},
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -122,14 +122,21 @@ func isInvalidKeyFileError(err error) bool {
 	return xerrors.As(err, &e)
 }
 
+// LockAccessToSealedKeysError is returned from ActivateVolumeWithTPMSealedKey if an error occurred whilst trying to lock access
+// to sealed keys created by this package.
 type LockAccessToSealedKeysError string
 
 func (e LockAccessToSealedKeysError) Error() string {
 	return "cannot lock access to sealed keys: " + string(e)
 }
 
+// ActivateWithTPMSealedKeyError is returned from ActivateVolumeWithTPMSealedKey if activation with the TPM protected key failed.
 type ActivateWithTPMSealedKeyError struct {
-	TPMErr      error
+	// TPMErr details the error that occurred during activation with the TPM sealed key.
+	TPMErr error
+
+	// RecoveryErr details the error that occurred during activation with the fallback recovery key, if activation with the recovery key
+	// was also unsuccessful.
 	RecoveryErr error
 }
 

--- a/errors.go
+++ b/errors.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 
 	"github.com/chrisccoulson/go-tpm2"
+
+	"golang.org/x/xerrors"
 )
 
 var (
@@ -84,6 +86,11 @@ func (e EKCertVerificationError) Error() string {
 	return fmt.Sprintf("cannot verify the endorsement key certificate: %s", e.msg)
 }
 
+func isEKCertVerificationError(err error) bool {
+	var e EKCertVerificationError
+	return xerrors.As(err, &e)
+}
+
 // TPMVerificationError is returned from SecureConnectToDefaultTPM if the TPM cannot prove it is the device for which the verified
 // EK certificate was issued.
 type TPMVerificationError struct {
@@ -92,6 +99,11 @@ type TPMVerificationError struct {
 
 func (e TPMVerificationError) Error() string {
 	return fmt.Sprintf("cannot verify that the TPM is the device for which the supplied EK certificate was issued: %s", e.msg)
+}
+
+func isTPMVerificationError(err error) bool {
+	var e TPMVerificationError
+	return xerrors.As(err, &e)
 }
 
 // InvalidKeyFileError indicates that the provided key data file is invalid. This error may also be returned in some
@@ -103,4 +115,27 @@ type InvalidKeyFileError struct {
 
 func (e InvalidKeyFileError) Error() string {
 	return fmt.Sprintf("invalid key data file: %s", e.msg)
+}
+
+func isInvalidKeyFileError(err error) bool {
+	var e InvalidKeyFileError
+	return xerrors.As(err, &e)
+}
+
+type LockAccessToSealedKeysError string
+
+func (e LockAccessToSealedKeysError) Error() string {
+	return "cannot lock access to sealed keys: " + string(e)
+}
+
+type ActivateWithTPMSealedKeyError struct {
+	TPMErr      error
+	RecoveryErr error
+}
+
+func (e *ActivateWithTPMSealedKeyError) Error() string {
+	if e.RecoveryErr != nil {
+		return fmt.Sprintf("cannot activate with TPM sealed key (%v) and activation with recovery key failed (%v)", e.TPMErr, e.RecoveryErr)
+	}
+	return fmt.Sprintf("cannot activate with TPM sealed key (%v) but activation with recovery key was successful", e.TPMErr)
 }

--- a/errors.go
+++ b/errors.go
@@ -135,14 +135,14 @@ type ActivateWithTPMSealedKeyError struct {
 	// TPMErr details the error that occurred during activation with the TPM sealed key.
 	TPMErr error
 
-	// RecoveryErr details the error that occurred during activation with the fallback recovery key, if activation with the recovery key
+	// RecoveryKeyUsageErr details the error that occurred during activation with the fallback recovery key, if activation with the recovery key
 	// was also unsuccessful.
-	RecoveryErr error
+	RecoveryKeyUsageErr error
 }
 
 func (e *ActivateWithTPMSealedKeyError) Error() string {
-	if e.RecoveryErr != nil {
-		return fmt.Sprintf("cannot activate with TPM sealed key (%v) and activation with recovery key failed (%v)", e.TPMErr, e.RecoveryErr)
+	if e.RecoveryKeyUsageErr != nil {
+		return fmt.Sprintf("cannot activate with TPM sealed key (%v) and activation with recovery key failed (%v)", e.TPMErr, e.RecoveryKeyUsageErr)
 	}
 	return fmt.Sprintf("cannot activate with TPM sealed key (%v) but activation with recovery key was successful", e.TPMErr)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -207,6 +207,22 @@ func MockEventLogPath(path string) (restore func()) {
 	}
 }
 
+func MockRunDir(path string) (restore func()) {
+	origRunDir := runDir
+	runDir = path
+	return func() {
+		runDir = origRunDir
+	}
+}
+
+func MockSystemdCryptsetupPath(path string) (restore func()) {
+	origSystemdCryptsetupPath := systemdCryptsetupPath
+	systemdCryptsetupPath = path
+	return func() {
+		systemdCryptsetupPath = origSystemdCryptsetupPath
+	}
+}
+
 func NewDynamicPolicyComputeParams(key *rsa.PrivateKey, signAlg tpm2.HashAlgorithmId, pcrValues []tpm2.PCRValues, policyCountIndexName tpm2.Name, policyCount uint64) *dynamicPolicyComputeParams {
 	return &dynamicPolicyComputeParams{
 		key:                  key,

--- a/run-tests
+++ b/run-tests
@@ -37,4 +37,4 @@ if [ $WITH_MSSIM -eq 1 ]; then
 fi
 
 
-go test -v -race ./... -args $MSSIM_ARGS $@
+go test -v -race ./... -args -check.v $MSSIM_ARGS $@

--- a/secboot_test.go
+++ b/secboot_test.go
@@ -1,0 +1,136 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"testing"
+
+	"github.com/chrisccoulson/go-tpm2"
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+var (
+	testAuth = []byte("1234")
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type tpmTestBase struct {
+	testutil.BaseTest
+	tpm *TPMConnection // Not anonymous because of tpm2.TPMContext.TestParms
+}
+
+func (b *tpmTestBase) setUpTestBase(c *C, tpm *TPMConnection) {
+	b.BaseTest.SetUpTest(c)
+	b.tpm = tpm
+
+	getFlushableHandles := func() (out []tpm2.Handle) {
+		for _, t := range []tpm2.HandleType{tpm2.HandleTypeTransient, tpm2.HandleTypeLoadedSession, tpm2.HandleTypeSavedSession} {
+			h, err := b.tpm.GetCapabilityHandles(t.BaseHandle(), tpm2.CapabilityMaxProperties, nil)
+			c.Assert(err, IsNil)
+			out = append(out, h...)
+		}
+		for i, h := range out {
+			if h.Type() == tpm2.HandleTypePolicySession {
+				out[i] = (h & 0xffffff) | (tpm2.Handle(tpm2.HandleTypeHMACSession) << 24)
+			}
+		}
+		return
+	}
+	startFlushableHandles := getFlushableHandles()
+
+	b.AddCleanup(func() {
+		for _, h := range getFlushableHandles() {
+			found := false
+			for _, sh := range startFlushableHandles {
+				if sh == h {
+					found = true
+					break
+				}
+			}
+			if found {
+				continue
+			}
+			var hc tpm2.HandleContext
+			switch h.Type() {
+			case tpm2.HandleTypeTransient:
+				var err error
+				hc, err = b.tpm.CreateResourceContextFromTPM(h)
+				c.Check(err, IsNil)
+			case tpm2.HandleTypeHMACSession:
+				hc = tpm2.CreateIncompleteSessionContext(h)
+			default:
+				c.Fatalf("Unexpected handle type")
+			}
+			c.Check(b.tpm.FlushContext(hc), IsNil)
+		}
+	})
+}
+
+func (b *tpmTestBase) SetUpTest(c *C) {
+	tpm, err := openTPMForTestingCommon()
+	c.Assert(err, IsNil)
+	if tpm == nil {
+		c.Skip("-use-mssim and -use-tpm not supplied")
+	}
+	b.setUpTestBase(c, tpm)
+}
+
+func (b *tpmTestBase) TearDownTest(c *C) {
+	// testutil.BaseTest doesn't execute cleanup handlers in reverse order, so we don't use AddCleanup for closing the TPM
+	// connection, as this is opened first and should be cleanup up last.
+	b.BaseTest.TearDownTest(c)
+	c.Assert(b.tpm.Close(), IsNil)
+}
+
+func (b *tpmTestBase) addCleanupNVSpace(c *C, authHandle, index tpm2.ResourceContext) {
+	b.AddCleanup(func() {
+		c.Check(b.tpm.NVUndefineSpace(authHandle, index, nil), IsNil)
+	})
+}
+
+func (b *tpmTestBase) setHierarchyAuth(c *C, hierarchy tpm2.Handle) {
+	c.Assert(b.tpm.HierarchyChangeAuth(b.tpm.GetPermanentContext(hierarchy), tpm2.Auth(testAuth), nil), IsNil)
+	b.AddCleanup(func() {
+		c.Check(b.tpm.HierarchyChangeAuth(b.tpm.GetPermanentContext(hierarchy), nil, nil), IsNil)
+	})
+}
+
+type tpmSimulatorTestBase struct {
+	tpmTestBase
+	tcti *tpm2.TctiMssim
+}
+
+func (b *tpmSimulatorTestBase) SetUpTest(c *C) {
+	tpm, tcti, err := openTPMSimulatorForTestingCommon()
+	c.Assert(err, IsNil)
+	if tpm == nil {
+		c.Skip("-use-mssim not supplied")
+	}
+	b.setUpTestBase(c, tpm)
+	b.tcti = tcti
+}
+
+func (b *tpmSimulatorTestBase) resetTPMSimulator(c *C) {
+	c.Assert(resetTPMSimulatorCommon(b.tpm, b.tcti), IsNil)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -22,6 +22,24 @@
 			"revisionTime": "2019-09-06T18:49:57Z"
 		},
 		{
+			"checksumSHA1": "kmcZh6191ZYy/+G/tIWFZoVEkGs=",
+			"path": "github.com/godbus/dbus",
+			"revision": "06fc4b473149e499166adbb9e31c7365a8ea146f",
+			"revisionTime": "2020-01-14T05:13:59Z"
+		},
+		{
+			"checksumSHA1": "SbguDK5lY8uhaHNrmJmNbiWIGM0=",
+			"path": "github.com/kr/text",
+			"revision": "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f",
+			"revisionTime": "2018-05-06T08:24:08Z"
+		},
+		{
+			"checksumSHA1": "YtvGaQLW242TVjn91Awqlth4B1M=",
+			"path": "github.com/niemeyer/pretty",
+			"revision": "a10e7caefd8e0d600cea437f5c3613aeb1553d56",
+			"revisionTime": "2020-02-27T12:48:42Z"
+		},
+		{
 			"checksumSHA1": "adHhPc08cw8siTSUYwpmg4bmN7c=",
 			"path": "github.com/snapcore/go-gettext",
 			"revision": "82bbea49e7854ab527f73d3ce03c57c4fd852aab",
@@ -80,6 +98,12 @@
 			"path": "github.com/snapcore/snapd/osutil",
 			"revision": "da480b74dc895a6cbc02d7f00f3a38529fd5fd29",
 			"revisionTime": "2020-02-12T13:56:49Z"
+		},
+		{
+			"checksumSHA1": "uviyHf48hcnZN/cGKNUxmvqLISQ=",
+			"path": "github.com/snapcore/snapd/osutil/mount",
+			"revision": "255cfaa1f5991a2d20232d57be6c4349338bbffa",
+			"revisionTime": "2020-03-30T18:40:30Z"
 		},
 		{
 			"checksumSHA1": "EYRtD9fNCHSSnWkkZSNTAB63IhQ=",
@@ -148,6 +172,12 @@
 			"revisionTime": "2020-02-12T13:56:49Z"
 		},
 		{
+			"checksumSHA1": "gwLER4MDLp8vaTXkUFarvfl5DXM=",
+			"path": "github.com/snapcore/snapd/testutil",
+			"revision": "255cfaa1f5991a2d20232d57be6c4349338bbffa",
+			"revisionTime": "2020-03-30T18:40:30Z"
+		},
+		{
 			"checksumSHA1": "leL+WTjj2xj4V+wbm76CXw2Eo/c=",
 			"path": "github.com/snapcore/snapd/timeout",
 			"revision": "3cf189a768580bcf3ea3397361566be1a6e04bc5",
@@ -182,6 +212,12 @@
 			"path": "golang.org/x/xerrors/internal",
 			"revision": "9bdfabe68543c54f90421aeb9a60ef8061b5b544",
 			"revisionTime": "2019-07-19T19:12:34Z"
+		},
+		{
+			"checksumSHA1": "QxGa2uH6p8ccOl8nFQPZyUoU4tA=",
+			"path": "gopkg.in/check.v1",
+			"revision": "8fa46927fb4f5b54d48bde78c6c08db205b2298c",
+			"revisionTime": "2020-02-27T12:52:54Z"
 		},
 		{
 			"checksumSHA1": "e5X6+yC/8PS/M2j+Y9Z0cSdDEYI=",


### PR DESCRIPTION
This adds 2 functions for activating LUKS volumes.

ActivateVolumeWithTPMSealedKey attempts to activate a volume using the TPM
protected secret. If a PIN is required to unseal the secret, it will be
requested using systemd-ask-password. Once unsealed, the secret will be
used to activate the LUKS volume using systemd-cryptsetup.

ActivateVolumeWithTPMSealedKey can fall back to activating with the
fallback recovery key if activating with the TPM protected secret fails.

ActivateVolumeWithRecoveryKey can be used to activate a volume with the
fallback recovery key directly without attempting first with the TPM
protected secret.

In both functions, the fallback recovery key is requested using
systemd-ask-password. When activation with the recovery key is successful,
the key is added to the user keyring in the kernel. The description of
the keyring entry will contain an indicator of the reason that the
fallback recovery key was used.