### PR TITLE
Add an API to bind a PCR profile to a set of snap models

### DIFF
--- a/policy_test.go
+++ b/policy_test.go
@@ -546,11 +546,11 @@ duwzA18V2dm66mFx1NcqfNyRUbclhN26KAaRnTDQrAaxFIgoO+Xm
 	// for PIN change (TPM2_NV_ChangeAuth), reading (TPM2_NV_Read) and TPM2_PolicyNV - see the first 5 calls to tpm2.ComputeAuthPolicy in
 	// createPinNVIndex.
 	var pinIndexAuthPolicies tpm2.DigestList
-	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexString(t, "199c42684aafe3d9c2e18dcc162a6d3875a40ca2ab8f06228b207135281d995f"))
-	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexString(t, "78b1915a25b400ec9a87a2830b07aaacfc440f754e0d2027d09799f894d134c0"))
-	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexString(t, "aa83a598d93a56c9ca6fea7c3ffc4e106357ff6d93e11a9b4ac2b6aae12ba0de"))
-	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexString(t, "47ce3032d8bad1f3089cb0c09088de43501491d460402b90cd1b7fc0b68ca92f"))
-	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexString(t, "203e4bd5d0448c9615cc13fa18e8d39222441cc40204d99a77262068dbd55a43"))
+	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexStringT(t, "199c42684aafe3d9c2e18dcc162a6d3875a40ca2ab8f06228b207135281d995f"))
+	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexStringT(t, "78b1915a25b400ec9a87a2830b07aaacfc440f754e0d2027d09799f894d134c0"))
+	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexStringT(t, "aa83a598d93a56c9ca6fea7c3ffc4e106357ff6d93e11a9b4ac2b6aae12ba0de"))
+	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexStringT(t, "47ce3032d8bad1f3089cb0c09088de43501491d460402b90cd1b7fc0b68ca92f"))
+	pinIndexAuthPolicies = append(pinIndexAuthPolicies, decodeHexStringT(t, "203e4bd5d0448c9615cc13fa18e8d39222441cc40204d99a77262068dbd55a43"))
 
 	trial, _ := tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
 	trial.PolicyOR(pinIndexAuthPolicies)
@@ -578,12 +578,12 @@ duwzA18V2dm66mFx1NcqfNyRUbclhN26KAaRnTDQrAaxFIgoO+Xm
 		{
 			desc:   "SHA256",
 			alg:    tpm2.HashAlgorithmSHA256,
-			policy: decodeHexString(t, "6996f631d4ff9ebe51aaf91f155446ea3b845f9d7f3c33d70efc3b44cbf9fde4"),
+			policy: decodeHexStringT(t, "6996f631d4ff9ebe51aaf91f155446ea3b845f9d7f3c33d70efc3b44cbf9fde4"),
 		},
 		{
 			desc:   "SHA1",
 			alg:    tpm2.HashAlgorithmSHA1,
-			policy: decodeHexString(t, "97859d33468dd99d02449128b5c0cda40fc2c272"),
+			policy: decodeHexStringT(t, "97859d33468dd99d02449128b5c0cda40fc2c272"),
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
@@ -693,7 +693,7 @@ func TestComputePolicyORData(t *testing.T) {
 			inputDigests: tpm2.DigestList{
 				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo")).end(),
 			},
-			outputPolicy: decodeHexString(t, "fd7451c024bafe5f117cab2841c2dd81f5304350bd8b17ef1f667bceda1ffcf9"),
+			outputPolicy: decodeHexStringT(t, "fd7451c024bafe5f117cab2841c2dd81f5304350bd8b17ef1f667bceda1ffcf9"),
 		},
 		{
 			desc: "MultipleDigests",
@@ -704,7 +704,7 @@ func TestComputePolicyORData(t *testing.T) {
 				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "abc")).end(),
 				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "1234")).end(),
 			},
-			outputPolicy: decodeHexString(t, "4088de0181ede03662fabce88ba4385b16448a981f6b399da861dfe6cc955b68"),
+			outputPolicy: decodeHexStringT(t, "4088de0181ede03662fabce88ba4385b16448a981f6b399da861dfe6cc955b68"),
 		},
 		{
 			desc: "2Rows",
@@ -736,7 +736,7 @@ func TestComputePolicyORData(t *testing.T) {
 				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
 				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
 			},
-			outputPolicy: decodeHexString(t, "0a023c5b9182d2456407c39bf0ab62f6b86f90a4cec61e594c026a087c43e84c"),
+			outputPolicy: decodeHexStringT(t, "0a023c5b9182d2456407c39bf0ab62f6b86f90a4cec61e594c026a087c43e84c"),
 		},
 		{
 			desc: "3Rows",
@@ -868,7 +868,7 @@ func TestComputePolicyORData(t *testing.T) {
 				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
 				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
 			},
-			outputPolicy: decodeHexString(t, "447f411c3cedd453e53e9b95958774413bea32267a75db8545cd258ed4968575"),
+			outputPolicy: decodeHexStringT(t, "447f411c3cedd453e53e9b95958774413bea32267a75db8545cd258ed4968575"),
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
@@ -952,7 +952,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			},
 			policyCount:  10,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}},
-			policy:       decodeHexString(t, "3cbe37896850d15904508ddf7a28f776642fe60e10b8c9b35e22f50bdc3a53dc"),
+			policy:       decodeHexStringT(t, "3cbe37896850d15904508ddf7a28f776642fe60e10b8c9b35e22f50bdc3a53dc"),
 		},
 		{
 			desc:    "Single/2",
@@ -968,7 +968,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			},
 			policyCount:  10,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8}}},
