### PR TITLE
Make PCRProtectionProfile.computePCRValues non recursive

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -241,16 +241,12 @@ func NewStaticPolicyComputeParams(key *tpm2.Public, pinIndexPub *tpm2.NVPublic, 
 	return &staticPolicyComputeParams{key: key, pinIndexPub: pinIndexPub, pinIndexAuthPolicies: pinIndexAuthPolicies, lockIndexName: lockIndexName}
 }
 
-func (p *PCRProtectionProfile) ComputePCRValues(tpm *tpm2.TPMContext) ([]tpm2.PCRValues, error) {
-	return p.computePCRValues(tpm, nil)
-}
-
 func (p *PCRProtectionProfile) ComputePCRDigests(tpm *tpm2.TPMContext, alg tpm2.HashAlgorithmId) (tpm2.PCRSelectionList, tpm2.DigestList, error) {
 	return p.computePCRDigests(tpm, alg)
 }
 
 func (p *PCRProtectionProfile) DumpValues(tpm *tpm2.TPMContext) string {
-	values, err := p.computePCRValues(tpm, nil)
+	values, err := p.computePCRValues(tpm)
 	if err != nil {
 		return ""
 	}

--- a/pcr_profile.go
+++ b/pcr_profile.go
@@ -280,8 +280,6 @@ func (p *PCRProtectionProfile) computePCRValues(tpm *tpm2.TPMContext) (pcrValues
 			contexts = contexts.finishBranch()
 		}
 	}
-
-	panic("not reached")
 }
 
 // computePCRDigests computes a PCR selection and list of PCR digests from this PCRProtectionProfile. The returned list of PCR digests

--- a/pcr_profile.go
+++ b/pcr_profile.go
@@ -152,9 +152,7 @@ type pcrProtectionProfileIterator struct {
 func (iter *pcrProtectionProfileIterator) descendInToProfiles(profiles ...*PCRProtectionProfile) {
 	instrs := make([][]pcrProtectionProfileInstr, 0, len(profiles)+len(iter.instrs))
 	for _, p := range profiles {
-		pi := make([]pcrProtectionProfileInstr, len(p.instrs))
-		copy(pi, p.instrs)
-		instrs = append(instrs, pi)
+		instrs = append(instrs, p.instrs)
 	}
 	instrs = append(instrs, iter.instrs...)
 	iter.instrs = instrs


### PR DESCRIPTION
AddEFISecureBootPolicyProfile currently operates non-recursively. A
future PR will change the interaction between
AddEFISecureBootPolicyProfile and PCRProtectionProfile so that it
creates a profile using the methods of PCRProtectionProfile rather
than computing PCR values itself and adding them to the profile with
PCRProtectionProfile.AddPCRValue as it does now. This change will
preserve the property that computing a PCR profile for the secure
boot policy is non-recursive.