### PR TITLE
Make it easier to bump the metadata version

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -30,12 +30,13 @@ import (
 
 // Export constants for testing
 const (
-	EkCertHandle        = ekCertHandle
-	EkHandle            = ekHandle
-	LockNVDataHandle    = lockNVDataHandle
-	LockNVHandle        = lockNVHandle
-	SanDirectoryNameTag = sanDirectoryNameTag
-	SrkHandle           = srkHandle
+	CurrentMetadataVersion = currentMetadataVersion
+	EkCertHandle           = ekCertHandle
+	EkHandle               = ekHandle
+	LockNVDataHandle       = lockNVDataHandle
+	LockNVHandle           = lockNVHandle
+	SanDirectoryNameTag    = sanDirectoryNameTag
+	SrkHandle              = srkHandle
 )
 
 // Export variables and unexported functions for testing
@@ -262,6 +263,6 @@ func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile, privateFile string, sess
 		pf = f
 	}
 
-	_, _, _, err = readAndValidateKeyData(tpm, kf, pf, session)
+	_, _, _, err = decodeAndValidateKeyData(tpm, kf, pf, session)
 	return err
 }

--- a/keydata.go
+++ b/keydata.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	currentVersion            uint32 = 0
+	currentMetadataVersion    uint32 = 0
 	keyDataHeader             uint32 = 0x55534b24
 	keyPolicyUpdateDataHeader uint32 = 0x55534b50
 )
@@ -51,95 +51,172 @@ const (
 	AuthModePIN
 )
 