-			policy:       decodeHexString(t, "86affbdd808f57ef16c369fc2cc099a3bfa4de6d39a5c4a2cba83710c555ecbe"),
+			policy:       decodeHexStringT(t, "86affbdd808f57ef16c369fc2cc099a3bfa4de6d39a5c4a2cba83710c555ecbe"),
 		},
 		{
 			desc:    "SHA1Session",
@@ -984,7 +984,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			},
 			policyCount:  4551,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}},
-			policy:       decodeHexString(t, "28ac61ddced6e86df127edebeea647b9dc5ca84d"),
+			policy:       decodeHexStringT(t, "28ac61ddced6e86df127edebeea647b9dc5ca84d"),
 		},
 		{
 			desc:    "SHA256SessionWithSHA512PCRs",
@@ -1000,7 +1000,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			},
 			policyCount:  403,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA512, Select: []int{7, 12}}},
-			policy:       decodeHexString(t, "3600c82daa5035cd43270f3bc3d0e54beb5c822068ba1951e1bb8757f9dd1d15"),
+			policy:       decodeHexStringT(t, "3600c82daa5035cd43270f3bc3d0e54beb5c822068ba1951e1bb8757f9dd1d15"),
 		},
 		{
 			desc:    "MultiplePCRValues/1",
@@ -1022,7 +1022,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			},
 			policyCount:  5,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}},
-			policy:       decodeHexString(t, "512b6a11965b51f1e5d7eef556bbe1d10a944e5151ed152632f51cb14a326949"),
+			policy:       decodeHexStringT(t, "512b6a11965b51f1e5d7eef556bbe1d10a944e5151ed152632f51cb14a326949"),
 		},
 		{
 			desc:    "MultiplePCRValues/2",
@@ -1040,7 +1040,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			}),
 			policyCount:  5,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}},
-			policy:       decodeHexString(t, "a17b393df59e27da3052bce83dbd8d97e777c4967c2ffa9ea9cc096a65944eed"),
+			policy:       decodeHexStringT(t, "a17b393df59e27da3052bce83dbd8d97e777c4967c2ffa9ea9cc096a65944eed"),
 		},
 		{
 			desc:    "SHA512AuthKey",
@@ -1056,7 +1056,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			},
 			policyCount:  10,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}},
-			policy:       decodeHexString(t, "3cbe37896850d15904508ddf7a28f776642fe60e10b8c9b35e22f50bdc3a53dc"),
+			policy:       decodeHexStringT(t, "3cbe37896850d15904508ddf7a28f776642fe60e10b8c9b35e22f50bdc3a53dc"),
 		},
 		{
 			desc:    "MultiplePCRAlgorithms",
@@ -1074,7 +1074,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			},
 			policyCount:  10,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{8}}, {Hash: tpm2.HashAlgorithmSHA512, Select: []int{7}}},
-			policy:       decodeHexString(t, "adacb43d5f894bf05b6153c16743251a1896ab92d88c9032a7e94095372869dd"),
+			policy:       decodeHexStringT(t, "adacb43d5f894bf05b6153c16743251a1896ab92d88c9032a7e94095372869dd"),
 		},
 		{
 			desc:    "LotsOfPCRValues",
@@ -1105,7 +1105,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 			}),
 			policyCount:  15,
 			pcrSelection: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}},
-			policy:       decodeHexString(t, "92a8744419642bd0c72195ec681fcc03a6f4dd3c644837c7f0eb8394d729f9d5"),
+			policy:       decodeHexStringT(t, "92a8744419642bd0c72195ec681fcc03a6f4dd3c644837c7f0eb8394d729f9d5"),
 		},
 		{
 			desc:    "IncompletePCRValues",

--- a/sdefistub_policy_test.go
+++ b/sdefistub_policy_test.go
@@ -47,12 +47,12 @@ func TestAddSystemdEFIStubProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						12: decodeHexString(t, "fc433eaf039c6261f496a2a5bf2addfd8ff1104b0fc98af3fe951517e3bde824"),
+						12: decodeHexStringT(t, "fc433eaf039c6261f496a2a5bf2addfd8ff1104b0fc98af3fe951517e3bde824"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						12: decodeHexString(t, "b3a29076eeeae197ae721c254da40480b76673038045305cfa78ec87421c4eea"),
+						12: decodeHexStringT(t, "b3a29076eeeae197ae721c254da40480b76673038045305cfa78ec87421c4eea"),
 					},
 				},
 			},
@@ -70,12 +70,12 @@ func TestAddSystemdEFIStubProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA1: {
-						12: decodeHexString(t, "eb6312b7db70fe16206c162326e36b2fcda74b68"),
+						12: decodeHexStringT(t, "eb6312b7db70fe16206c162326e36b2fcda74b68"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA1: {
-						12: decodeHexString(t, "bd612bea9efa582fcbfae97973c89b163756fe0b"),
+						12: decodeHexStringT(t, "bd612bea9efa582fcbfae97973c89b163756fe0b"),
 					},
 				},
 			},
