### PR TITLE
Don't create a transient EK in ConnectToDefaultTPM

### DIFF
--- a/tpm.go
+++ b/tpm.go
@@ -204,8 +204,10 @@ func (t *TPMConnection) init() error {
 	t.ek = nil
 	t.provisionedSrk = nil
 
+	secureMode := len(t.verifiedEkCertChain) > 0
+
 	// Acquire an unverified ResourceContext for the EK. If there is no object at the persistent EK index, then attempt to create
-	// a transient EK with the supplied authorization.
+	// a transient EK with the supplied authorization if this is a secure connection.
 	//
 	// Under the hood, go-tpm2 initializes the ResourceContext with TPM2_ReadPublic (or TPM2_CreatePrimary if we create a new one),
 	// and it cross-checks that the returned name and public area match. The returned name is available via ek.Name and the
@@ -217,7 +219,7 @@ func (t *TPMConnection) init() error {
 		if err == nil {
 			return ek, nil
 		}
-		if !tpm2.IsResourceUnavailableError(err, ekHandle) {
+		if !tpm2.IsResourceUnavailableError(err, ekHandle) || !secureMode {
 			return nil, err
 		}
 		if ek, err := createTransientEk(t.TPMContext); err == nil {
@@ -225,30 +227,31 @@ func (t *TPMConnection) init() error {
 		}
 		return nil, err
 	}()
-	if err != nil && len(t.verifiedEkCertChain) > 0 {
+	if err != nil && secureMode {
 		// A lack of EK should be fatal in this context
 		return xerrors.Errorf("cannot obtain context for EK: %w", err)
 	}
 
-	ekIsPersistent := false
-	if ek != nil {
-		if ek.Handle().Type() == tpm2.HandleTypeTransient {
-			defer t.FlushContext(ek)
-		} else {
-			ekIsPersistent = true
+	defer func() {
+		if ek == nil {
+			return
 		}
-	}
+		if ek.Handle() == ekHandle {
+			return
+		}
+		t.FlushContext(ek)
+	}()
 
-	if len(t.verifiedEkCertChain) > 0 {
+	if secureMode {
 		// Verify that ek is associated with the verified EK certificate. If the first attempt fails and ek references a persistent
 		// object, then try to create a transient EK with the provided authorization and make another attempt at verification, in case
 		// the persistent object isn't a valid EK.
 		rc, err := func() (tpm2.ResourceContext, error) {
 			err := verifyEk(t.verifiedEkCertChain[0], ek)
 			if err == nil {
-				return ek, nil
+				return nil, nil
 			}
-			if ek.Handle().Type() == tpm2.HandleTypeTransient {
+			if ek.Handle() != ekHandle {
 				// If this was already a transient EK, fail now
 				return nil, err
 			}
@@ -265,25 +268,17 @@ func (t *TPMConnection) init() error {
 		if err != nil {
 			return verificationError{xerrors.Errorf("cannot verify public area of endorsement key read from the TPM: %w", err)}
 		}
-		if ekIsPersistent && rc.Handle().Type() == tpm2.HandleTypeTransient {
+		if rc != nil {
 			// The persistent EK was bad, and we created and verified a transient EK instead
-			defer t.FlushContext(rc)
-			ekIsPersistent = false
+			ek = rc
 		}
-		ek = rc
-	} else if ekIsPersistent {
+	} else if ek != nil {
 		// If we don't have a verified EK certificate and ek is a persistent object, just do a sanity check that the public area returned
-		// from the TPM has the expected properties. If it doesn't, then attempt to create a transient EK with the provided authorization
-		// value.
+		// from the TPM has the expected properties. If it doesn't, then don't use it, as TPM2_StartAuthSession might fail.
 		if ok, err := isObjectPrimaryKeyWithTemplate(t.TPMContext, t.EndorsementHandleContext(), ek, ekTemplate, nil); err != nil {
 			return xerrors.Errorf("cannot determine if object is a primary key in the endorsement hierarchy: %w", err)
 		} else if !ok {
-			transientEk, err := createTransientEk(t.TPMContext)
-			if err == nil {
-				defer t.FlushContext(transientEk)
-			}
-			ekIsPersistent = false
-			ek = transientEk
+			ek = nil
 		}
 	}
 
@@ -319,7 +314,7 @@ func (t *TPMConnection) init() error {
 
 	succeeded = true
 
-	if ekIsPersistent {
+	if ek != nil && ek.Handle() == ekHandle {
 		t.ek = ek
 	}
 	t.hmacSession = session
@@ -875,7 +870,8 @@ func ConnectToDefaultTPM() (*TPMConnection, error) {
 // executed yet), this function will attempt to create a transient endorsement key. This requires knowledge of the endorsement
 // hierarchy authorization value, provided via the endorsementAuth argument, The endorsement hierarchy authorization value will be
 // empty on a newly cleared device. If there is no valid persistent endorsement key and creation of a transient endorsement key fails,
-// ErrTPMProvisioning will be returned.
+// ErrTPMProvisioning will be returned. Note that creation of a transient endorsement key may take a long time on some TPMs (in excess
+// of 10 seconds).
 //
 // If the TPM cannot prove it is the device for which the endorsement key certificate was issued, a TPMVerificationError error will be
 // returned. This can happen if there is an object at the persistent endorsement key index but it is not the object for which the

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -472,21 +472,6 @@ func TestConnectToDefaultTPM(t *testing.T) {
 
 		run(t, false, nil)
 	})
-
-	t.Run("UnprovisionedWithEndorsementAuth", func(t *testing.T) {
-		testAuth := []byte("foo")
-		func() {
-			tpm := connectAndClear(t)
-			defer closeTPM(t, tpm)
-			if err := tpm.HierarchyChangeAuth(tpm.EndorsementHandleContext(), testAuth, nil); err != nil {
-				t.Fatalf("HierarchyChangeAuth failed: %v", err)
-			}
-		}()
-
-		run(t, false, func(tpm *TPMConnection) {
-			clearTPMWithPlatformAuth(t, tpm)
-		})
-	})
 }
 
 func TestSecureConnectToDefaultTPM(t *testing.T) {


### PR DESCRIPTION
If the TPM doesn't have a persistent endorsement key, both
ConnectToDefaultTPM and SecureConnectToDefaultTPM try to create a
transient one. RSA key creation on hardware TPMs is quite slow (in
excess of 10 seconds), so don't do this inside ConnectToDefaultTPM.