### PR TITLE
Use the PIN to derive additional key material

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -324,7 +324,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPIN(c *C, data *tes
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
 	// Test with a single PIN attempt.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", testPIN), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyAndPIN(c, &testActivateVolumeWithTPMSealedKeyAndPINData{
 		pins:     []string{testPIN},
 		pinTries: 1,
@@ -334,7 +334,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN2(c *C) {
 	// Test with 2 PIN attempts.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", testPIN), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyAndPIN(c, &testActivateVolumeWithTPMSealedKeyAndPINData{
 		pins:     []string{"", testPIN},
 		pinTries: 2,
@@ -377,7 +377,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(c *C) {
 	// Test with the correct PIN provided via the io.Reader.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pinFileContents: testPIN + "\n",
@@ -388,7 +388,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader2(c *C) {
 	// Test with the correct PIN provided via the io.Reader when the file doesn't end in a newline.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pinFileContents: testPIN,
@@ -399,7 +399,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader2(
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader3(c *C) {
 	// Test falling back to asking for a PIN if the wrong PIN is provided via the io.Reader.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pins:            []string{testPIN},
@@ -411,7 +411,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader3(
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader4(c *C) {
 	// Test falling back to asking for a PIN without using a try if the io.Reader has no contents.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pins:     []string{testPIN},
@@ -589,7 +589,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 	// Test that recovery fallback works if the wrong PIN is supplied.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", testPIN), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
 		pinTries:         1,
 		recoveryKeyTries: 1,
@@ -608,7 +608,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling10(c *C) {
 	// Test that recovery fallback works if a PIN is set but no PIN attempts are permitted.
-	c.Assert(ChangePIN(s.tpm, s.keyFile, "", "1234"), IsNil)
+	c.Assert(ChangePIN(s.tpm, s.keyFile, &testPINParams, "", "1234"), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
 		recoveryKeyTries:  1,
 		passphrases:       []string{strings.Join(s.recoveryKeyAscii, "-")},

--- a/export_test.go
+++ b/export_test.go
@@ -66,7 +66,7 @@ var (
 	OidTcgAttributeTpmModel                  = oidTcgAttributeTpmModel
 	OidTcgAttributeTpmVersion                = oidTcgAttributeTpmVersion
 	OidTcgKpEkCertificate                    = oidTcgKpEkCertificate
-	PerformPinChange                         = performPinChange
+	PerformPinChange                         = performTPMPinChange
 	ReadAndValidateLockNVIndexPublic         = readAndValidateLockNVIndexPublic
 	ReadDynamicPolicyCounter                 = readDynamicPolicyCounter
 	ReadShimVendorCert                       = readShimVendorCert
@@ -169,7 +169,7 @@ func MakeMockPolicyPCRValuesFull(params []MockPolicyPCRParam) (out []tpm2.PCRVal
 	for {
 		v := make(tpm2.PCRValues)
 		for i := range params {
-			v.SetValue(params[i].PCR, params[i].Alg, params[i].Digests[indices[i]])
+			v.SetValue(params[i].Alg, params[i].PCR, params[i].Digests[indices[i]])
 		}
 		out = append(out, v)
 

--- a/pcr_profile.go
+++ b/pcr_profile.go
@@ -33,7 +33,7 @@ type pcrValuesList []tpm2.PCRValues
 // setValue sets the specified PCR to the supplied value for all branches.
 func (l pcrValuesList) setValue(alg tpm2.HashAlgorithmId, pcr int, value tpm2.Digest) {
 	for _, v := range l {
-		v.SetValue(pcr, alg, value)
+		v.SetValue(alg, pcr, value)
 	}
 }
 

--- a/policy.go
+++ b/policy.go
@@ -706,7 +706,7 @@ func executePolicyORAssertions(tpm *tpm2.TPMContext, session tpm2.SessionContext
 // executePolicySession executes an authorization policy session using the supplied metadata. On success, the supplied policy
 // session can be used for authorization.
 func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContext, staticInput *staticPolicyData,
-	dynamicInput *dynamicPolicyData, pin string, hmacSession tpm2.SessionContext) error {
+	dynamicInput *dynamicPolicyData, authValue []byte, hmacSession tpm2.SessionContext) error {
 	if err := tpm.PolicyPCR(policySession, nil, dynamicInput.PCRSelection); err != nil {
 		return xerrors.Errorf("cannot execute PCR assertion: %w", err)
 	}
@@ -806,7 +806,7 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 		return xerrors.Errorf("dynamic authorization policy check failed: %w", err)
 	}
 
-	pinIndex.SetAuthValue([]byte(pin))
+	pinIndex.SetAuthValue(authValue)
 	if _, _, err := tpm.PolicySecret(pinIndex, policySession, nil, nil, 0, hmacSession); err != nil {
 		return xerrors.Errorf("cannot execute PolicySecret assertion: %w", err)
 	}

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -105,7 +105,7 @@ func TestUnsealWithPIN(t *testing.T) {
 
 	testPIN := "1234"
 
-	if err := ChangePIN(tpm, keyFile, "", testPIN); err != nil {
+	if err := ChangePIN(tpm, keyFile, &testPINParams, "", testPIN); err != nil {
 		t.Errorf("ChangePIN failed: %v", err)
 	}
 
@@ -275,7 +275,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 		defer closeTPM(t, tpm)
 
 		err := run(t, tpm, func(keyFile, _ string) {
-			if err := ChangePIN(tpm, keyFile, "", "1234"); err != nil {
+			if err := ChangePIN(tpm, keyFile, &testPINParams, "", "1234"); err != nil {
 				t.Errorf("ChangePIN failed: %v", err)
 			}
 		})

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "FM+dp3Hv1n+R9b/gqhtjSq6W4T8=",
+			"checksumSHA1": "ePxuuPL3SO9H2fEjFsmPB5qtmOM=",
 			"path": "github.com/canonical/go-tpm2",
-			"revision": "16307201a54dc51583440f9416cfa836bcf0b3fc",
-			"revisionTime": "2020-04-16T00:17:14Z"
+			"revision": "2bcab904452b67bb81f346b4fa65ac0d1cfcadbd",
+			"revisionTime": "2020-04-29T23:11:47Z"
 		},
 		{
 			"checksumSHA1": "bT/rC7K8St3lNRXf/XJGpB4wNJU=",
@@ -217,6 +217,18 @@
 			"revisionTime": "2020-01-28T12:03:23Z"
 		},
 		{
+			"checksumSHA1": "FwW3Vv4jW0Nv7V2SZC7x/Huj5M4=",
+			"path": "golang.org/x/crypto/argon2",
+			"revision": "4b2356b1ed79e6be3deca3737a3db3d132d2847a",
+			"revisionTime": "2020-04-23T13:34:55Z"
+		},
+		{
+			"checksumSHA1": "jBA6C2r4EBCfIA8B8C71Lr3MMEk=",
+			"path": "golang.org/x/crypto/blake2b",
+			"revision": "4b2356b1ed79e6be3deca3737a3db3d132d2847a",
+			"revisionTime": "2020-04-23T13:34:55Z"
+		},
+		{
 			"checksumSHA1": "zJybXQZcPAht+soLp/ozc9q5teE=",
 			"path": "golang.org/x/crypto/cast5",
 			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",
@@ -305,6 +317,12 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "53403b58ad1b561927d19068c655246f2db79d48",
 			"revisionTime": "2020-01-21T17:19:40Z"
+		},
+		{
+			"checksumSHA1": "tZ9GNzrjTZEPDhoJEkouGPKRmZk=",
+			"path": "maze.io/x/crypto/afis",
+			"revision": "9b94c9afe06676a7da39a608a48ed4e31f5d125f",
+			"revisionTime": "2019-01-31T09:06:03Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/secboot"


### PR DESCRIPTION
The default configuration of having no PIN set protects data from
opportunistic attackers. Setting a PIN protects data from more
determined attackers. This is the case even if the PIN is fairly low
entropy, because we use the TPM to assert that the provided PIN is
correct and this benefits from the TPM's dictionary attack logic. It is
beyond the ability even for most determined attackers to compromise the
actual TPM hardware to defeat this mechanism.

However, this may not be sufficient to protect your data from 3 letter
agencies with the means to compromise the TPM hardware in a way that
allows them access to a shielded location without the use of a protected
capability (a function that operates on a shielded location) - the type
of thing that would only be possible by state actors. Setting a higher
entropy PIN or passhprase doesn't help here, because the TPM just asserts
that the supplied PIN or passphrase is correct - it doesn't provide any
additional key material required for unsealing the disk encryption key,
and the PIN is stored inside the TPM's NV memory too. All of the key
material required to unlock an encrypted volume lives on the device.

In the future, we may want to support a network unlocking feature, where a
trusted server can work with the existing TPM protected key object to
authorize disk unlocking as long as the device is physically attached to
a specific network. An implementation of this should require that the
trusted server contributes key material required to unlock an encrypted
volume, but this doesn't fit well with the current design.

Some use cases for network unlocking are:
- Preventing automatic unlocking of devices that are detached from a
specific network (ie, if they are stolen).
- Bypassing the requirement for a PIN in enterprise environments when
devices are physically attached to a corporate network (where a PIN is
required when the device isn't physically attached to it).

This commit changes how the PIN is used to protect a key in order to
improve this.

During SealKeyToTPM, rather than sealing the disk encryption key (DEK) to
the TPM, it now:
- Generates an intermediate key (IK).
- Encrypts DEK with IK and an initialization vector (DEKiv) to produce
DEKenc.
- Seals DEKenc to the TPM.
- Passes IK through a AF splitter to produce IKsplit.
- Saves DEKiv and IKsplit to the metadata of the sealed key object.

During unsealing when a PIN hasn't been set, the following happens:
- The TPM unseals DEKenc if the PCR values match the PCR policy.
- IKsplit is merged to recreate IK.
- DEKiv and IK are used to decrypt DEKenc to recover DEK.

When a PIN is set, the following happens:
- The PIN and a salt are passed through Argon2i to create a derived key
(DK).
- The upper 32-bits of DK are used for the authorization value of the
associated NV index on the TPM, which is updated accordingly.
- The lower 32-bits of DK are used with an initialization vector (IKiv) to
encrypt IKsplit.
- The encrypted IKsplit is written to the sealed key object metadata,
replacing the unencrypted version.
- The salt and IKiv are also written to the sealed key object metadata.

Unsealing with a PIN looks like this:
- The supplied PIN and a salt are passed through Argon2i to create a
derived key (DK).
- The TPM unseals DEKenc if the PCR values match the PCR policy and the
upper 32-bits of DK match the authorization value of the PIN NV index.
- The lower 32-bits of DK are used along with IKiv to decrypt IKsplit.
- The decrypted IKsplit is merged to recreate IK.
- DEKiv and IK are used to decrypt DEKenc to recover DEK.

This scheme retains the property that low-entropy PINs provide some
protection of data against most determined attackers, because it still
relies on the TPM asserting knowledge of the correct PIN before unsealing
the encrypted DEK, and this benefits from the TPM's dictionary attack
protection. Also, without a compromise of the TPM hardware, the most
recently set PIN is always required in order to unlock a volume, even if
an attacker has a backup of a sealed key data file with an IK encrypted
with a previous PIN.

This scheme should be more suitable for incorporating a network unlock
feature in the future, where IK can be protected with the public key of
a trusted device on the local network (an assertion signed by the network
server's private key would probably also be require to allow the encrypted
DEK to be unsealed from the TPM).