### PR TITLE
Make SealKeyToTPM enforce a key size of 64-bytes

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -174,7 +174,7 @@ type cryptTPMTestBase struct {
 
 func (ctb *cryptTPMTestBase) setUpSuiteBase(c *C) {
 	ctb.cryptTestBase.setUpSuiteBase(c)
-	ctb.tpmKey = make([]byte, 32)
+	ctb.tpmKey = make([]byte, 64)
 	rand.Read(ctb.tpmKey)
 }
 

--- a/seal.go
+++ b/seal.go
@@ -95,7 +95,7 @@ type KeyCreationParams struct {
 // sealed key is written to a file at the path specified by policyUpdatePath. This file must live inside the encrypted volume
 // protected by the sealed key.
 //
-// The supplied key must be 32 bytes long. An error will be returned if it isn't.
+// The supplied key must be 64-bytes long. An error will be returned if it isn't.
 //
 // This function requires knowledge of the authorization value for the storage hierarchy, which must be provided by calling
 // TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the provided authorization value is incorrect,
@@ -118,8 +118,8 @@ type KeyCreationParams struct {
 // argument.
 func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath string, params *KeyCreationParams) error {
 	// Check that the key is the correct length.
-	if len(key) != 32 {
-		return fmt.Errorf("expected a key length of 256 bits (got %d)", len(key)*8)
+	if len(key) != 64 {
+		return fmt.Errorf("expected a key length of 512 bits (got %d)", len(key)*8)
 	}
 	// params is mandatory.
 	if params == nil {

--- a/seal_test.go
+++ b/seal_test.go
@@ -47,7 +47,7 @@ func TestSealKeyToTPM(t *testing.T) {
 		}
 	}()
 
-	key := make([]byte, 32)
+	key := make([]byte, 64)
 	rand.Read(key)
 
 	run := func(t *testing.T, tpm *TPMConnection, withPolicyUpdateFile bool, params *KeyCreationParams) {
@@ -131,7 +131,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		t.Errorf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 32)
+	key := make([]byte, 64)
 	rand.Read(key)
 
 	run := func(t *testing.T, tmpDir string, params *KeyCreationParams, key []byte) error {
@@ -178,15 +178,12 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}
-		if err.Error() != "expected a key length of 256 bits (got 128)" {
+		if err.Error() != "expected a key length of 512 bits (got 128)" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
 
 	t.Run("NilParams", func(t *testing.T) {
-		key := make([]byte, 32)
-		rand.Read(key)
-
 		err := run(t, "", nil, key)
 		if err == nil {
 			t.Fatalf("Expected an error")
@@ -313,9 +310,6 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 	})
 
 	t.Run("InvalidPCRProfile", func(t *testing.T) {
-		key := make([]byte, 32)
-		rand.Read(key)
-
 		pcrProfile := NewPCRProtectionProfile().
 			AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7).
 			AddProfileOR(

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -38,7 +38,7 @@ func TestUnsealWithNo2FA(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 32)
+	key := make([]byte, 64)
 	rand.Read(key)
 
 	run := func(t *testing.T, params *KeyCreationParams) {
@@ -80,7 +80,7 @@ func TestUnsealWithNo2FA(t *testing.T) {
 }
 
 func TestUnsealErrorHandling(t *testing.T) {
-	key := make([]byte, 32)
+	key := make([]byte, 64)
 	rand.Read(key)
 
 	run := func(t *testing.T, tpm *TPMConnection, fn func(string, string)) error {


### PR DESCRIPTION
With AES-256 and XTS block cipher mode, both the volume key and derived
key (the one sealed by this function) are 512-bits.