@@ -92,7 +92,7 @@ func TestAddSystemdEFIStubProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						8: decodeHexString(t, "74fe9080b798f9220c18d0fcdd0ccb82d50ce2a317bc6cdaa2d8715d02d0efbe"),
+						8: decodeHexStringT(t, "74fe9080b798f9220c18d0fcdd0ccb82d50ce2a317bc6cdaa2d8715d02d0efbe"),
 					},
 				},
 			},
@@ -115,7 +115,7 @@ func TestAddSystemdEFIStubProfile(t *testing.T) {
 				{
 					tpm2.HashAlgorithmSHA256: {
 						7: makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo"),
-						8: decodeHexString(t, "3d39c0db757b47b484006003724d990403d533044ed06e8798ab374bd73f32dc"),
+						8: decodeHexStringT(t, "3d39c0db757b47b484006003724d990403d533044ed06e8798ab374bd73f32dc"),
 					},
 				},
 			},

--- a/secboot_test.go
+++ b/secboot_test.go
@@ -20,6 +20,7 @@
 package secboot_test
 
 import (
+	"encoding/hex"
 	"math/rand"
 	"testing"
 
@@ -143,3 +144,9 @@ func (r *testRng) Read(p []byte) (int, error) {
 }
 
 var testRandReader = &testRng{}
+
+func decodeHexString(c *C, s string) []byte {
+	b, err := hex.DecodeString(s)
+	c.Assert(err, IsNil)
+	return b
+}

--- a/secureboot_policy_test.go
+++ b/secureboot_policy_test.go
@@ -100,7 +100,7 @@ func TestReadShimVendorCert(t *testing.T) {
 		{
 			desc:     "WithVendorCert",
 			path:     "testdata/mockshim1.efi.signed.2",
-			certHash: decodeHexString(t, "9badc31b6b648413f07dfa94559c27e1b923f474e2cf6bd7b40369913b6cd334"),
+			certHash: decodeHexStringT(t, "9badc31b6b648413f07dfa94559c27e1b923f474e2cf6bd7b40369913b6cd334"),
 		},
 		{
 			desc: "NoVendorCert",
@@ -155,16 +155,16 @@ func TestDecodeSecureBootDb(t *testing.T) {
 
 		microsoftRootCAName = "CN=Microsoft Root Certificate Authority 2010,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US"
 		microsoftPCASubject = "CN=Microsoft Windows Production PCA 2011,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US"
-		microsoftPCASerial  = decodeHexString(t, "61077656000000000008")
+		microsoftPCASerial  = decodeHexStringT(t, "61077656000000000008")
 
 		microsoftThirdPartyRootCAName = "CN=Microsoft Corporation Third Party Marketplace Root,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US"
 		microsoftCASubject            = "CN=Microsoft Corporation UEFI CA 2011,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US"
-		microsoftCASerial             = decodeHexString(t, "6108d3c4000000000004")
+		microsoftCASerial             = decodeHexStringT(t, "6108d3c4000000000004")
 
 		testOwnerGuid  = tcglog.NewEFIGUID(0xd1b37b32, 0x172d, 0x4d2a, 0x909f, [...]uint8{0xc7, 0x80, 0x81, 0x50, 0x17, 0x86})
 		testRootCAName = "CN=Test UEFI CA"
 		testCASubject  = "CN=Test UEFI CA"
-		testCASerial1  = decodeHexString(t, "1bd2a0d563e5901d6d1488431bc639bf06e0f4fa")
+		testCASerial1  = decodeHexStringT(t, "1bd2a0d563e5901d6d1488431bc639bf06e0f4fa")
 	)
 
 	type certId struct {
@@ -248,7 +248,7 @@ func TestDecodeSecureBootDb(t *testing.T) {
 				{
 					issuer:  testRootCAName,
 					subject: testCASubject,
-					serial:  decodeHexString(t, "2c7a9ef3e50ab167953021d32e4e9233cbc480a9"),
+					serial:  decodeHexStringT(t, "2c7a9ef3e50ab167953021d32e4e9233cbc480a9"),
 					owner:   testOwnerGuid,
 				},
 			},
@@ -261,7 +261,7 @@ func TestDecodeSecureBootDb(t *testing.T) {
 				{
 					issuer:  microsoftRootCAName,
 					subject: "CN=Microsoft Windows PCA 2010,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US",
-					serial:  decodeHexString(t, "610c6a19000000000004"),
+					serial:  decodeHexStringT(t, "610c6a19000000000004"),
 					owner:   tcglog.NewEFIGUID(0x00000000, 0x0000, 0x0000, 0x0000, [...]uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
 				},
 			},
@@ -397,27 +397,27 @@ func TestComputeDbUpdate(t *testing.T) {
 			desc:          "AppendOneCertToDb",
 			orig:          "testdata/efivars1/db-d719b2cb-3d3a-4596-a3bc-dad00e67656f",
 			update:        "testdata/updates1/db/1.bin",
-			sha1hash:      decodeHexString(t, "49785b436fbcbbc4349dfae2c0895477baba15e8"),
+			sha1hash:      decodeHexStringT(t, "49785b436fbcbbc4349dfae2c0895477baba15e8"),
 			newSignatures: 1,
 		},
 		{
 			desc:     "AppendExistingCertToDb",
 			orig:     "testdata/efivars2/db-d719b2cb-3d3a-4596-a3bc-dad00e67656f",
 			update:   "testdata/updates1/db/1.bin",
-			sha1hash: decodeHexString(t, "49785b436fbcbbc4349dfae2c0895477baba15e8"),
+			sha1hash: decodeHexStringT(t, "49785b436fbcbbc4349dfae2c0895477baba15e8"),
 		},
 		{
 			desc:          "AppendMsDbxUpdate",
 			orig:          "testdata/efivars1/dbx-d719b2cb-3d3a-4596-a3bc-dad00e67656f",
 			update:        "testdata/updates/dbx/MS-2016-08-08.bin",
-			sha1hash:      decodeHexString(t, "96f7dc104ee34a0ce8425aac20f29e2b2aba9d7e"),
+			sha1hash:      decodeHexStringT(t, "96f7dc104ee34a0ce8425aac20f29e2b2aba9d7e"),
 			newSignatures: 77,
 		},
 		{
 			desc:          "AppendDbxUpdateWithDuplicateSignatures",
 			orig:          "testdata/efivars3/dbx-d719b2cb-3d3a-4596-a3bc-dad00e67656f",
 			update:        "testdata/updates2/dbx/1.bin",
-			sha1hash:      decodeHexString(t, "b49564b2daee39b01b524bef75cf9cde2c3a2a0d"),
+			sha1hash:      decodeHexStringT(t, "b49564b2daee39b01b524bef75cf9cde2c3a2a0d"),
 			newSignatures: 2,
 		},
 	} {
@@ -527,7 +527,7 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
+						7: decodeHexStringT(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
 					},
 				},
 			},
@@ -562,7 +562,7 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
+						7: decodeHexStringT(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
 					},
 				},
 			},
@@ -607,7 +607,7 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
+						7: decodeHexStringT(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
 					},
 				},
 			},
