### PR TITLE
Simplify identifyInitialOSLaunchVerificationEvent

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -86,14 +86,10 @@ func (s *EFISignatureData) Data() []byte {
 	return s.data
 }
 
-type SecureBootVerificationEvent secureBootVerificationEvent
+type SecureBootVerificationEvent = secureBootVerificationEvent
 
-func (e *SecureBootVerificationEvent) Event() *tcglog.Event {
-	return e.event
-}
-
-func (e *SecureBootVerificationEvent) ImageLoadEvent() *tcglog.Event {
-	return e.imageLoadEvent
+func (e *SecureBootVerificationEvent) MeasuredInPreOS() bool {
+	return e.measuredInPreOS
 }
 
 type SigDbUpdateQuirkMode = sigDbUpdateQuirkMode

--- a/secureboot_policy_test.go
+++ b/secureboot_policy_test.go
@@ -356,15 +356,17 @@ func TestIdentifyInitialOSLaunchVerificationEvent(t *testing.T) {
 				if err != nil {
 					t.Fatalf("IdentifyInitialOSLaunchVerificationEvent failed: %v", err)
 				}
-				e := (*SecureBootVerificationEvent)(event)
-				if events[data.index] != e.Event() {
+				if events[data.index] != event.Event {
 					t.Errorf("incorrect event detected")
 				}
-				if e.Event().PCRIndex != 7 {
+				if event.PCRIndex != 7 {
 					t.Errorf("Detected event has wrong PCR index")
 				}
-				if e.Event().EventType != tcglog.EventTypeEFIVariableAuthority {
+				if event.EventType != tcglog.EventTypeEFIVariableAuthority {
 					t.Errorf("Detected event has wrong type")
+				}
+				if event.MeasuredInPreOS() {
+					t.Errorf("Detected pre-OS event")
 				}
 			} else {
 				if err == nil {


### PR DESCRIPTION
This simplifies identifyInitialOSLaunchVerificationEvent and also ensures
it should work with UEFI system preparation applications.