### PR TITLE
Don't panic when processing a profile with an empty branch

### DIFF
--- a/pcr_profile_test.go
+++ b/pcr_profile_test.go
@@ -302,6 +302,24 @@ func TestPCRProtectionProfile(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "EmptyProfileOR",
+			alg: tpm2.HashAlgorithmSHA256,
+			profile: func() *PCRProtectionProfile {
+				return NewPCRProtectionProfile().
+					AddPCRValue(tpm2.HashAlgorithmSHA256, 7, makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo")).
+					AddProfileOR().
+					AddPCRValue(tpm2.HashAlgorithmSHA256, 8, makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar"))
+			}(),
+			values: []tpm2.PCRValues{
+				{
+					tpm2.HashAlgorithmSHA256: {
+						7: makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "foo"),
+						8: makePCRDigestFromEvents(tpm2.HashAlgorithmSHA256, "bar"),
+					},
+				},
+			},
+		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
 			expectedPcrs := data.values[0].SelectionList()


### PR DESCRIPTION
Calling PCRProtectionProfile.AddProfileOR with no branches is pointless,
but it probably shouldn't result in a panic when computing PCR digests.
Handle this case gracefully by just omitting it from the profile.