@@ -738,7 +738,7 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
+						7: decodeHexStringT(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
 					},
 				},
 			},
@@ -784,7 +784,7 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
+						7: decodeHexStringT(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
 					},
 				},
 			},
@@ -829,7 +829,7 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "f73bb24f88ba33e9a99688bb47e72edd798f2442c8e072e0de03cde9edbbf394"),
+						7: decodeHexStringT(t, "f73bb24f88ba33e9a99688bb47e72edd798f2442c8e072e0de03cde9edbbf394"),
 					},
 				},
 			},
@@ -883,12 +883,12 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "bed6e96b835c1e2bb3c7ea930f9ec728f05eeeb5622e99b8f12fafe6df93039f"),
+						7: decodeHexStringT(t, "bed6e96b835c1e2bb3c7ea930f9ec728f05eeeb5622e99b8f12fafe6df93039f"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "46387dc7040c29ec3ac57b5e616f5ede478a9f735fec08311e6f0b78e53ddb66"),
+						7: decodeHexStringT(t, "46387dc7040c29ec3ac57b5e616f5ede478a9f735fec08311e6f0b78e53ddb66"),
 					},
 				},
 			},
@@ -951,7 +951,7 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
+						7: decodeHexStringT(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
 					},
 				},
 			},
@@ -996,12 +996,12 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
+						7: decodeHexStringT(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "a64025484424ba7a64dc1154889eb8fe78d7b204fa581ace55522c074050e428"),
+						7: decodeHexStringT(t, "a64025484424ba7a64dc1154889eb8fe78d7b204fa581ace55522c074050e428"),
 					},
 				},
 			},
@@ -1036,12 +1036,12 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
+						7: decodeHexStringT(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "38ae1e75ea7237983f4d44c3695e08a1d7b60d8cbac3c65e576473b72777616e"),
+						7: decodeHexStringT(t, "38ae1e75ea7237983f4d44c3695e08a1d7b60d8cbac3c65e576473b72777616e"),
 					},
 				},
 			},
@@ -1078,17 +1078,17 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
+						7: decodeHexStringT(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "38ae1e75ea7237983f4d44c3695e08a1d7b60d8cbac3c65e576473b72777616e"),
+						7: decodeHexStringT(t, "38ae1e75ea7237983f4d44c3695e08a1d7b60d8cbac3c65e576473b72777616e"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "3d612a0eda6deb41982b81d4c24695cf721e00233b40489af5918dae865320ac"),
+						7: decodeHexStringT(t, "3d612a0eda6deb41982b81d4c24695cf721e00233b40489af5918dae865320ac"),
 					},
 				},
 			},
@@ -1144,17 +1144,17 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
+						7: decodeHexStringT(t, "e80130f2d8212d6969f0cd20effc3bbded14584861f8f560fbc5208a8bfc0681"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "bed6e96b835c1e2bb3c7ea930f9ec728f05eeeb5622e99b8f12fafe6df93039f"),
+						7: decodeHexStringT(t, "bed6e96b835c1e2bb3c7ea930f9ec728f05eeeb5622e99b8f12fafe6df93039f"),
 					},
 				},
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "46387dc7040c29ec3ac57b5e616f5ede478a9f735fec08311e6f0b78e53ddb66"),
+						7: decodeHexStringT(t, "46387dc7040c29ec3ac57b5e616f5ede478a9f735fec08311e6f0b78e53ddb66"),
 					},
 				},
 			},
