### PR TITLE
Don't use crypto/rand in tests

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -20,10 +20,10 @@
 package secboot_test
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"

--- a/pin_test.go
+++ b/pin_test.go
@@ -21,7 +21,6 @@ package secboot_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"crypto/rsa"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestCreatePinNVIndex(t *testing.T) {
 	tpm := openTPMForTesting(t)
 	defer closeTPM(t, tpm)
 
-	key, err := rsa.GenerateKey(rand.Reader, 768)
+	key, err := rsa.GenerateKey(testRandReader, 768)
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
@@ -105,7 +104,7 @@ func TestPerformPinChange(t *testing.T) {
 	tpm := openTPMForTesting(t)
 	defer closeTPM(t, tpm)
 
-	key, err := rsa.GenerateKey(rand.Reader, 768)
+	key, err := rsa.GenerateKey(testRandReader, 768)
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -21,7 +21,6 @@ package secboot_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/binary"
@@ -101,7 +100,7 @@ func TestIncrementDynamicPolicyCounter(t *testing.T) {
 	tpm := openTPMForTesting(t)
 	defer closeTPM(t, tpm)
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := rsa.GenerateKey(testRandReader, 2048)
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
@@ -163,7 +162,7 @@ func TestReadDynamicPolicyCounter(t *testing.T) {
 		t.Fatalf("NVReadCounter failed: %v", err)
 	}
 
-	key, err := rsa.GenerateKey(rand.Reader, 768)
+	key, err := rsa.GenerateKey(testRandReader, 768)
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
@@ -394,7 +393,7 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 		// Test with a bogus lock NV index that allows writes far in to the future, making it possible
 		// to recreate it to remove the read lock bit.
 
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		key, err := rsa.GenerateKey(testRandReader, 2048)
 		if err != nil {
 			t.Fatalf("GenerateKey failed: %v", err)
 		}
@@ -440,7 +439,7 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 		h.Write(policySession.NonceTPM())
 		binary.Write(h, binary.BigEndian, int32(0))
 
-		sig, err := rsa.SignPSS(rand.Reader, key, tpm2.HashAlgorithmSHA256.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+		sig, err := rsa.SignPSS(testRandReader, key, tpm2.HashAlgorithmSHA256.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
 		if err != nil {
 			t.Errorf("SignPSS failed: %v", err)
 		}
@@ -916,7 +915,7 @@ func TestComputePolicyORData(t *testing.T) {
 }
 
 func TestComputeDynamicPolicy(t *testing.T) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := rsa.GenerateKey(testRandReader, 2048)
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
@@ -1184,7 +1183,7 @@ func TestExecutePolicy(t *testing.T) {
 		t.Errorf("ensureLockNVIndex failed: %v", err)
 	}
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := rsa.GenerateKey(testRandReader, 2048)
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
@@ -2143,7 +2142,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
-			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			key, err := rsa.GenerateKey(testRandReader, 2048)
 			if err != nil {
 				t.Fatalf("GenerateKey failed: %v", err)
 			}
@@ -2192,7 +2191,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
-			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			key, err := rsa.GenerateKey(testRandReader, 2048)
 			if err != nil {
 				t.Fatalf("GenerateKey failed: %v", err)
 			}
@@ -2200,7 +2199,7 @@ func TestExecutePolicy(t *testing.T) {
 			h := alg.NewHash()
 			h.Write(d.AuthorizedPolicy)
 
-			sig, err := rsa.SignPSS(rand.Reader, key, alg.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+			sig, err := rsa.SignPSS(testRandReader, key, alg.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
 			if err != nil {
 				t.Fatalf("SignPSS failed: %v", err)
 			}
@@ -2247,7 +2246,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
-			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			key, err := rsa.GenerateKey(testRandReader, 2048)
 			if err != nil {
 				t.Fatalf("GenerateKey failed: %v", err)
 			}
@@ -2259,7 +2258,7 @@ func TestExecutePolicy(t *testing.T) {
 			h := signAlg.NewHash()
 			h.Write(d.AuthorizedPolicy)
 
-			sig, err := rsa.SignPSS(rand.Reader, key, signAlg.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+			sig, err := rsa.SignPSS(testRandReader, key, signAlg.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
 			if err != nil {
 				t.Fatalf("SignPSS failed: %v", err)
 			}
@@ -2472,7 +2471,7 @@ func TestLockAccessToSealedKeys(t *testing.T) {
 		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 	}
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := rsa.GenerateKey(testRandReader, 2048)
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}

--- a/seal_test.go
+++ b/seal_test.go
@@ -21,8 +21,8 @@ package secboot_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"syscall"
 	"testing"

--- a/secboot_test.go
+++ b/secboot_test.go
@@ -20,6 +20,7 @@
 package secboot_test
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/chrisccoulson/go-tpm2"
@@ -134,3 +135,11 @@ func (b *tpmSimulatorTestBase) SetUpTest(c *C) {
 func (b *tpmSimulatorTestBase) resetTPMSimulator(c *C) {
 	c.Assert(resetTPMSimulatorCommon(b.tpm, b.tcti), IsNil)
 }
+
+type testRng struct{}
+
+func (r *testRng) Read(p []byte) (int, error) {
+	return rand.Read(p)
+}
+
+var testRandReader = &testRng{}

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -21,8 +21,8 @@ package secboot_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"testing"
 


### PR DESCRIPTION
Tests don't need cryptographically secure random numbers, so switch to
using math/rand in tests instead.

Fixes https://github.com/snapcore/secboot/issues/42