### PR TITLE
Store the TPM simulator's persistent data in a temporary directory

### DIFF
--- a/tpm_test.go
+++ b/tpm_test.go
@@ -832,9 +832,9 @@ func TestMain(m *testing.M) {
 
 			tmpRoot := ""
 			if mssimSnapName != "" {
-				home, err := os.UserHomeDir()
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Cannot determine home directory: %v\n", err)
+				home := os.Getenv("HOME")
+				if home == "" {
+					fmt.Fprintf(os.Stderr, "Cannot determine home directory\n")
 					return 1
 				}
 				tmpRoot = snap.UserCommonDataDir(home, mssimSnapName)

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -838,6 +838,10 @@ func TestMain(m *testing.M) {
 					return 1
 				}
 				tmpRoot = snap.UserCommonDataDir(home, mssimSnapName)
+				if err := os.MkdirAll(tmpRoot, 0755); err != nil {
+					fmt.Fprintf(os.Stderr, "Cannot create snap common data dir: %v\n", err)
+					return 1
+				}
 			}
 
 			mssimTmpDir, err := ioutil.TempDir(tmpRoot, "secboot.mssim")


### PR DESCRIPTION
This creates a temporary directory for storing the TPM simulator's
persistent data. For the snap version of the TPM simulator, it uses the
snap's common data directory instead, because it has a private tmpdir in
which we can't create a temporary directory outside of the snap.

Once this code moves in internal/testutil, it will have the ability to
specify a location for the persistent data, so that the simulator can run
with pre-generated, checked-in data.