@@ -1233,8 +1233,8 @@ func TestAddEFISecureBootPolicyProfile(t *testing.T) {
 			values: []tpm2.PCRValues{
 				{
 					tpm2.HashAlgorithmSHA256: {
-						7: decodeHexString(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
-						8: decodeHexString(t, "a98b1d896c9383603b7923fffe230c9e4df24218eb84c90c5c758e63ce62843c"),
+						7: decodeHexStringT(t, "4a4fd90c8418bc4e6c763acc6d8849fdd997ceafbafe83538c507daf165ae8e6"),
+						8: decodeHexStringT(t, "a98b1d896c9383603b7923fffe230c9e4df24218eb84c90c5c758e63ce62843c"),
 					},
 				},
 			},

--- a/snapmodel_policy.go
+++ b/snapmodel_policy.go
@@ -23,12 +23,35 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"github.com/canonical/go-tpm2"
 	"github.com/snapcore/snapd/asserts"
 
 	"golang.org/x/xerrors"
 )
+
+const (
+	modelGradeUnset uint8 = iota
+	modelGradeSecured
+	modelGradeSigned
+	modelGradeDangerous
+)
+
+func modelGradeEnum(grade asserts.ModelGrade) (uint8, error) {
+	switch grade {
+	case asserts.ModelGradeUnset:
+		return modelGradeUnset, nil
+	case asserts.ModelSecured:
+		return modelGradeSecured, nil
+	case asserts.ModelSigned:
+		return modelGradeSigned, nil
+	case asserts.ModelDangerous:
+		return modelGradeDangerous, nil
+	default:
+		return modelGradeUnset, fmt.Errorf("unknown grade: %v", grade)
+	}
+}
 
 // SnapModelProfileParams provides the parameters to AddSnapModelProfile.
 type SnapModelProfileParams struct {
@@ -48,13 +71,22 @@ type SnapModelProfileParams struct {
 // a PCR policy that is bound to a specific set of device models. It is the responsibility of snap-bootstrap to verify the integrity
 // of the model that it has measured.
 //
-// The measurement of a model is a digest computed as follows (where H is the supplied params.PCRAlgorithm):
+// The profile consists of 2 measurements (where H is the digest algorithm supplied via params.PCRAlgorithm):
+//  H(uint32(0))
+//  digestModel
+//
+// digestModel is computed as follows:
 //  digest1 = H(tpm2.HashAlgorithmSHA384 || sign-key-sha3-384 || brand-id)
 //  digest2 = H(digest1 || model)
-//  digest3 = H(digest2 || series)
-// String fields are hashed without null terminators, the signing key digest algorithm identifier is encoded in little-endian
-// format, and the sign-key-sha3-384 field is hashed in decoded (binary) form. Separate extend operations are used because brand-id,
-// model and series are variable length.
+//  digestModel = H(digest2 || series || grade)
+// The signing key digest algorithm is encoded in little-endian format, and the sign-key-sha3-384 field is hashed in decoded (binary)
+// form. The brand-id, model and series fields are hashed without null terminators. The grade field is encoded as a single byte with
+// the following conversion:
+//  "unset":     0
+//  "secured":   1
+//  "signed":    2
+//  "dangerous": 3
+// Separate extend operations are used because brand-id, model and series are variable length.
 //
 // The PCR index that snap-bootstrap measures the model to can be specified via the PCRIndex field of params.
 //
@@ -67,11 +99,17 @@ func AddSnapModelProfile(profile *PCRProtectionProfile, params *SnapModelProfile
 		return errors.New("no models provided")
 	}
 
+	h := params.PCRAlgorithm.NewHash()
+	binary.Write(h, binary.LittleEndian, uint32(0))
+	versionDigest := h.Sum(nil)
+
 	var subProfiles []*PCRProtectionProfile
 	for _, model := range params.Models {
 		if model == nil {
 			return errors.New("nil model")
 		}
+
+		subProfile := NewPCRProtectionProfile().ExtendPCR(params.PCRAlgorithm, params.PCRIndex, versionDigest)
 
 		signKeyId, err := base64.RawURLEncoding.DecodeString(model.SignKeyID())
 		if err != nil {
@@ -88,11 +126,16 @@ func AddSnapModelProfile(profile *PCRProtectionProfile, params *SnapModelProfile
 		h.Write([]byte(model.Model()))
 		digest = h.Sum(nil)
 
+		grade, err := modelGradeEnum(model.Grade())
+		if err != nil {
+			return xerrors.Errorf("cannot detemine grade of model: %w", err)
+		}
 		h = params.PCRAlgorithm.NewHash()
 		h.Write(digest)
 		h.Write([]byte(model.Series()))
+		h.Write([]byte{grade})
 
-		subProfiles = append(subProfiles, NewPCRProtectionProfile().ExtendPCR(params.PCRAlgorithm, params.PCRIndex, h.Sum(nil)))
+		subProfiles = append(subProfiles, subProfile.ExtendPCR(params.PCRAlgorithm, params.PCRIndex, h.Sum(nil)))
 	}
 
 	profile.AddProfileOR(subProfiles...)

--- a/snapmodel_policy.go
+++ b/snapmodel_policy.go
@@ -24,7 +24,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/chrisccoulson/go-tpm2"
+	"github.com/canonical/go-tpm2"
 	"github.com/snapcore/snapd/asserts"
 
 	"golang.org/x/xerrors"

--- a/snapmodel_policy.go
+++ b/snapmodel_policy.go
@@ -101,15 +101,13 @@ func AddSnapModelProfile(profile *PCRProtectionProfile, params *SnapModelProfile
 
 	h := params.PCRAlgorithm.NewHash()
 	binary.Write(h, binary.LittleEndian, uint32(0))
-	versionDigest := h.Sum(nil)
+	profile.ExtendPCR(params.PCRAlgorithm, params.PCRIndex, h.Sum(nil))
 
 	var subProfiles []*PCRProtectionProfile
 	for _, model := range params.Models {
 		if model == nil {
 			return errors.New("nil model")
 		}
-
-		subProfile := NewPCRProtectionProfile().ExtendPCR(params.PCRAlgorithm, params.PCRIndex, versionDigest)
 
 		signKeyId, err := base64.RawURLEncoding.DecodeString(model.SignKeyID())
 		if err != nil {
@@ -135,7 +133,7 @@ func AddSnapModelProfile(profile *PCRProtectionProfile, params *SnapModelProfile
 		h.Write([]byte(model.Series()))
 		h.Write([]byte{grade})
 
-		subProfiles = append(subProfiles, subProfile.ExtendPCR(params.PCRAlgorithm, params.PCRIndex, h.Sum(nil)))
+		subProfiles = append(subProfiles, NewPCRProtectionProfile().ExtendPCR(params.PCRAlgorithm, params.PCRIndex, h.Sum(nil)))
 	}
 
 	profile.AddProfileOR(subProfiles...)

--- a/snapmodel_policy.go
+++ b/snapmodel_policy.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"encoding/base64"
+	"errors"
+
+	"github.com/chrisccoulson/go-tpm2"
+	"github.com/snapcore/snapd/asserts"
+
+	"golang.org/x/xerrors"
+)
+
+// SnapModelProfileParams provides the parameters to AddSnapModelProfile.
+type SnapModelProfileParams struct {
+	// PCRAlgorithm is the algorithm for which to compute PCR digests for. TPMs compliant with the "TCG PC Client Platform TPM Profile
+	// (PTP) Specification" Level 00, Revision 01.03 v22, May 22 2017 are required to support tpm2.HashAlgorithmSHA1 and
+	// tpm2.HashAlgorithmSHA256. Support for other digest algorithms is optional.
+	PCRAlgorithm tpm2.HashAlgorithmId
+
+	// PCRIndex is the PCR that snap-bootstrap measures the model to.
+	PCRIndex int
+
+	// Models is the set of models to add to the PCR profile.
+	Models []*asserts.Model
+}
+
+// AddSnapModelProfile adds the snap model profile to the PCR protection profile, as measured by snap-bootstrap, in order to generate
+// a PCR policy that is bound to a specific set of device models. It is the responsibility of snap-bootstrap to verify the integrity
+// of the model that it has measured.
+//
+// The measurement of a model is a digest computed as follows (where H is the supplied params.PCRAlgorithm):
+//  digest1 = H(sign-key-sha3-384 || brand-id)
+//  digest2 = H(digest1 || model)
+//  digest3 = H(digest2 || series)
+// Strings are hashed without null terminators, and the sign-key-sha3-384 field is hashed in decoded form. Separate extend operations
+// are used because brand-id, model and series are variable length.
+//
+// The PCR index that snap-bootstrap measures the model to can be specified via the PCRIndex field of params.
+//
+// The set of models to add to the PCRProtectionProfile is specified via the Models field of params.
+func AddSnapModelProfile(profile *PCRProtectionProfile, params *SnapModelProfileParams) error {
+	if params.PCRIndex < 0 {
+		return errors.New("invalid PCR index")
+	}
+	if len(params.Models) == 0 {
+		return errors.New("no models provided")
+	}
+
+	var subProfiles []*PCRProtectionProfile
+	for _, model := range params.Models {
+		if model == nil {
+			return errors.New("nil model")
+		}
+
+		signKeyId, err := base64.RawURLEncoding.DecodeString(model.SignKeyID())
+		if err != nil {
+			return xerrors.Errorf("cannot decode signing key ID: %w", err)
+		}
+		h := params.PCRAlgorithm.NewHash()
+		h.Write(signKeyId)
+		h.Write([]byte(model.BrandID()))
+		digest := h.Sum(nil)
+
+		h = params.PCRAlgorithm.NewHash()
+		h.Write(digest)
+		h.Write([]byte(model.Model()))
+		digest = h.Sum(nil)
+
+		h = params.PCRAlgorithm.NewHash()
+		h.Write(digest)
+		h.Write([]byte(model.Series()))
+
+		subProfiles = append(subProfiles, NewPCRProtectionProfile().ExtendPCR(params.PCRAlgorithm, params.PCRIndex, h.Sum(nil)))
+	}
+
+	profile.AddProfileOR(subProfiles...)
+	return nil
+}

--- a/snapmodel_policy_test.go
+++ b/snapmodel_policy_test.go
@@ -50,6 +50,14 @@ func (s *snapModelProfileTest) testAddSnapModelProfile(c *C, data *testAddSnapMo
 	values, err := profile.ComputePCRValues(nil)
 	c.Assert(err, IsNil)
 	c.Check(values, DeepEquals, data.values)
+	for i, v := range values {
+		c.Logf("Value %d:", i)
+		for alg := range v {
+			for pcr := range v[alg] {
+				c.Logf(" PCR%d,%v: %x", pcr, alg, v[alg][pcr])
+			}
+		}
+	}
 }
 
 func (s *snapModelProfileTest) TestAddSnapModelProfile1(c *C) {
@@ -74,7 +82,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile1(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "e42b7ae1c9027eba122fa5ee5d3fcafe5482ea46cda1280ec3065d89d6175e4e"),
+					12: decodeHexString(c, "4d4e46741b272922844798df559dc511366f6239d9b987f856cbb7e8ef0f8131"),
 				},
 			},
 		},
@@ -107,7 +115,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile2(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "cb6830f3b5ba8873e532cfc6c0475136ecb89eee2300769172dab700d9edb785"),
+					12: decodeHexString(c, "df6f0c42b613de7d273822675a8dcc45446b05a8ac2286c462bb88c71a306bd1"),
 				},
 			},
 		},
@@ -137,7 +145,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile3(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "1c60ad55a1c03f74b50944c3e067d49735080c85bada53e175fe6747a77b5578"),
+					12: decodeHexString(c, "243420e1dc752a6ea5700040c7e55c9b5975ed5351f55732b56f0e8b5e89879b"),
 				},
 			},
 		},