+type keyPolicyUpdateDataRaw_v0 struct {
+	AuthKey        []byte
+	CreationData   *tpm2.CreationData
+	CreationTicket *tpm2.TkCreation
+}
+
 // keyPolicyUpdateData corresponds to the private part of a sealed key object that is required in order to create new dynamic
 // authorization policies.
 type keyPolicyUpdateData struct {
-	Data struct {
-		AuthKey []byte
+	version        uint32
+	authKey        *rsa.PrivateKey
+	creationInfo   tpm2.Data
+	creationData   *tpm2.CreationData
+	creationTicket *tpm2.TkCreation
+}
+
+func (d *keyPolicyUpdateData) Marshal(w io.Writer) (nbytes int, err error) {
+	raw := &keyPolicyUpdateDataRaw_v0{
+		AuthKey:        x509.MarshalPKCS1PrivateKey(d.authKey),
+		CreationData:   d.creationData,
+		CreationTicket: d.creationTicket}
+	return tpm2.MarshalToWriter(w, d.version, raw)
+}
+
+func (d *keyPolicyUpdateData) Unmarshal(r io.Reader) (nbytes int, err error) {
+	var version uint32
+	n, err := tpm2.UnmarshalFromReader(r, &version)
+	nbytes += n
+	if err != nil {
+		return nbytes, xerrors.Errorf("cannot unmarshal version number: %w", err)
 	}
-	CreationData   *tpm2.CreationData
-	CreationTicket *tpm2.TkCreation
+
+	switch version {
+	case 0:
+		var raw keyPolicyUpdateDataRaw_v0
+		n, err := tpm2.UnmarshalFromReader(r, &raw)
+		nbytes += n
+		if err != nil {
+			return nbytes, xerrors.Errorf("cannot unmarshal data: %w", err)
+		}
+
+		authKey, err := x509.ParsePKCS1PrivateKey(raw.AuthKey)
+		if err != nil {
+			return nbytes, xerrors.Errorf("cannot parse dynamic authorization policy signing key: %w", err)
+		}
+
+		h := crypto.SHA256.New()
+		if _, err := tpm2.MarshalToWriter(h, raw.AuthKey); err != nil {
+			panic(fmt.Sprintf("cannot marshal dynamic authorization policy signing key: %v", err))
+		}
+
+		*d = keyPolicyUpdateData{
+			version:        0,
+			authKey:        authKey,
+			creationInfo:   h.Sum(nil),
+			creationData:   raw.CreationData,
+			creationTicket: raw.CreationTicket}
+	default:
+		return nbytes, fmt.Errorf("unexpected version number (%d)", version)
+	}
+	return
+}
+
+// write serializes keyPolicyUpdateData to the provided io.Writer.
+func (d *keyPolicyUpdateData) write(buf io.Writer) error {
+	if d.version != currentMetadataVersion {
+		return errors.New("writing old metadata versions is not supported")
+	}
+
+	if _, err := tpm2.MarshalToWriter(buf, keyPolicyUpdateDataHeader, d); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// decodeKeyPolicyUpdateData deserializes keyPolicyUpdateData from the provided io.Reader.
+func decodeKeyPolicyUpdateData(r io.Reader) (*keyPolicyUpdateData, error) {
+	var header uint32
+	if _, err := tpm2.UnmarshalFromReader(r, &header); err != nil {
+		return nil, xerrors.Errorf("cannot unmarshal header: %w", err)
+	}
+	if header != keyPolicyUpdateDataHeader {
+		return nil, fmt.Errorf("unexpected header (%d)", header)
+	}
+
+	var d keyPolicyUpdateData
+	if _, err := tpm2.UnmarshalFromReader(r, &d); err != nil {
+		return nil, xerrors.Errorf("cannot unmarshal data: %w", err)
+	}
+
+	return &d, nil
+}
+
+type keyDataRaw_v0 struct {
+	KeyPrivate        tpm2.Private
+	KeyPublic         *tpm2.Public
+	AuthModeHint      AuthMode
+	StaticPolicyData  *staticPolicyDataRaw_v0
+	DynamicPolicyData *dynamicPolicyDataRaw_v0
 }
 
 // keyData corresponds to the part of a sealed key object that contains the TPM sealed object and associated metadata required
 // for executing authorization policy assertions.
 type keyData struct {
-	KeyPrivate        tpm2.Private
-	KeyPublic         *tpm2.Public
-	AuthModeHint      AuthMode
-	StaticPolicyData  *staticPolicyData
-	DynamicPolicyData *dynamicPolicyData
+	version           uint32
+	keyPrivate        tpm2.Private
+	keyPublic         *tpm2.Public
+	authModeHint      AuthMode
+	staticPolicyData  *staticPolicyData
+	dynamicPolicyData *dynamicPolicyData
 }
 
-// readKeyPolicyUpdateData deserializes keyPolicyUpdateData from the provided io.Reader.
-func readKeyPolicyUpdateData(buf io.Reader) (*keyPolicyUpdateData, error) {
-	var header uint32
+func (d *keyData) Marshal(w io.Writer) (nbytes int, err error) {
+	n, err := tpm2.MarshalToWriter(w, d.version)
+	nbytes += n
+	if err != nil {
+		return nbytes, xerrors.Errorf("cannot marshal version number: %w", err)
+	}
+
+	switch d.version {
+	case 0:
+		raw := keyDataRaw_v0{
+			KeyPrivate:        d.keyPrivate,
+			KeyPublic:         d.keyPublic,
+			AuthModeHint:      d.authModeHint,
+			StaticPolicyData:  makeStaticPolicyDataRaw_v0(d.staticPolicyData),
+			DynamicPolicyData: makeDynamicPolicyDataRaw_v0(d.dynamicPolicyData)}
+		n, err := tpm2.MarshalToWriter(w, raw)
+		nbytes += n
+		if err != nil {
+			return nbytes, xerrors.Errorf("cannot marshal raw data: %w", err)
+		}
+	default:
+		return nbytes, fmt.Errorf("unexpected version number (%d)", d.version)
+	}
+	return
+}
+
+func (d *keyData) Unmarshal(r io.Reader) (nbytes int, err error) {
 	var version uint32
-	if _, err := tpm2.UnmarshalFromReader(buf, &header, &version); err != nil {
-		return nil, xerrors.Errorf("cannot unmarshal header and version number: %w", err)
+	n, err := tpm2.UnmarshalFromReader(r, &version)
+	nbytes += n
+	if err != nil {
+		return nbytes, xerrors.Errorf("cannot unmarshal version number: %w", err)
 	}
 
-	if header != keyPolicyUpdateDataHeader {
-		return nil, fmt.Errorf("unexpected header (%d)", header)
+	switch version {
+	case 0:
+		var raw keyDataRaw_v0
+		n, err := tpm2.UnmarshalFromReader(r, &raw)
+		nbytes += n
+		if err != nil {
+			return nbytes, xerrors.Errorf("cannot unmarshal data: %w", err)
+		}
+		*d = keyData{
+			version:           0,
+			keyPrivate:        raw.KeyPrivate,
+			keyPublic:         raw.KeyPublic,
+			authModeHint:      raw.AuthModeHint,
+			staticPolicyData:  raw.StaticPolicyData.data(),
+			dynamicPolicyData: raw.DynamicPolicyData.data()}
+	default:
+		return nbytes, fmt.Errorf("unexpected version number (%d)", version)
 	}
-	if version != currentVersion {
-		return nil, fmt.Errorf("unexpected version number (%d)", version)
-	}
-
-	var d keyPolicyUpdateData
-	if _, err := tpm2.UnmarshalFromReader(buf, &d); err != nil {
-		return nil, xerrors.Errorf("cannot unmarshal key data: %w", err)
-	}
-
-	return &d, nil
-}
-
-// write serializes keyPolicyUpdateData to the provided io.Writer.
-func (d *keyPolicyUpdateData) write(buf io.Writer) error {
-	if _, err := tpm2.MarshalToWriter(buf, keyPolicyUpdateDataHeader, currentVersion, d); err != nil {
-		return err
-	}
-	return nil
-}
-
-type keyFileError struct {
-	err error
-}
-
-func (e keyFileError) Error() string {
-	return e.err.Error()
-}
-
-func (e keyFileError) Unwrap() error {
-	return e.err
-}
-
-func isKeyFileError(err error) bool {
-	var e keyFileError
-	return xerrors.As(err, &e)
-}
-
-// readKeyData deserializes keyData from the provided io.Reader.
-func readKeyData(buf io.Reader) (*keyData, error) {
-	var header uint32
-	var version uint32
-	if _, err := tpm2.UnmarshalFromReader(buf, &header, &version); err != nil {
-		return nil, keyFileError{xerrors.Errorf("cannot unmarshal header and version number: %w", err)}
-	}
-
-	if header != keyDataHeader {
-		return nil, keyFileError{fmt.Errorf("unexpected header (%d)", header)}
-	}
-	if version != currentVersion {
-		return nil, keyFileError{fmt.Errorf("unexpected version number (%d)", version)}
-	}
-
-	var d keyData
-	if _, err := tpm2.UnmarshalFromReader(buf, &d); err != nil {
-		return nil, keyFileError{xerrors.Errorf("cannot unmarshal key data: %w", err)}
-	}
-
-	return &d, nil
+	return
 }
 
 // load loads the TPM sealed object associated with this keyData in to the storage hierarchy of the TPM, and returns the newly
@@ -150,7 +227,7 @@ func (d *keyData) load(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.
 		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
 	}
 
-	keyContext, err := tpm.Load(srkContext, d.KeyPrivate, d.KeyPublic, session)
+	keyContext, err := tpm.Load(srkContext, d.keyPrivate, d.keyPublic, session)
 	if err != nil {
 		invalidObject := false
 		switch {
@@ -168,36 +245,9 @@ func (d *keyData) load(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.
 	return keyContext, nil
 }
 
-// write serializes keyData in to the provided io.Writer.
-func (d *keyData) write(buf io.Writer) error {
-	if _, err := tpm2.MarshalToWriter(buf, keyDataHeader, currentVersion, d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// writeToFileAtomic serializes keyData and writes it atomically to the file at the specified path.
-func (d *keyData) writeToFileAtomic(dest string) error {
-	f, err := osutil.NewAtomicFile(dest, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
-	if err != nil {
-		return xerrors.Errorf("cannot create new atomic file: %w", err)
-	}
-	defer f.Cancel()
-
-	if _, err := tpm2.MarshalToWriter(f, keyDataHeader, currentVersion, d); err != nil {
-		return xerrors.Errorf("cannot marshal key data to temporary file: %w", err)
-	}
-
-	if err := f.Commit(); err != nil {
-		return xerrors.Errorf("cannot atomically replace file: %w", err)
-	}
-
-	return nil
-}
-
-// validateKeyData performs some correctness checking on the provided keyData and keyPolicyUpdateData. On success, it returns the validated
+// validate performs some correctness checking on the provided keyData and keyPolicyUpdateData. On success, it returns the validated
 // public area for the PIN NV index.
-func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyPolicyUpdateData, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
+func (d *keyData) validate(tpm *tpm2.TPMContext, policyUpdateData *keyPolicyUpdateData, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
 	srkContext, err := tpm.CreateResourceContextFromTPM(srkHandle)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
@@ -205,16 +255,18 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 
 	sealedKeyTemplate := makeSealedKeyTemplate()
 
+	keyPublic := d.keyPublic
+
 	// Perform some initial checks on the sealed data object's public area
-	if data.KeyPublic.Type != sealedKeyTemplate.Type {
+	if keyPublic.Type != sealedKeyTemplate.Type {
 		return nil, keyFileError{errors.New("sealed key object has the wrong type")}
 	}
-	if data.KeyPublic.Attrs != sealedKeyTemplate.Attrs {
+	if keyPublic.Attrs != sealedKeyTemplate.Attrs {
 		return nil, keyFileError{errors.New("sealed key object has the wrong attributes")}
 	}
 
 	// Load the sealed data object in to the TPM for integrity checking
-	keyContext, err := tpm.Load(srkContext, data.KeyPrivate, data.KeyPublic, session)
+	keyContext, err := tpm.Load(srkContext, d.keyPrivate, keyPublic, session)
 	if err != nil {
 		invalidObject := false
 		switch {
@@ -246,27 +298,29 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 	// Obtain a ResourceContext for the PIN NV index. Go-tpm2 calls TPM2_NV_ReadPublic twice here. The second time is with a session, and
 	// there is also verification that the returned public area is for the specified handle so that we know that the returned
 	// ResourceContext corresponds to an actual entity on the TPM at PinIndexHandle.
-	if data.StaticPolicyData.PinIndexHandle.Type() != tpm2.HandleTypeNVIndex {
+	pinIndexHandle := d.staticPolicyData.PinIndexHandle
+	if pinIndexHandle.Type() != tpm2.HandleTypeNVIndex {
 		return nil, keyFileError{errors.New("PIN NV index handle is invalid")}
 	}
-	pinIndex, err := tpm.CreateResourceContextFromTPM(data.StaticPolicyData.PinIndexHandle, session.IncludeAttrs(tpm2.AttrAudit))
+	pinIndex, err := tpm.CreateResourceContextFromTPM(pinIndexHandle, session.IncludeAttrs(tpm2.AttrAudit))
 	if err != nil {
-		if tpm2.IsResourceUnavailableError(err, data.StaticPolicyData.PinIndexHandle) {
+		if tpm2.IsResourceUnavailableError(err, pinIndexHandle) {
 			return nil, keyFileError{errors.New("PIN NV index is unavailable")}
 		}
 		return nil, xerrors.Errorf("cannot create context for PIN NV index: %w", err)
 	}
 
-	authKeyName, err := data.StaticPolicyData.AuthPublicKey.Name()
+	authPublicKey := d.staticPolicyData.AuthPublicKey
+	authKeyName, err := authPublicKey.Name()
 	if err != nil {
 		return nil, keyFileError{xerrors.Errorf("cannot compute name of dynamic authorization policy key: %w", err)}
 	}
-	if data.StaticPolicyData.AuthPublicKey.Type != tpm2.ObjectTypeRSA {
+	if authPublicKey.Type != tpm2.ObjectTypeRSA {
 		return nil, keyFileError{errors.New("public area of dynamic authorization policy signing key has the wrong type")}
 	}
 
 	// Make sure that the static authorization policy data is consistent with the sealed key object's policy.
-	trial, err := tpm2.ComputeAuthPolicy(data.KeyPublic.NameAlg)
+	trial, err := tpm2.ComputeAuthPolicy(keyPublic.NameAlg)
 	if err != nil {
 		return nil, keyFileError{xerrors.Errorf("cannot determine if static authorization policy matches sealed key object: %w", err)}
 	}
@@ -274,7 +328,7 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 	trial.PolicySecret(pinIndex.Name(), nil)
 	trial.PolicyNV(lockIndex.Name(), nil, 0, tpm2.OpEq)
 
-	if !bytes.Equal(trial.GetDigest(), data.KeyPublic.AuthPolicy) {
+	if !bytes.Equal(trial.GetDigest(), keyPublic.AuthPolicy) {
 		return nil, keyFileError{errors.New("the sealed key object's authorization policy is inconsistent with the associatedc metadata or persistent TPM resources")}
 	}
 
@@ -283,21 +337,22 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 		return nil, xerrors.Errorf("cannot read public area of PIN NV index: %w", err)
 	}
 
+	pinIndexAuthPolicies := d.staticPolicyData.PinIndexAuthPolicies
 	expectedPinIndexAuthPolicies, err := computePinNVIndexPostInitAuthPolicies(pinIndexPublic.NameAlg, authKeyName)
 	if err != nil {
 		return nil, keyFileError{xerrors.Errorf("cannot determine if PIN NV index has a valid authorization policy: %w", err)}
 	}
-	if len(data.StaticPolicyData.PinIndexAuthPolicies)-1 != len(expectedPinIndexAuthPolicies) {
+	if len(pinIndexAuthPolicies)-1 != len(expectedPinIndexAuthPolicies) {
 		return nil, keyFileError{errors.New("unexpected number of OR policy digests for PIN NV index")}
 	}
 	for i, expected := range expectedPinIndexAuthPolicies {
-		if !bytes.Equal(expected, data.StaticPolicyData.PinIndexAuthPolicies[i+1]) {
+		if !bytes.Equal(expected, pinIndexAuthPolicies[i+1]) {
 			return nil, keyFileError{errors.New("unexpected OR policy digest for PIN NV index")}
 		}
 	}
 
 	trial, _ = tpm2.ComputeAuthPolicy(pinIndexPublic.NameAlg)
-	trial.PolicyOR(data.StaticPolicyData.PinIndexAuthPolicies)
+	trial.PolicyOR(pinIndexAuthPolicies)
 	if !bytes.Equal(pinIndexPublic.AuthPolicy, trial.GetDigest()) {
 		return nil, keyFileError{errors.New("PIN NV index has unexpected authorization policy")}
 	}
@@ -311,12 +366,12 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 	}
 
 	// Verify that the private data structure is bound to the key data structure.
-	h := data.KeyPublic.NameAlg.NewHash()
-	if _, err := tpm2.MarshalToWriter(h, policyUpdateData.CreationData); err != nil {
+	h := keyPublic.NameAlg.NewHash()
+	if _, err := tpm2.MarshalToWriter(h, policyUpdateData.creationData); err != nil {
 		panic(fmt.Sprintf("cannot marshal creation data: %v", err))
 	}
 
-	if _, _, err := tpm.CertifyCreation(nil, keyContext, nil, h.Sum(nil), nil, policyUpdateData.CreationTicket, nil,
+	if _, _, err := tpm.CertifyCreation(nil, keyContext, nil, h.Sum(nil), nil, policyUpdateData.creationTicket, nil,
 		session.IncludeAttrs(tpm2.AttrAudit)); err != nil {
 		if tpm2.IsTPMParameterError(err, tpm2.ErrorTicket, tpm2.CommandCertifyCreation, 4) {
 			return nil, keyFileError{errors.New("key data file and dynamic authorization policy update data file mismatch: invalid creation ticket")}
@@ -324,49 +379,102 @@ func validateKeyData(tpm *tpm2.TPMContext, data *keyData, policyUpdateData *keyP
 		return nil, xerrors.Errorf("cannot validate creation data for sealed data object: %w", err)
 	}
 
-	h = crypto.SHA256.New()
-	if _, err := tpm2.MarshalToWriter(h, &policyUpdateData.Data); err != nil {
-		panic(fmt.Sprintf("cannot marshal dynamic authorization policy update data: %v", err))
-	}
-
-	if !bytes.Equal(h.Sum(nil), policyUpdateData.CreationData.OutsideInfo) {
+	if !bytes.Equal(policyUpdateData.creationInfo, policyUpdateData.creationData.OutsideInfo) {
 		return nil, keyFileError{errors.New("key data file and dynamic authorization policy update data file mismatch: digest doesn't match creation data")}
 	}
 
-	authKey, err := x509.ParsePKCS1PrivateKey(policyUpdateData.Data.AuthKey)
-	if err != nil {
-		return nil, keyFileError{xerrors.Errorf("cannot parse dynamic authorization policy signing key: %w", err)}
-	}
-
-	authPublicKey := rsa.PublicKey{
-		N: new(big.Int).SetBytes(data.StaticPolicyData.AuthPublicKey.Unique.RSA()),
-		E: int(data.StaticPolicyData.AuthPublicKey.Params.RSADetail().Exponent)}
-	if authKey.PublicKey.E != authPublicKey.E || authKey.PublicKey.N.Cmp(authPublicKey.N) != 0 {
+	authKey := policyUpdateData.authKey
+	goAuthPublicKey := rsa.PublicKey{
+		N: new(big.Int).SetBytes(authPublicKey.Unique.RSA()),
+		E: int(authPublicKey.Params.RSADetail().Exponent)}
+	if authKey.E != goAuthPublicKey.E || authKey.N.Cmp(goAuthPublicKey.N) != 0 {
 		return nil, keyFileError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
 	}
 
 	return pinIndexPublic, nil
 }
 
-// readAndValidateKeyData will deserialize keyData and keyPolicyUpdateData from the provided io.Readers and then perform some correctness
-// checking. On success, it returns the keyData, keyPolicyUpdateData and the validated public area of the PIN NV index.
-func readAndValidateKeyData(tpm *tpm2.TPMContext, keyFile, keyPolicyUpdateFile io.Reader, session tpm2.SessionContext) (*keyData, *keyPolicyUpdateData, *tpm2.NVPublic, error) {
-	// Read the key data
-	data, err := readKeyData(keyFile)
+// write serializes keyData in to the provided io.Writer.
+func (d *keyData) write(w io.Writer) error {
+	if _, err := tpm2.MarshalToWriter(w, keyDataHeader, d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeToFileAtomic serializes keyData and writes it atomically to the file at the specified path.
+func (d *keyData) writeToFileAtomic(dest string) error {
+	f, err := osutil.NewAtomicFile(dest, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
 	if err != nil {
-		return nil, nil, nil, xerrors.Errorf("cannot read key data: %w", err)
+		return xerrors.Errorf("cannot create new atomic file: %w", err)
+	}
+	defer f.Cancel()
+
+	if err := d.write(f); err != nil {
+		return xerrors.Errorf("cannot write to temporary file: %w", err)
+	}
+
+	if err := f.Commit(); err != nil {
+		return xerrors.Errorf("cannot atomically replace file: %w", err)
+	}
+
+	return nil
+}
+
+// decodeKeyData deserializes keyData from the provided io.Reader.
+func decodeKeyData(r io.Reader) (*keyData, error) {
+	var header uint32
+	if _, err := tpm2.UnmarshalFromReader(r, &header); err != nil {
+		return nil, xerrors.Errorf("cannot unmarshal header: %w", err)
+	}
+	if header != keyDataHeader {
+		return nil, fmt.Errorf("unexpected header (%d)", header)
+	}
+
+	var d keyData
+	if _, err := tpm2.UnmarshalFromReader(r, &d); err != nil {
+		return nil, xerrors.Errorf("cannot unmarshal data: %w", err)
+	}
+
+	return &d, nil
+}
+
+type keyFileError struct {
+	err error
+}
+
+func (e keyFileError) Error() string {
+	return e.err.Error()
+}
+
+func (e keyFileError) Unwrap() error {
+	return e.err
+}
+
+func isKeyFileError(err error) bool {
+	var e keyFileError
+	return xerrors.As(err, &e)
+}
+
+// decodeAndValidateKeyData will deserialize keyData and keyPolicyUpdateData from the provided io.Readers and then perform some correctness
+// checking. On success, it returns the keyData, keyPolicyUpdateData and the validated public area of the PIN NV index.
+func decodeAndValidateKeyData(tpm *tpm2.TPMContext, keyFile, keyPolicyUpdateFile io.Reader, session tpm2.SessionContext) (*keyData, *keyPolicyUpdateData, *tpm2.NVPublic, error) {
+	// Read the key data
+	data, err := decodeKeyData(keyFile)
+	if err != nil {
+		return nil, nil, nil, keyFileError{xerrors.Errorf("cannot read key data: %w", err)}
 	}
 
 	var policyUpdateData *keyPolicyUpdateData
 	if keyPolicyUpdateFile != nil {
 		var err error
-		policyUpdateData, err = readKeyPolicyUpdateData(keyPolicyUpdateFile)
+		policyUpdateData, err = decodeKeyPolicyUpdateData(keyPolicyUpdateFile)
 		if err != nil {
-			return nil, nil, nil, xerrors.Errorf("cannot read dynamic policy authorization data: %w", err)
+			return nil, nil, nil, keyFileError{xerrors.Errorf("cannot read dynamic policy update data: %w", err)}
 		}
 	}
 
-	pinNVPublic, err := validateKeyData(tpm, data, policyUpdateData, session)
+	pinNVPublic, err := data.validate(tpm, policyUpdateData, session)
 	if err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot validate key data: %w", err)
 	}
@@ -382,12 +490,12 @@ type SealedKeyObject struct {
 
 // AuthMode2F indicates the 2nd-factor authentication type for this sealed key object.
 func (k *SealedKeyObject) AuthMode2F() AuthMode {
-	return k.data.AuthModeHint
+	return k.data.authModeHint
 }
 
 // PINIndexHandle indicates the handle of the NV index used for PIN support for this sealed key object.
 func (k *SealedKeyObject) PINIndexHandle() tpm2.Handle {
-	return k.data.StaticPolicyData.PinIndexHandle
+	return k.data.staticPolicyData.PinIndexHandle
 }
 
 // ReadSealedKeyObject loads a sealed key data file created by SealKeyToTPM from the specified path. If the file cannot be opened,
@@ -401,7 +509,7 @@ func ReadSealedKeyObject(path string) (*SealedKeyObject, error) {
 	}
 	defer f.Close()
 
-	data, err := readKeyData(f)
+	data, err := decodeKeyData(f)
 	if err != nil {
 		return nil, InvalidKeyFileError{err.Error()}
 	}

--- a/keydata.go
+++ b/keydata.go
@@ -51,6 +51,7 @@ const (
 	AuthModePIN
 )
 
+// keyPolicyUpdateDataRaw_v0 is version 0 of the on-disk format of keyPolicyUpdateData.
 type keyPolicyUpdateDataRaw_v0 struct {
 	AuthKey        []byte
 	CreationData   *tpm2.CreationData
@@ -145,6 +146,7 @@ func decodeKeyPolicyUpdateData(r io.Reader) (*keyPolicyUpdateData, error) {
 	return &d, nil
 }
 
+// keyDataRaw_v0 is version 0 of the on-disk format of keyDataRaw.
 type keyDataRaw_v0 struct {
 	KeyPrivate        tpm2.Private
 	KeyPublic         *tpm2.Public

--- a/policy.go
+++ b/policy.go
@@ -67,6 +67,16 @@ type policyOrDataNode struct {
 
 type policyOrDataTree []policyOrDataNode
 
+type dynamicPolicyDataRaw_v0 dynamicPolicyData
+
+func (d *dynamicPolicyDataRaw_v0) data() *dynamicPolicyData {
+	return (*dynamicPolicyData)(d)
+}
+
+func makeDynamicPolicyDataRaw_v0(data *dynamicPolicyData) *dynamicPolicyDataRaw_v0 {
+	return (*dynamicPolicyDataRaw_v0)(data)
+}
+
 type dynamicPolicyData struct {
 	PCRSelection              tpm2.PCRSelectionList
 	PCROrData                 policyOrDataTree
@@ -81,6 +91,16 @@ type staticPolicyComputeParams struct {
 	pinIndexPub          *tpm2.NVPublic  // Public area of the NV index used for the PIN
 	pinIndexAuthPolicies tpm2.DigestList // Metadata for executing policy sessions to interact with the PIN NV index
 	lockIndexName        tpm2.Name       // Name of the global NV index for locking access to sealed key objects
+}
+
+type staticPolicyDataRaw_v0 staticPolicyData
+
+func (d *staticPolicyDataRaw_v0) data() *staticPolicyData {
+	return (*staticPolicyData)(d)
+}
+
+func makeStaticPolicyDataRaw_v0(data *staticPolicyData) *staticPolicyDataRaw_v0 {
+	return (*staticPolicyDataRaw_v0)(data)
 }
 
 // staticPolicyData is an output of computeStaticPolicy and provides metadata for executing a policy session.
@@ -565,7 +585,10 @@ func computePCRSelectionListFromValues(v tpm2.PCRValues) (out tpm2.PCRSelectionL
 
 // computeDynamicPolicy computes the part of an authorization policy associated with a sealed key object that can change and be
 // updated.
-func computeDynamicPolicy(alg tpm2.HashAlgorithmId, input *dynamicPolicyComputeParams) (*dynamicPolicyData, error) {
+func computeDynamicPolicy(version uint32, alg tpm2.HashAlgorithmId, input *dynamicPolicyComputeParams) (*dynamicPolicyData, error) {
+	if version != 0 {
+		return nil, errors.New("invalid version")
+	}
 	if len(input.pcrValues) == 0 {
 		return nil, errors.New("no PCR values specified")
 	}
@@ -724,12 +747,13 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 		return dynamicPolicyDataError{xerrors.Errorf("cannot complete OR assertions: %w", err)}
 	}
 
-	if staticInput.PinIndexHandle.Type() != tpm2.HandleTypeNVIndex {
+	pinIndexHandle := staticInput.PinIndexHandle
+	if pinIndexHandle.Type() != tpm2.HandleTypeNVIndex {
 		return staticPolicyDataError{errors.New("invalid handle type for PIN NV index")}
 	}
-	pinIndex, err := tpm.CreateResourceContextFromTPM(staticInput.PinIndexHandle)
+	pinIndex, err := tpm.CreateResourceContextFromTPM(pinIndexHandle)
 	switch {
-	case tpm2.IsResourceUnavailableError(err, staticInput.PinIndexHandle):
+	case tpm2.IsResourceUnavailableError(err, pinIndexHandle):
 		// If there is no NV index at the expected handle then the key file is invalid and must be recreated.
 		return staticPolicyDataError{errors.New("no PIN NV index found")}
 	case err != nil:
@@ -775,10 +799,11 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 		return xerrors.Errorf("dynamic authorization policy revocation check failed: %w", err)
 	}
 
-	if !staticInput.AuthPublicKey.NameAlg.Supported() {
+	authPublicKey := staticInput.AuthPublicKey
+	if !authPublicKey.NameAlg.Supported() {
 		return staticPolicyDataError{errors.New("public area of dynamic authorization policy signature verification key has an unsupported name algorithm")}
 	}
-	authorizeKey, err := tpm.LoadExternal(nil, staticInput.AuthPublicKey, tpm2.HandleOwner)
+	authorizeKey, err := tpm.LoadExternal(nil, authPublicKey, tpm2.HandleOwner)
 	if err != nil {
 		if tpm2.IsTPMParameterError(err, tpm2.AnyErrorCode, tpm2.CommandLoadExternal, 2) {
 			// staticInput.AuthPublicKey is invalid
@@ -788,7 +813,7 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 	}
 	defer tpm.FlushContext(authorizeKey)
 
-	h := staticInput.AuthPublicKey.NameAlg.NewHash()
+	h := authPublicKey.NameAlg.NewHash()
 	h.Write(dynamicInput.AuthorizedPolicy)
 
 	authorizeTicket, err := tpm.VerifySignature(authorizeKey, h.Sum(nil), dynamicInput.AuthorizedPolicySignature)

--- a/policy.go
+++ b/policy.go
@@ -67,22 +67,26 @@ type policyOrDataNode struct {
 
 type policyOrDataTree []policyOrDataNode
 
-type dynamicPolicyDataRaw_v0 dynamicPolicyData
-
-func (d *dynamicPolicyDataRaw_v0) data() *dynamicPolicyData {
-	return (*dynamicPolicyData)(d)
-}
-
-func makeDynamicPolicyDataRaw_v0(data *dynamicPolicyData) *dynamicPolicyDataRaw_v0 {
-	return (*dynamicPolicyDataRaw_v0)(data)
-}
-
+// dynamicPolicyData is an output of computeDynamicPolicy and provides metadata for executing a policy session.
 type dynamicPolicyData struct {
 	PCRSelection              tpm2.PCRSelectionList
 	PCROrData                 policyOrDataTree
 	PolicyCount               uint64
 	AuthorizedPolicy          tpm2.Digest
 	AuthorizedPolicySignature *tpm2.Signature
+}
+
+// dynamicPolicyDataRaw_v0 is version 0 of the on-disk format of dynamicPolicyData. They are currently the same structures.
+type dynamicPolicyDataRaw_v0 dynamicPolicyData
+
+func (d *dynamicPolicyDataRaw_v0) data() *dynamicPolicyData {
+	return (*dynamicPolicyData)(d)
+}
+
+// makeDynamicPolicyDataRaw_v0 converts dynamicPolicyData to version 0 of the on-disk format. They are currently the same structures
+// so this is just a cast, but this may not be the case if the metadata version changes in the future.
+func makeDynamicPolicyDataRaw_v0(data *dynamicPolicyData) *dynamicPolicyDataRaw_v0 {
+	return (*dynamicPolicyDataRaw_v0)(data)
 }
 
 // staticPolicyComputeParams provides the parameters to computeStaticPolicy.
@@ -93,21 +97,24 @@ type staticPolicyComputeParams struct {
 	lockIndexName        tpm2.Name       // Name of the global NV index for locking access to sealed key objects
 }
 
+// staticPolicyData is an output of computeStaticPolicy and provides metadata for executing a policy session.
+type staticPolicyData struct {
+	AuthPublicKey        *tpm2.Public
+	PinIndexHandle       tpm2.Handle
+	PinIndexAuthPolicies tpm2.DigestList
+}
+
+// staticPolicyDataRaw_v0 is the v0 version of the on-disk format of staticPolicyData. They are currently the same structures.
 type staticPolicyDataRaw_v0 staticPolicyData
 
 func (d *staticPolicyDataRaw_v0) data() *staticPolicyData {
 	return (*staticPolicyData)(d)
 }
 
+// makeStaticPolicyDataRaw_v0 converts staticPolicyData to version 0 of the on-disk format. They are currently the same structures
+// so this is just a cast, but this may not be the case if the metadata version changes in the future.
 func makeStaticPolicyDataRaw_v0(data *staticPolicyData) *staticPolicyDataRaw_v0 {
 	return (*staticPolicyDataRaw_v0)(data)
-}
-
-// staticPolicyData is an output of computeStaticPolicy and provides metadata for executing a policy session.
-type staticPolicyData struct {
-	AuthPublicKey        *tpm2.Public
-	PinIndexHandle       tpm2.Handle
-	PinIndexAuthPolicies tpm2.DigestList
 }
 
 // incrementDynamicPolicyCounter will increment the NV counter index associated with nvPublic. This is designed to operate on a

--- a/policy.go
+++ b/policy.go
@@ -593,6 +593,7 @@ func computePCRSelectionListFromValues(v tpm2.PCRValues) (out tpm2.PCRSelectionL
 // computeDynamicPolicy computes the part of an authorization policy associated with a sealed key object that can change and be
 // updated.
 func computeDynamicPolicy(version uint32, alg tpm2.HashAlgorithmId, input *dynamicPolicyComputeParams) (*dynamicPolicyData, error) {
+	// We only have a single metadata version at the moment (version 0)
 	if version != 0 {
 		return nil, errors.New("invalid version")
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -1129,7 +1129,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
-			dataout, err := ComputeDynamicPolicy(data.alg, NewDynamicPolicyComputeParams(key, data.signAlg, data.pcrValues, pinName, data.policyCount))
+			dataout, err := ComputeDynamicPolicy(CurrentMetadataVersion, data.alg, NewDynamicPolicyComputeParams(key, data.signAlg, data.pcrValues, pinName, data.policyCount))
 			if data.err == "" {
 				if err != nil {
 					t.Fatalf("ComputeDynamicPolicy failed: %v", err)
@@ -1241,7 +1241,7 @@ func TestExecutePolicy(t *testing.T) {
 			t.Fatalf("ComputeStaticPolicy failed: %v", err)
 		}
 		signAlg := staticPolicyData.AuthPublicKey.NameAlg
-		dynamicPolicyData, err := ComputeDynamicPolicy(data.alg, NewDynamicPolicyComputeParams(key, signAlg, data.pcrValues, pinIndex.Name(), data.policyCount))
+		dynamicPolicyData, err := ComputeDynamicPolicy(CurrentMetadataVersion, data.alg, NewDynamicPolicyComputeParams(key, signAlg, data.pcrValues, pinIndex.Name(), data.policyCount))
 		if err != nil {
 			t.Fatalf("ComputeDynamicPolicy failed: %v", err)
 		}
@@ -2505,7 +2505,7 @@ func TestLockAccessToSealedKeys(t *testing.T) {
 	}
 
 	signAlg := staticPolicyData.AuthPublicKey.NameAlg
-	dynamicPolicyData, err := ComputeDynamicPolicy(tpm2.HashAlgorithmSHA256,
+	dynamicPolicyData, err := ComputeDynamicPolicy(CurrentMetadataVersion, tpm2.HashAlgorithmSHA256,
 		NewDynamicPolicyComputeParams(key, signAlg, []tpm2.PCRValues{{tpm2.HashAlgorithmSHA256: {7: makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo")}}},
 			pinIndex.Name(), policyCount))
 	if err != nil {

--- a/unseal.go
+++ b/unseal.go
@@ -115,13 +115,13 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) ([]byte,
 	defer tpm.FlushContext(key)
 
 	// Begin and execute policy session
-	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, k.data.KeyPublic.NameAlg)
+	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, k.data.keyPublic.NameAlg)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot start policy session: %w", err)
 	}
 	defer tpm.FlushContext(policySession)
 
-	if err := executePolicySession(tpm.TPMContext, policySession, k.data.StaticPolicyData, k.data.DynamicPolicyData, pin, hmacSession); err != nil {
+	if err := executePolicySession(tpm.TPMContext, policySession, k.data.staticPolicyData, k.data.dynamicPolicyData, pin, hmacSession); err != nil {
 		err = xerrors.Errorf("cannot complete authorization policy assertions: %w", err)
 		switch {
 		case isDynamicPolicyDataError(err):


### PR DESCRIPTION
This splits keyData, keyPolicyUpdateData, staticPolicyData and
dynamicPolicyData in to version agnostic parts and version-specific
parts. The version-specific parts are what is marshalled / unmarshalled.