@@ -167,7 +175,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile4(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "9aedf76f8049f50bf3b7f569ab899d3add8cec50958cd9ea801a0fa61a3e9d93"),
+					12: decodeHexString(c, "79010a11d00afb85a7c6798b37ea65e19d5c469fc04c28cce3139f205382e4f9"),
 				},
 			},
 		},
@@ -197,7 +205,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile5(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "7b80a5b2f3f2f40bcecbb09a356a4a8a11a1f0612ea66088537c164af7db8c59"),
+					12: decodeHexString(c, "80804cb20ed8ec6069b61cf37304c6c18f8b8785bb83736fa48dd3b3e6d59daf"),
 				},
 			},
 		},
@@ -227,7 +235,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile6(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA1: {
-					12: decodeHexString(c, "c84633bbf62a72b01b9c3190821613956ca2bd06"),
+					12: decodeHexString(c, "e92abf598a159fad8e1cda1a408ba8b278295f0c"),
 				},
 			},
 		},
@@ -257,7 +265,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile7(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					14: decodeHexString(c, "e42b7ae1c9027eba122fa5ee5d3fcafe5482ea46cda1280ec3065d89d6175e4e"),
+					14: decodeHexString(c, "4d4e46741b272922844798df559dc511366f6239d9b987f856cbb7e8ef0f8131"),
 				},
 			},
 		},
@@ -298,12 +306,12 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile8(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "e42b7ae1c9027eba122fa5ee5d3fcafe5482ea46cda1280ec3065d89d6175e4e"),
+					12: decodeHexString(c, "4d4e46741b272922844798df559dc511366f6239d9b987f856cbb7e8ef0f8131"),
 				},
 			},
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "9aedf76f8049f50bf3b7f569ab899d3add8cec50958cd9ea801a0fa61a3e9d93"),
+					12: decodeHexString(c, "79010a11d00afb85a7c6798b37ea65e19d5c469fc04c28cce3139f205382e4f9"),
 				},
 			},
 		},
@@ -348,13 +356,13 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile9(c *C) {
 			{
 				tpm2.HashAlgorithmSHA256: {
 					7:  makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo"),
-					12: decodeHexString(c, "7c49a939ab34ea2ba8d21acb79539f8d035acc3c8f581fe1551a1c844e179060"),
+					12: decodeHexString(c, "2c3caf892570525d37d4729bfb260593f8a1ca607ae8e8b2ea573bb7e0bc3904"),
 				},
 			},
 			{
 				tpm2.HashAlgorithmSHA256: {
 					7:  makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo"),
-					12: decodeHexString(c, "0ab1f69d3c4de619917b67da524dfaf7db17b6d9e6e43ffb8fa9c2a6abd6feec"),
+					12: decodeHexString(c, "566e37630ca8b0adcce77f7c77f193bffc98d307944503188b7aa46a5c7555ce"),
 				},
 			},
 		},
@@ -385,7 +393,7 @@ func (s *snapModelProfileTest) TestAddSnapModelProfile10(c *C) {
 		values: []tpm2.PCRValues{
 			{
 				tpm2.HashAlgorithmSHA256: {
-					12: decodeHexString(c, "f1edd468aca0259aa0352576371e017466025e64ac869d5c8a2089dcaffd15a5"),
+					12: decodeHexString(c, "7c7b7f6062cf23af1b717b2980ceefc7404f30a4a9c37c43573e4bbbe53c4a5b"),
 				},
 			},
 		},

--- a/snapmodel_policy_test.go
+++ b/snapmodel_policy_test.go
@@ -23,7 +23,7 @@ import (
 	"encoding/base64"
 	"time"
 
-	"github.com/chrisccoulson/go-tpm2"
+	"github.com/canonical/go-tpm2"
 	. "github.com/snapcore/secboot"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -59,7 +59,7 @@ var (
 	testEncodedEkCertChain []byte
 )
 
-func decodeHexString(t *testing.T, s string) []byte {
+func decodeHexStringT(t *testing.T, s string) []byte {
 	b, err := hex.DecodeString(s)
 	if err != nil {
 		t.Fatalf("DecodeHexString failed: %v", err)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -70,12 +70,6 @@
 			"revisionTime": "2020-04-15T14:21:00Z"
 		},
 		{
-			"checksumSHA1": "/ZS6P2x+MCvvCCCGcZEoT7pAbbc=",
-			"path": "github.com/snapcore/snapd/asserts/assertstest",
-			"revision": "5a4d77fa2cab712c2f31249afb12f2c319c0b723",
-			"revisionTime": "2020-04-15T18:48:21Z"
-		},
-		{
 			"checksumSHA1": "dgVsGNzbHyFKJ57G677B0ks2ldw=",
 			"path": "github.com/snapcore/snapd/cmd/cmdutil",
 			"revision": "3cf189a768580bcf3ea3397361566be1a6e04bc5",
@@ -222,12 +216,6 @@
 		{
 			"checksumSHA1": "zJybXQZcPAht+soLp/ozc9q5teE=",
 			"path": "golang.org/x/crypto/cast5",
-			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
-			"revisionTime": "2020-04-11T01:31:37Z"
-		},
-		{
-			"checksumSHA1": "b944y4fIe3sOBkJsJLPCzRW9mZE=",
-			"path": "golang.org/x/crypto/openpgp/armor",
 			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
 			"revisionTime": "2020-04-11T01:31:37Z"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -64,6 +64,18 @@
 			"revisionTime": "2020-02-12T13:56:49Z"
 		},
 		{
+			"checksumSHA1": "eLrXwgWW73OWXLajqFBkkWBMoNM=",
+			"path": "github.com/snapcore/snapd/asserts",
+			"revision": "85d045458ea5a9b9eb01ed67c3ffbbf59ff4c8a0",
+			"revisionTime": "2020-04-15T14:21:00Z"
+		},
+		{
+			"checksumSHA1": "/ZS6P2x+MCvvCCCGcZEoT7pAbbc=",
+			"path": "github.com/snapcore/snapd/asserts/assertstest",
+			"revision": "5a4d77fa2cab712c2f31249afb12f2c319c0b723",
+			"revisionTime": "2020-04-15T18:48:21Z"
+		},
+		{
 			"checksumSHA1": "dgVsGNzbHyFKJ57G677B0ks2ldw=",
 			"path": "github.com/snapcore/snapd/cmd/cmdutil",
 			"revision": "3cf189a768580bcf3ea3397361566be1a6e04bc5",
@@ -148,6 +160,12 @@
 			"revisionTime": "2020-03-26T10:31:06Z"
 		},
 		{
+			"checksumSHA1": "o5TwzS0cwJNV8HNIIZrRfZPANLU=",
+			"path": "github.com/snapcore/snapd/snap/channel",
+			"revision": "85d045458ea5a9b9eb01ed67c3ffbbf59ff4c8a0",
+			"revisionTime": "2020-04-15T14:21:00Z"
+		},
+		{
 			"checksumSHA1": "oxw0r23JHi+xZgzBDLnJLESkZPk=",
 			"path": "github.com/snapcore/snapd/snap/naming",
 			"revision": "1ca48cd75c9bfdf73fe8f1f45419f7cdad267638",
@@ -202,10 +220,58 @@
 			"revisionTime": "2020-02-28T13:54:56Z"
 		},
 		{
+			"checksumSHA1": "zJybXQZcPAht+soLp/ozc9q5teE=",
+			"path": "golang.org/x/crypto/cast5",
+			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
+			"revisionTime": "2020-04-11T01:31:37Z"
+		},
+		{
+			"checksumSHA1": "b944y4fIe3sOBkJsJLPCzRW9mZE=",
+			"path": "golang.org/x/crypto/openpgp/armor",
+			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
+			"revisionTime": "2020-04-11T01:31:37Z"
+		},
+		{
+			"checksumSHA1": "juTyoXrV63uP4Quf10LtBfNdHO0=",
+			"path": "golang.org/x/crypto/openpgp/elgamal",
+			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
+			"revisionTime": "2020-04-11T01:31:37Z"
+		},
+		{
+			"checksumSHA1": "rlxVSaGgqdAgwblsErxTxIfuGfg=",
+			"path": "golang.org/x/crypto/openpgp/errors",
+			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
+			"revisionTime": "2020-04-11T01:31:37Z"
+		},
+		{
+			"checksumSHA1": "nmTG13ss3pBFyKgAjiKXm5xmjGw=",
+			"path": "golang.org/x/crypto/openpgp/packet",
+			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
+			"revisionTime": "2020-04-11T01:31:37Z"
+		},
+		{
+			"checksumSHA1": "s2qT4UwvzBSkzXuiuMkowif1Olw=",
+			"path": "golang.org/x/crypto/openpgp/s2k",
+			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
+			"revisionTime": "2020-04-11T01:31:37Z"
+		},
+		{
+			"checksumSHA1": "drLEAT3CZZ9uo4nlQx1kxuDnXpU=",
+			"path": "golang.org/x/crypto/sha3",
+			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
+			"revisionTime": "2020-04-11T01:31:37Z"
+		},
+		{
 			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
 			"path": "golang.org/x/net/context",
 			"revision": "16171245cfb220d5317888b716d69c1fb4e7992b",
 			"revisionTime": "2020-01-30T10:58:50Z"
+		},
+		{
+			"checksumSHA1": "/b8Fw69AsJ3HgYjSxafhU5VrgGE=",
+			"path": "golang.org/x/sys/cpu",
+			"revision": "669c56c373c468cbe0f0c12b7939832b26088d33",
+			"revisionTime": "2020-04-10T17:18:43Z"
 		},
 		{
 			"checksumSHA1": "Ola9GKVm7hRQO+Wworwy7zE16L0=",


### PR DESCRIPTION
This binds a PCR profile to the brand (via the brand-id and sign-key-sha3-384 fields), model and series properties of a set of model assertions and defines the format in which snap-bootstrap should perform the actual measurement of these properties.