### PR TITLE
Don't use a NV index for PIN integration

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -249,9 +249,9 @@ func (ctb *cryptTPMTestBase) setUpTestBase(c *C, ttb *testutil.TPMTestBase) {
 	dir := c.MkDir()
 	ctb.keyFile = dir + "/keydata"
 
-	pinHandle := tpm2.Handle(0x0181fff0)
-	c.Assert(SealKeyToTPM(ttb.TPM, ctb.tpmKey, ctb.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: pinHandle}), IsNil)
-	pinIndex, err := ttb.TPM.CreateResourceContextFromTPM(pinHandle)
+	policyCounterHandle := tpm2.Handle(0x0181fff0)
+	c.Assert(SealKeyToTPM(ttb.TPM, ctb.tpmKey, ctb.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: policyCounterHandle}), IsNil)
+	pinIndex, err := ttb.TPM.CreateResourceContextFromTPM(policyCounterHandle)
 	c.Assert(err, IsNil)
 	ttb.AddCleanupNVSpace(c, ttb.TPM.OwnerHandleContext(), pinIndex)
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -249,9 +249,9 @@ func (ctb *cryptTPMTestBase) setUpTestBase(c *C, ttb *testutil.TPMTestBase) {
 	dir := c.MkDir()
 	ctb.keyFile = dir + "/keydata"
 
-	policyCounterHandle := tpm2.Handle(0x0181fff0)
-	c.Assert(SealKeyToTPM(ttb.TPM, ctb.tpmKey, ctb.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: policyCounterHandle}), IsNil)
-	pinIndex, err := ttb.TPM.CreateResourceContextFromTPM(policyCounterHandle)
+	pcrPolicyCounterHandle := tpm2.Handle(0x0181fff0)
+	c.Assert(SealKeyToTPM(ttb.TPM, ctb.tpmKey, ctb.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: pcrPolicyCounterHandle}), IsNil)
+	pinIndex, err := ttb.TPM.CreateResourceContextFromTPM(pcrPolicyCounterHandle)
 	c.Assert(err, IsNil)
 	ttb.AddCleanupNVSpace(c, ttb.TPM.OwnerHandleContext(), pinIndex)
 

--- a/export_test.go
+++ b/export_test.go
@@ -44,7 +44,8 @@ var (
 	ComputeDbUpdate                          = computeDbUpdate
 	ComputeDynamicPolicy                     = computeDynamicPolicy
 	ComputePcrPolicyCounterAuthPolicies      = computePcrPolicyCounterAuthPolicies
-	ComputePcrPolicyRef                      = computePcrPolicyRef
+	ComputePcrPolicyRefFromCounterContext    = computePcrPolicyRefFromCounterContext
+	ComputePcrPolicyRefFromCounterName       = computePcrPolicyRefFromCounterName
 	ComputePeImageDigest                     = computePeImageDigest
 	ComputePolicyORData                      = computePolicyORData
 	ComputeSnapModelDigest                   = computeSnapModelDigest
@@ -142,10 +143,6 @@ func (d *StaticPolicyData) V0PinIndexAuthPolicies() tpm2.DigestList {
 	return d.v0PinIndexAuthPolicies
 }
 
-func (d *StaticPolicyData) PcrPolicyRef() tpm2.Nonce {
-	return d.pcrPolicyRef
-}
-
 type WinCertificate interface {
 	ToWinCertificateAuthenticode() *WinCertificateAuthenticode
 	ToWinCertificateUefiGuid() *WinCertificateUefiGuid
@@ -233,16 +230,15 @@ func MockSystemdCryptsetupPath(path string) (restore func()) {
 	}
 }
 
-func NewDynamicPolicyComputeParams(key *rsa.PrivateKey, signAlg tpm2.HashAlgorithmId, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name, policyCount uint64,
-	policyRef tpm2.Nonce) *dynamicPolicyComputeParams {
+func NewDynamicPolicyComputeParams(key *rsa.PrivateKey, signAlg tpm2.HashAlgorithmId, pcrs tpm2.PCRSelectionList,
+	pcrDigests tpm2.DigestList, policyCounterName tpm2.Name, policyCount uint64) *dynamicPolicyComputeParams {
 	return &dynamicPolicyComputeParams{
 		key:               key,
 		signAlg:           signAlg,
 		pcrs:              pcrs,
 		pcrDigests:        pcrDigests,
 		policyCounterName: policyCounterName,
-		policyCount:       policyCount,
-		policyRef:         policyRef}
+		policyCount:       policyCount}
 }
 
 func NewStaticPolicyComputeParams(key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, lockIndexName tpm2.Name) *staticPolicyComputeParams {

--- a/export_test.go
+++ b/export_test.go
@@ -43,13 +43,13 @@ const (
 var (
 	ComputeDbUpdate                          = computeDbUpdate
 	ComputeDynamicPolicy                     = computeDynamicPolicy
-	ComputeDynamicPolicyCounterAuthPolicies  = computeDynamicPolicyCounterAuthPolicies
-	ComputeDynamicPolicyRef                  = computeDynamicPolicyRef
+	ComputePcrPolicyCounterAuthPolicies      = computePcrPolicyCounterAuthPolicies
+	ComputePcrPolicyRef                      = computePcrPolicyRef
 	ComputePeImageDigest                     = computePeImageDigest
 	ComputePolicyORData                      = computePolicyORData
 	ComputeSnapModelDigest                   = computeSnapModelDigest
 	ComputeStaticPolicy                      = computeStaticPolicy
-	CreateDynamicPolicyCounter               = createDynamicPolicyCounter
+	CreatePcrPolicyCounter                   = createPcrPolicyCounter
 	CreatePublicAreaForRSASigningKey         = createPublicAreaForRSASigningKey
 	DecodeSecureBootDb                       = decodeSecureBootDb
 	DecodeWinCertificate                     = decodeWinCertificate
@@ -58,13 +58,13 @@ var (
 	EnsureLockNVIndex                        = ensureLockNVIndex
 	ExecutePolicySession                     = executePolicySession
 	IdentifyInitialOSLaunchVerificationEvent = identifyInitialOSLaunchVerificationEvent
-	IncrementDynamicPolicyCounter            = incrementDynamicPolicyCounter
+	IncrementPcrPolicyCounter                = incrementPcrPolicyCounter
 	IsDynamicPolicyDataError                 = isDynamicPolicyDataError
 	IsStaticPolicyDataError                  = isStaticPolicyDataError
 	LockNVIndexAttrs                         = lockNVIndexAttrs
 	PerformPinChange                         = performPinChange
 	ReadAndValidateLockNVIndexPublic         = readAndValidateLockNVIndexPublic
-	ReadDynamicPolicyCounter                 = readDynamicPolicyCounter
+	ReadPcrPolicyCounter                     = readPcrPolicyCounter
 	ReadShimVendorCert                       = readShimVendorCert
 	WinCertTypePKCSSignedData                = winCertTypePKCSSignedData
 	WinCertTypeEfiGuid                       = winCertTypeEfiGuid
@@ -130,20 +130,20 @@ func (d *StaticPolicyData) AuthPublicKey() *tpm2.Public {
 	return d.authPublicKey
 }
 
-func (d *StaticPolicyData) PolicyCounterHandle() tpm2.Handle {
-	return d.policyCounterHandle
+func (d *StaticPolicyData) PcrPolicyCounterHandle() tpm2.Handle {
+	return d.pcrPolicyCounterHandle
 }
 
-func (d *StaticPolicyData) SetPolicyCounterHandle(h tpm2.Handle) {
-	d.policyCounterHandle = h
+func (d *StaticPolicyData) SetPcrPolicyCounterHandle(h tpm2.Handle) {
+	d.pcrPolicyCounterHandle = h
 }
 
 func (d *StaticPolicyData) V0PinIndexAuthPolicies() tpm2.DigestList {
 	return d.v0PinIndexAuthPolicies
 }
 
-func (d *StaticPolicyData) DynamicPolicyRef() tpm2.Nonce {
-	return d.dynamicPolicyRef
+func (d *StaticPolicyData) PcrPolicyRef() tpm2.Nonce {
+	return d.pcrPolicyRef
 }
 
 type WinCertificate interface {
@@ -245,8 +245,8 @@ func NewDynamicPolicyComputeParams(key *rsa.PrivateKey, signAlg tpm2.HashAlgorit
 		policyRef:         policyRef}
 }
 
-func NewStaticPolicyComputeParams(key *tpm2.Public, policyCounterPub *tpm2.NVPublic, lockIndexName tpm2.Name) *staticPolicyComputeParams {
-	return &staticPolicyComputeParams{key: key, policyCounterPub: policyCounterPub, lockIndexName: lockIndexName}
+func NewStaticPolicyComputeParams(key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, lockIndexName tpm2.Name) *staticPolicyComputeParams {
+	return &staticPolicyComputeParams{key: key, pcrPolicyCounterPub: pcrPolicyCounterPub, lockIndexName: lockIndexName}
 }
 
 func (p *PCRProtectionProfile) ComputePCRDigests(tpm *tpm2.TPMContext, alg tpm2.HashAlgorithmId) (tpm2.PCRSelectionList, tpm2.DigestList, error) {

--- a/export_test.go
+++ b/export_test.go
@@ -86,8 +86,8 @@ func (d *DynamicPolicyData) PolicyCount() uint64 {
 	return d.policyCount
 }
 
-func (d *DynamicPolicyData) IncrementPolicyCount() {
-	d.policyCount += 1
+func (d *DynamicPolicyData) SetPolicyCount(c uint64) {
+	d.policyCount = c
 }
 
 func (d *DynamicPolicyData) AuthorizedPolicy() tpm2.Digest {

--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -205,7 +205,7 @@ func (s *compatTestSuiteBase) testUpdateKeyPCRProtectionPolicyRevokes(c *C, pcrP
 	c.Assert(err, IsNil)
 
 	_, err = k.UnsealFromTPM(s.TPM, "")
-	c.Check(err, ErrorMatches, "invalid key data file: cannot complete authorization policy assertions: the dynamic authorization policy has been revoked")
+	c.Check(err, ErrorMatches, "invalid key data file: cannot complete authorization policy assertions: the PCR policy has been revoked")
 }
 
 func (s *compatTestSuiteBase) testUpdateKeyPCRProtectionPolicyAndUnseal(c *C, pcrProfile *secboot.PCRProtectionProfile, pcrEvents io.Reader) {

--- a/keydata.go
+++ b/keydata.go
@@ -122,8 +122,8 @@ func (d *afSplitData) merge() ([]byte, error) {
 	return afis.MergeHash(d.data, int(d.stripes), func() hash.Hash { return d.hashAlg.NewHash() })
 }
 
-func makeAfSplitData(data []byte, sz int, hashAlg tpm2.HashAlgorithmId) (*afSplitData, error) {
-	stripes := uint32((sz / len(data)) + 1)
+func makeAfSplitData(data []byte, minSz int, hashAlg tpm2.HashAlgorithmId) (*afSplitData, error) {
+	stripes := uint32((minSz / len(data)) + 1)
 
 	split, err := afis.SplitHash(data, int(stripes), func() hash.Hash { return hashAlg.NewHash() })
 	if err != nil {

--- a/keydata.go
+++ b/keydata.go
@@ -293,7 +293,7 @@ func (d *keyData) Marshal(w io.Writer) (nbytes int, err error) {
 		if _, err := tpm2.MarshalToWriter(&tmpW, raw); err != nil {
 			return 0, xerrors.Errorf("cannot marshal data: %w", err)
 		}
-		splitData, err := makeAfSplitData(tmpW.Bytes(), 128*1204, tpm2.HashAlgorithmSHA256)
+		splitData, err := makeAfSplitData(tmpW.Bytes(), 128*1024, tpm2.HashAlgorithmSHA256)
 		if err != nil {
 			return 0, xerrors.Errorf("cannot split data: %w", err)
 		}

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -46,7 +46,7 @@ func (s *keyDataSuite) TestValidateAfterLock(c *C) {
 
 	pinHandle := tpm2.Handle(0x0181fff0)
 
-	c.Assert(SealKeyToTPM(s.TPM, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: tpm2.Handle(0x0181fff0)}), IsNil)
+	c.Assert(SealKeyToTPM(s.TPM, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: tpm2.Handle(0x0181fff0)}), IsNil)
 	pinIndex, err := s.TPM.CreateResourceContextFromTPM(pinHandle)
 	c.Assert(err, IsNil)
 	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), pinIndex)

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -46,7 +46,7 @@ func (s *keyDataSuite) TestValidateAfterLock(c *C) {
 
 	pinHandle := tpm2.Handle(0x0181fff0)
 
-	c.Assert(SealKeyToTPM(s.TPM, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: tpm2.Handle(0x0181fff0)}), IsNil)
+	c.Assert(SealKeyToTPM(s.TPM, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.Handle(0x0181fff0)}), IsNil)
 	pinIndex, err := s.TPM.CreateResourceContextFromTPM(pinHandle)
 	c.Assert(err, IsNil)
 	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), pinIndex)

--- a/pin.go
+++ b/pin.go
@@ -168,7 +168,7 @@ func ChangePIN(tpm *TPMConnection, path string, oldPIN, newPIN string) error {
 	defer keyFile.Close()
 
 	// Read and validate the key data file
-	data, _, policyCounterPub, err := decodeAndValidateKeyData(tpm.TPMContext, keyFile, nil, tpm.HmacSession())
+	data, _, pcrPolicyCounterPub, err := decodeAndValidateKeyData(tpm.TPMContext, keyFile, nil, tpm.HmacSession())
 	if err != nil {
 		if isKeyFileError(err) {
 			return InvalidKeyFileError{err.Error()}
@@ -178,7 +178,7 @@ func ChangePIN(tpm *TPMConnection, path string, oldPIN, newPIN string) error {
 
 	// Change the PIN
 	if data.version == 0 {
-		if err := performPinChangeV0(tpm.TPMContext, policyCounterPub, data.staticPolicyData.v0PinIndexAuthPolicies, oldPIN, newPIN, tpm.HmacSession()); err != nil {
+		if err := performPinChangeV0(tpm.TPMContext, pcrPolicyCounterPub, data.staticPolicyData.v0PinIndexAuthPolicies, oldPIN, newPIN, tpm.HmacSession()); err != nil {
 			if isAuthFailError(err, tpm2.CommandNVChangeAuth, 1) {
 				return ErrPINFail
 			}

--- a/pin.go
+++ b/pin.go
@@ -20,24 +20,22 @@
 package secboot
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"encoding/binary"
 	"os"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/snapcore/secboot/internal/tcg"
 
 	"golang.org/x/xerrors"
 )
 
-// computePinNVIndexPostInitAuthPolicies computes the authorization policy digests associated with the post-initialization
-// actions on a NV index created with createPinNVIndex. These are:
+// computeV0PinNVIndexPostInitAuthPolicies computes the authorization policy digests associated with the post-initialization
+// actions on a NV index created with the removed createPinNVIndex for version 0 key files. These are:
 // - A policy for updating the index to revoke old dynamic authorization policies, requiring an assertion signed by the key
 //   associated with updateKeyName.
 // - A policy for updating the authorization value (PIN / passphrase), requiring knowledge of the current authorization value.
 // - A policy for reading the counter value without knowing the authorization value, as the value isn't secret.
 // - A policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
-func computePinNVIndexPostInitAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) (tpm2.DigestList, error) {
+func computeV0PinNVIndexPostInitAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) (tpm2.DigestList, error) {
 	var out tpm2.DigestList
 	// Compute a policy for incrementing the index to revoke dynamic authorization policies, requiring an assertion signed by the
 	// key associated with updateKeyName.
@@ -78,152 +76,13 @@ func computePinNVIndexPostInitAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyNa
 	return out, nil
 }
 
-// createPinNVIndex creates a NV index that is associated with a sealed key object and is used for implementing PIN support. It is
-// also used as a counter to support revoking of dynamic authorization policies.
+// performPinChangeV0 changes the authorization value of the dynamic authorization policy counter associated with the public
+// argument, for PIN integration in version 0 key files. This requires the authorization policy digests initially returned from
+// (the now removed) createPinNVIndex function in order to execute the policy session required to change the authorization value.
+// The current authorization value must be provided via the oldAuth argument.
 //
-// To prevent someone with knowledge of the owner authorization (which is empty unless someone has taken ownership of the TPM) from
-// resetting the PIN by just undefining and redifining a new NV index with the same properties, we need a way to prevent someone
-// from being able to create an index with the same name. To do this, we require the NV index to have been written to and only allow
-// the initial write with a signed authorization policy. Once initialized, the signing key that authorized the initial write is
-// discarded. This works because the name of the signing key is included in the authorization policy digest for the NV index, and the
-// authorization policy digest and attributes are included in the name of the NV index. Without the private part of the signing key,
-// it is impossible to create a new NV index with the same name, and so, if this NV index is undefined then it becomes impossible to
-// satisfy the authorization policy for the sealed key object to which it is associated.
-//
-// The NV index will be created with an authorization policy that permits TPM2_NV_Read and TPM2_PolicyNV without knowing the PIN,
-// and an authorization policy that permits TPM2_NV_Increment with a signed authorization policy, signed by the key associated with
-// updateKeyName.
-func createPinNVIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKeyName tpm2.Name, hmacSession tpm2.SessionContext) (*tpm2.NVPublic, tpm2.DigestList, error) {
-	initKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot create signing key for initializing NV index: %w", err)
-	}
-
-	initKeyPublic := createPublicAreaForRSASigningKey(&initKey.PublicKey)
-	initKeyName, err := initKeyPublic.Name()
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot compute name of signing key for initializing NV index: %w", err)
-	}
-
-	nameAlg := tpm2.HashAlgorithmSHA256
-
-	// The NV index requires 5 policies:
-	// - A policy for initializing the index, requiring an assertion signed with an ephemeral key so that the index cannot be recreated.
-	// - A policy for updating the index to revoke old dynamic authorization policies, requiring a signed assertion.
-	// - A policy for updating the authorization value (PIN / passphrase), requiring knowledge of the current authorization value.
-	// - A policy for reading the counter value without knowing the authorization value, as the value isn't secret.
-	// - A policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
-	var authPolicies tpm2.DigestList
-
-	// Compute a policy for initialization which requires an assertion signed with an ephemeral key (initKey)
-	trial, _ := tpm2.ComputeAuthPolicy(nameAlg)
-	trial.PolicyCommandCode(tpm2.CommandNVIncrement)
-	trial.PolicyNvWritten(false)
-	trial.PolicySigned(initKeyName, nil)
-	authPolicies = append(authPolicies, trial.GetDigest())
-
-	// Compute the remaining 4 post-initalization policies.
-	postInitAuthPolicies, err := computePinNVIndexPostInitAuthPolicies(nameAlg, updateKeyName)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot compute authorization policies: %w", err)
-	}
-	authPolicies = append(authPolicies, postInitAuthPolicies...)
-
-	trial, _ = tpm2.ComputeAuthPolicy(nameAlg)
-	trial.PolicyOR(authPolicies)
-
-	// Define the NV index
-	public := &tpm2.NVPublic{
-		Index:      handle,
-		NameAlg:    nameAlg,
-		Attrs:      tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVPolicyRead),
-		AuthPolicy: trial.GetDigest(),
-		Size:       8}
-
-	index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, public, hmacSession)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot define NV space: %w", err)
-	}
-
-	// NVDefineSpace was integrity protected, so we know that we have an index with the expected public area at the handle we specified
-	// at this point.
-
-	succeeded := false
-	defer func() {
-		if succeeded {
-			return
-		}
-		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, hmacSession)
-	}()
-
-	// Begin a session to initialize the index.
-	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, nameAlg)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot begin policy session to initialize NV index: %w", err)
-	}
-	defer tpm.FlushContext(policySession)
-
-	// Compute a digest for signing with our key
-	signDigest := tpm2.HashAlgorithmSHA256
-	h := signDigest.NewHash()
-	h.Write(policySession.NonceTPM())
-	binary.Write(h, binary.BigEndian, int32(0))
-
-	// Sign the digest
-	sig, err := rsa.SignPSS(rand.Reader, initKey, signDigest.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot provide signature for initializing NV index: %w", err)
-	}
-
-	// Load the public part of the key in to the TPM. There's no integrity protection for this command as if it's altered in
-	// transit then either the signature verification fails or the policy digest will not match the one associated with the NV
-	// index.
-	initKeyContext, err := tpm.LoadExternal(nil, initKeyPublic, tpm2.HandleEndorsement)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot load public part of key used to initialize NV index to the TPM: %w", err)
-	}
-	defer tpm.FlushContext(initKeyContext)
-
-	signature := tpm2.Signature{
-		SigAlg: tpm2.SigSchemeAlgRSAPSS,
-		Signature: tpm2.SignatureU{
-			Data: &tpm2.SignatureRSAPSS{
-				Hash: signDigest,
-				Sig:  tpm2.PublicKeyRSA(sig)}}}
-
-	// Execute the policy assertions
-	if err := tpm.PolicyCommandCode(policySession, tpm2.CommandNVIncrement); err != nil {
-		return nil, nil, xerrors.Errorf("cannot execute assertion to initialize NV index: %w", err)
-	}
-	if err := tpm.PolicyNvWritten(policySession, false); err != nil {
-		return nil, nil, xerrors.Errorf("cannot execute assertion to initialize NV index: %w", err)
-	}
-	if _, _, err := tpm.PolicySigned(initKeyContext, policySession, true, nil, nil, 0, &signature); err != nil {
-		return nil, nil, xerrors.Errorf("cannot execute assertion to initialize NV index: %w", err)
-	}
-	if err := tpm.PolicyOR(policySession, authPolicies); err != nil {
-		return nil, nil, xerrors.Errorf("cannot execute assertion to initialize NV index: %w", err)
-	}
-
-	// Initialize the index
-	if err := tpm.NVIncrement(index, index, policySession, hmacSession.IncludeAttrs(tpm2.AttrAudit)); err != nil {
-		return nil, nil, xerrors.Errorf("cannot initialize NV index: %w", err)
-	}
-
-	// The index has a different name now that it has been written, so update the public area we return so that it can be used
-	// to construct an authorization policy.
-	public.Attrs |= tpm2.AttrNVWritten
-
-	succeeded = true
-	return public, authPolicies, nil
-}
-
-// performPinChange changes the authorization value of the PIN NV index associated with the public argument. This requires the
-// authorization policy digests initially returned from createPinNVIndex in order to execute the policy session required to change
-// the authorization value. The current authorization value must be provided via the oldAuth argument.
-//
-// On success, the authorization value of the PIN NV index will be changed to newAuth.
-func performPinChange(tpm *tpm2.TPMContext, public *tpm2.NVPublic, authPolicies tpm2.DigestList, oldAuth, newAuth string, hmacSession tpm2.SessionContext) error {
+// On success, the authorization value of the counter will be changed to newAuth.
+func performPinChangeV0(tpm *tpm2.TPMContext, public *tpm2.NVPublic, authPolicies tpm2.DigestList, oldAuth, newAuth string, hmacSession tpm2.SessionContext) error {
 	index, err := tpm2.CreateNVIndexResourceContextFromPublic(public)
 	if err != nil {
 		return xerrors.Errorf("cannot create resource context for NV index: %w", err)
@@ -251,6 +110,33 @@ func performPinChange(tpm *tpm2.TPMContext, public *tpm2.NVPublic, authPolicies 
 	}
 
 	return nil
+}
+
+// performPinChange changes the authorization value of the sealed key object associated with keyPrivate and keyPublic, for PIN
+// integration in current key files. The sealed key file must be created without the AttrAdminWithPolicy attribute. The current
+// authorization value must be provided via the oldAuth argument.
+//
+// On success, a new private area will be returned for the sealed key object, containing the new PIN.
+func performPinChange(tpm *tpm2.TPMContext, keyPrivate tpm2.Private, keyPublic *tpm2.Public, oldPIN, newPIN string, session tpm2.SessionContext) (tpm2.Private, error) {
+	srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
+	}
+
+	key, err := tpm.Load(srk, keyPrivate, keyPublic, session)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot load sealed key object in to TPM: %w", err)
+	}
+	defer tpm.FlushContext(key)
+
+	key.SetAuthValue([]byte(oldPIN))
+
+	newKeyPrivate, err := tpm.ObjectChangeAuth(key, srk, []byte(newPIN), session.IncludeAttrs(tpm2.AttrCommandEncrypt))
+	if err != nil {
+		return nil, xerrors.Errorf("cannot change sealed key object authorization value: %w", err)
+	}
+
+	return newKeyPrivate, nil
 }
 
 // ChangePIN changes the PIN for the key data file at the specified path. The existing PIN must be supplied via the oldPIN argument.
@@ -282,21 +168,31 @@ func ChangePIN(tpm *TPMConnection, path string, oldPIN, newPIN string) error {
 	defer keyFile.Close()
 
 	// Read and validate the key data file
-	data, _, pinIndexPublic, err := decodeAndValidateKeyData(tpm.TPMContext, keyFile, nil, tpm.HmacSession())
+	data, _, policyCounterPub, err := decodeAndValidateKeyData(tpm.TPMContext, keyFile, nil, tpm.HmacSession())
 	if err != nil {
-		var kfErr keyFileError
-		if xerrors.As(err, &kfErr) {
+		if isKeyFileError(err) {
 			return InvalidKeyFileError{err.Error()}
 		}
 		return xerrors.Errorf("cannot read and validate key data file: %w", err)
 	}
 
 	// Change the PIN
-	if err := performPinChange(tpm.TPMContext, pinIndexPublic, data.staticPolicyData.PinIndexAuthPolicies, oldPIN, newPIN, tpm.HmacSession()); err != nil {
-		if isAuthFailError(err, tpm2.CommandNVChangeAuth, 1) {
-			return ErrPINFail
+	if data.version == 0 {
+		if err := performPinChangeV0(tpm.TPMContext, policyCounterPub, data.staticPolicyData.v0PinIndexAuthPolicies, oldPIN, newPIN, tpm.HmacSession()); err != nil {
+			if isAuthFailError(err, tpm2.CommandNVChangeAuth, 1) {
+				return ErrPINFail
+			}
+			return err
 		}
-		return err
+	} else {
+		newKeyPrivate, err := performPinChange(tpm.TPMContext, data.keyPrivate, data.keyPublic, oldPIN, newPIN, tpm.HmacSession())
+		if err != nil {
+			if isAuthFailError(err, tpm2.CommandObjectChangeAuth, 1) {
+				return ErrPINFail
+			}
+			return err
+		}
+		data.keyPrivate = newKeyPrivate
 	}
 
 	// Update the metadata and write a new key data file
@@ -307,7 +203,7 @@ func ChangePIN(tpm *TPMConnection, path string, oldPIN, newPIN string) error {
 		data.authModeHint = AuthModePIN
 	}
 
-	if origAuthModeHint == data.authModeHint {
+	if origAuthModeHint == data.authModeHint && data.version == 0 {
 		return nil
 	}
 

--- a/pin_test.go
+++ b/pin_test.go
@@ -21,145 +21,79 @@ package secboot_test
 
 import (
 	"bytes"
-	"crypto/rsa"
 	"math/rand"
-	"os"
 	"testing"
 
 	"github.com/canonical/go-tpm2"
 	. "github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/tcg"
 	"github.com/snapcore/secboot/internal/testutil"
 
 	. "gopkg.in/check.v1"
 )
 
-func TestCreatePinNVIndex(t *testing.T) {
-	tpm := openTPMForTesting(t)
-	defer closeTPM(t, tpm)
-
-	key, err := rsa.GenerateKey(testutil.RandReader, 768)
-	if err != nil {
-		t.Fatalf("GenerateKey failed: %v", err)
-	}
-	keyPublic := CreatePublicAreaForRSASigningKey(&key.PublicKey)
-	keyName, err := keyPublic.Name()
-	if err != nil {
-		t.Fatalf("Cannot compute key name: %v", err)
-	}
-
-	for _, data := range []struct {
-		desc   string
-		handle tpm2.Handle
-	}{
-		{
-			desc:   "0x01800000",
-			handle: 0x01800000,
-		},
-		{
-			desc:   "0x0181ff00",
-			handle: 0x0181ff00,
-		},
-	} {
-		t.Run(data.desc, func(t *testing.T) {
-			pub, authPolicies, err := CreatePinNVIndex(tpm.TPMContext, data.handle, keyName, tpm.HmacSession())
-			if err != nil {
-				t.Fatalf("CreatePinNVIndex failed: %v", err)
-			}
-			defer func() {
-				index, err := tpm2.CreateNVIndexResourceContextFromPublic(pub)
-				if err != nil {
-					t.Errorf("CreateNVIndexResourceContextFromPublic failed: %v", err)
-				}
-				undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-			}()
-
-			if pub.Index != data.handle {
-				t.Errorf("Public area has wrong handle")
-			}
-			if pub.NameAlg != tpm2.HashAlgorithmSHA256 {
-				t.Errorf("Public area has wrong name algorithm")
-			}
-			if pub.Attrs != tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVPolicyRead|tpm2.AttrNVWritten) {
-				t.Errorf("Public area has wrong attributes")
-			}
-			trial, _ := tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-			trial.PolicyOR(authPolicies)
-			if !bytes.Equal(pub.AuthPolicy, trial.GetDigest()) {
-				t.Errorf("Public area has wrong auth policy")
-			}
-			// Note, we test the individual components of the authorization policy during tests for
-			// incrementDynamicPolicyCounter, readDynamicPolicyCounter, performPinChange and executePolicySession.
-
-			pinIndexName, err := pub.Name()
-			if err != nil {
-				t.Errorf("NVPublic.Name failed: %v", err)
-			}
-			index, err := tpm.CreateResourceContextFromTPM(data.handle)
-			if err != nil {
-				t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
-			}
-			if !bytes.Equal(index.Name(), pinIndexName) {
-				t.Errorf("Unexpected name read back from TPM")
-			}
-		})
-	}
-}
-
 func TestPerformPinChange(t *testing.T) {
 	tpm := openTPMForTesting(t)
 	defer closeTPM(t, tpm)
 
-	key, err := rsa.GenerateKey(testutil.RandReader, 768)
-	if err != nil {
-		t.Fatalf("GenerateKey failed: %v", err)
+	if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
+		t.Errorf("Failed to provision TPM for test: %v", err)
 	}
-	keyPublic := CreatePublicAreaForRSASigningKey(&key.PublicKey)
-	keyName, err := keyPublic.Name()
+
+	srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
 	if err != nil {
-		t.Fatalf("Cannot compute key name: %v", err)
+		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 	}
-	pinIndexPub, pinIndexAuthPolicies, err := CreatePinNVIndex(tpm.TPMContext, 0x01810000, keyName, tpm.HmacSession())
+
+	sensitive := tpm2.SensitiveCreate{Data: []byte("foo")}
+	template := tpm2.Public{
+		Type:    tpm2.ObjectTypeKeyedHash,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrUserWithAuth,
+		Params:  tpm2.PublicParamsU{Data: &tpm2.KeyedHashParams{Scheme: tpm2.KeyedHashScheme{Scheme: tpm2.KeyedHashSchemeNull}}}}
+
+	priv, pub, _, _, _, err := tpm.Create(srk, &sensitive, &template, nil, nil, nil)
 	if err != nil {
-		t.Fatalf("CreatePinNVIndex failed: %v", err)
+		t.Fatalf("Create failed: %v", err)
 	}
-	defer func() {
-		index, err := tpm2.CreateNVIndexResourceContextFromPublic(pinIndexPub)
-		if err != nil {
-			t.Errorf("CreateNVIndexResourceContextFromPublic failed: %v", err)
-		}
-		undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-	}()
+
+	key, err := tpm.Load(srk, priv, pub, nil)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	defer flushContext(t, tpm, key)
 
 	pin := "1234"
 
-	if err := PerformPinChange(tpm.TPMContext, pinIndexPub, pinIndexAuthPolicies, "", pin, tpm.HmacSession()); err != nil {
+	newPriv, err := PerformPinChange(tpm.TPMContext, priv, pub, "", pin, tpm.HmacSession())
+	if err != nil {
 		t.Fatalf("PerformPinChange failed: %v", err)
 	}
 
-	// Verify that the PIN change succeeded by executing a PolicySecret assertion, which is immediate and will fail if it
-	// didn't work.
-	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)
+	// Verify that the PIN change succeeded by loading the new private area and trying to unseal it
+	newKey, err := tpm.Load(srk, newPriv, pub, nil)
 	if err != nil {
-		t.Fatalf("StartAuthSession failed: %v", err)
+		t.Fatalf("Load failed: %v", err)
 	}
-	defer flushContext(t, tpm, policySession)
+	defer flushContext(t, tpm, newKey)
 
-	pinIndex, err := tpm2.CreateNVIndexResourceContextFromPublic(pinIndexPub)
+	newKey.SetAuthValue([]byte(pin))
+
+	data, err := tpm.Unseal(newKey, nil)
 	if err != nil {
-		t.Fatalf("CreateNVIndexResourceContextFromPublic failed: %v", err)
+		t.Errorf("Unseal failed: %v", err)
 	}
-	pinIndex.SetAuthValue([]byte(pin))
 
-	if _, _, err := tpm.PolicySecret(pinIndex, policySession, nil, nil, 0, nil); err != nil {
-		t.Errorf("PolicySecret assertion failed: %v", err)
+	if !bytes.Equal(data, sensitive.Data) {
+		t.Errorf("Unexpected data")
 	}
 }
 
 type pinSuite struct {
 	testutil.TPMTestBase
-	key       []byte
-	pinHandle tpm2.Handle
-	keyFile   string
+	key                 []byte
+	policyCounterHandle tpm2.Handle
+	keyFile             string
 }
 
 var _ = Suite(&pinSuite{})
@@ -167,7 +101,7 @@ var _ = Suite(&pinSuite{})
 func (s *pinSuite) SetUpSuite(c *C) {
 	s.key = make([]byte, 64)
 	rand.Read(s.key)
-	s.pinHandle = tpm2.Handle(0x0181fff0)
+	s.policyCounterHandle = tpm2.Handle(0x0181fff0)
 }
 
 func (s *pinSuite) SetUpTest(c *C) {
@@ -177,10 +111,10 @@ func (s *pinSuite) SetUpTest(c *C) {
 	dir := c.MkDir()
 	s.keyFile = dir + "/keydata"
 
-	c.Assert(SealKeyToTPM(s.TPM, s.key, s.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: s.pinHandle}), IsNil)
-	pinIndex, err := s.TPM.CreateResourceContextFromTPM(s.pinHandle)
+	c.Assert(SealKeyToTPM(s.TPM, s.key, s.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: s.policyCounterHandle}), IsNil)
+	policyCounter, err := s.TPM.CreateResourceContextFromTPM(s.policyCounterHandle)
 	c.Assert(err, IsNil)
-	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), pinIndex)
+	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), policyCounter)
 }
 
 func (s *pinSuite) checkPIN(c *C, pin string) {
@@ -192,17 +126,9 @@ func (s *pinSuite) checkPIN(c *C, pin string) {
 		c.Check(k.AuthMode2F(), Equals, AuthModePIN)
 	}
 
-	// Verify that the PIN change succeeded by executing a PolicySecret assertion, which is immediate and will fail if it
-	// didn't work.
-	policySession, err := s.TPM.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)
-	c.Assert(err, IsNil)
-
-	pinIndex, err := s.TPM.CreateResourceContextFromTPM(k.PINIndexHandle())
-	c.Assert(err, IsNil)
-	pinIndex.SetAuthValue([]byte(pin))
-
-	_, _, err = s.TPM.PolicySecret(pinIndex, policySession, nil, nil, 0, nil)
+	key, err := k.UnsealFromTPM(s.TPM, pin)
 	c.Check(err, IsNil)
+	c.Check(key, DeepEquals, s.key)
 }
 
 func (s *pinSuite) TestSetAndClearPIN(c *C) {
@@ -212,18 +138,6 @@ func (s *pinSuite) TestSetAndClearPIN(c *C) {
 
 	c.Check(ChangePIN(s.TPM, s.keyFile, testPIN, ""), IsNil)
 	s.checkPIN(c, "")
-}
-
-func (s *pinSuite) TestChangePINDoesntUpdateFileIfAuthModeDoesntChange(c *C) {
-	fi1, err := os.Stat(s.keyFile)
-	c.Assert(err, IsNil)
-
-	c.Check(ChangePIN(s.TPM, s.keyFile, "", ""), IsNil)
-	s.checkPIN(c, "")
-
-	fi2, err := os.Stat(s.keyFile)
-	c.Assert(err, IsNil)
-	c.Check(fi2.ModTime(), DeepEquals, fi1.ModTime())
 }
 
 type testChangePINErrorHandlingData struct {
@@ -260,16 +174,5 @@ func (s *pinSuite) TestChangePINErrorHandling3(c *C) {
 		keyFile:        "/path/to/nothing",
 		errChecker:     ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot open key data file: open /path/to/nothing: no such file or directory"},
-	})
-}
-
-func (s *pinSuite) TestChangePINErrorHandling4(c *C) {
-	pinIndex, err := s.TPM.CreateResourceContextFromTPM(s.pinHandle)
-	c.Assert(err, IsNil)
-	c.Assert(s.TPM.NVUndefineSpace(s.TPM.OwnerHandleContext(), pinIndex, nil), IsNil)
-	s.testChangePINErrorHandling(c, &testChangePINErrorHandlingData{
-		keyFile:        s.keyFile,
-		errChecker:     ErrorMatches,
-		errCheckerArgs: []interface{}{"invalid key data file: cannot validate key data: PIN NV index is unavailable"},
 	})
 }

--- a/pin_test.go
+++ b/pin_test.go
@@ -91,9 +91,9 @@ func TestPerformPinChange(t *testing.T) {
 
 type pinSuite struct {
 	testutil.TPMTestBase
-	key                 []byte
-	policyCounterHandle tpm2.Handle
-	keyFile             string
+	key                    []byte
+	pcrPolicyCounterHandle tpm2.Handle
+	keyFile                string
 }
 
 var _ = Suite(&pinSuite{})
@@ -101,7 +101,7 @@ var _ = Suite(&pinSuite{})
 func (s *pinSuite) SetUpSuite(c *C) {
 	s.key = make([]byte, 64)
 	rand.Read(s.key)
-	s.policyCounterHandle = tpm2.Handle(0x0181fff0)
+	s.pcrPolicyCounterHandle = tpm2.Handle(0x0181fff0)
 }
 
 func (s *pinSuite) SetUpTest(c *C) {
@@ -111,8 +111,8 @@ func (s *pinSuite) SetUpTest(c *C) {
 	dir := c.MkDir()
 	s.keyFile = dir + "/keydata"
 
-	c.Assert(SealKeyToTPM(s.TPM, s.key, s.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: s.policyCounterHandle}), IsNil)
-	policyCounter, err := s.TPM.CreateResourceContextFromTPM(s.policyCounterHandle)
+	c.Assert(SealKeyToTPM(s.TPM, s.key, s.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: s.pcrPolicyCounterHandle}), IsNil)
+	policyCounter, err := s.TPM.CreateResourceContextFromTPM(s.pcrPolicyCounterHandle)
 	c.Assert(err, IsNil)
 	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), policyCounter)
 }

--- a/policy.go
+++ b/policy.go
@@ -660,7 +660,7 @@ func computeDynamicPolicyRef(alg tpm2.HashAlgorithmId, counterPublic *tpm2.NVPub
 	}
 
 	h := alg.NewHash()
-	h.Write([]byte("DYNAMIC-PCR"))
+	h.Write([]byte("AUTH-PCR-POLICY"))
 	h.Write(counterName)
 
 	return h.Sum(nil), nil

--- a/policy.go
+++ b/policy.go
@@ -657,6 +657,9 @@ func computePcrPolicyRef(alg tpm2.HashAlgorithmId, counterPublic *tpm2.NVPublic)
 		if err != nil {
 			return nil, xerrors.Errorf("cannot compute name of counter: %w", err)
 		}
+	} else {
+		counterName = make(tpm2.Name, binary.Size(tpm2.Handle(0)))
+		binary.BigEndian.PutUint32(counterName, uint32(tpm2.HandleNull))
 	}
 
 	h := alg.NewHash()

--- a/policy_test.go
+++ b/policy_test.go
@@ -572,7 +572,7 @@ duwzA18V2dm66mFx1NcqfNyRUbclhN26KAaRnTDQrAaxFIgoO+Xm
 		{
 			desc:   "NoPolicyCounter",
 			alg:    tpm2.HashAlgorithmSHA256,
-			policy: decodeHexStringT(t, "e172910f530f8ba086fd347f57709a5e7aa0528a766c5270d7fd2e2c5bad55ac"),
+			policy: decodeHexStringT(t, "84a089cef19c8ea684e6338cd2a12ed53cf7e7601600a15304edd5914b1c3c0f"),
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -560,17 +560,17 @@ duwzA18V2dm66mFx1NcqfNyRUbclhN26KAaRnTDQrAaxFIgoO+Xm
 		{
 			desc:   "SHA256",
 			alg:    tpm2.HashAlgorithmSHA256,
-			policy: decodeHexStringT(t, "9016aa17b6b321b5a2df22558baa9adff1f9b00621d6ca1ca47f2bc683a609a1"),
+			policy: decodeHexStringT(t, "e172910f530f8ba086fd347f57709a5e7aa0528a766c5270d7fd2e2c5bad55ac"),
 		},
 		{
 			desc:   "SHA1",
 			alg:    tpm2.HashAlgorithmSHA1,
-			policy: decodeHexStringT(t, "4c2a68d7bcbe0a4d8ff4aadba7651505589bd7a9"),
+			policy: decodeHexStringT(t, "90b35075d3a988632ae3be3ddfc92227e322c17f"),
 		},
 		{
 			desc:   "NoPolicyCounter",
 			alg:    tpm2.HashAlgorithmSHA256,
-			policy: decodeHexStringT(t, "9016aa17b6b321b5a2df22558baa9adff1f9b00621d6ca1ca47f2bc683a609a1"),
+			policy: decodeHexStringT(t, "e172910f530f8ba086fd347f57709a5e7aa0528a766c5270d7fd2e2c5bad55ac"),
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -558,14 +558,16 @@ duwzA18V2dm66mFx1NcqfNyRUbclhN26KAaRnTDQrAaxFIgoO+Xm
 		policy           tpm2.Digest
 	}{
 		{
-			desc:   "SHA256",
-			alg:    tpm2.HashAlgorithmSHA256,
-			policy: decodeHexStringT(t, "e172910f530f8ba086fd347f57709a5e7aa0528a766c5270d7fd2e2c5bad55ac"),
+			desc:             "SHA256",
+			alg:              tpm2.HashAlgorithmSHA256,
+			policyCounterPub: policyCounterPub,
+			policy:           decodeHexStringT(t, "b3040eda571b46a83266c0d548e80dc69932eaa66f3ad724cd1a6db5606cca72"),
 		},
 		{
-			desc:   "SHA1",
-			alg:    tpm2.HashAlgorithmSHA1,
-			policy: decodeHexStringT(t, "90b35075d3a988632ae3be3ddfc92227e322c17f"),
+			desc:             "SHA1",
+			alg:              tpm2.HashAlgorithmSHA1,
+			policyCounterPub: policyCounterPub,
+			policy:           decodeHexStringT(t, "53401cc75dc653571c955f004700a0f8efb85a34"),
 		},
 		{
 			desc:   "NoPolicyCounter",

--- a/seal.go
+++ b/seal.go
@@ -43,7 +43,7 @@ func makeSealedKeyTemplate() *tpm2.Public {
 }
 
 func computeSealedKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, version uint32, alg, signAlg tpm2.HashAlgorithmId, authKey *rsa.PrivateKey,
-	counterPub *tpm2.NVPublic, counterAuthPolicies tpm2.DigestList, pcrProfile *PCRProtectionProfile, policyRef tpm2.Nonce,
+	counterPub *tpm2.NVPublic, counterAuthPolicies tpm2.DigestList, pcrProfile *PCRProtectionProfile,
 	session tpm2.SessionContext) (*dynamicPolicyData, error) {
 	// Obtain the count for the new policy
 	var nextPolicyCount uint64
@@ -103,8 +103,7 @@ func computeSealedKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, version uint32, alg
 		pcrs:              pcrs,
 		pcrDigests:        pcrDigests,
 		policyCounterName: counterName,
-		policyCount:       nextPolicyCount,
-		policyRef:         policyRef}
+		policyCount:       nextPolicyCount}
 
 	policyData, err := computeDynamicPolicy(version, alg, &policyParams)
 	if err != nil {
@@ -302,7 +301,7 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 		pcrProfile = &PCRProtectionProfile{}
 	}
 	dynamicPolicyData, err := computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, currentMetadataVersion, template.NameAlg,
-		authPublicKey.NameAlg, authKey, pcrPolicyCounterPub, nil, pcrProfile, staticPolicyData.pcrPolicyRef, session)
+		authPublicKey.NameAlg, authKey, pcrPolicyCounterPub, nil, pcrProfile, session)
 	if err != nil {
 		return xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}
@@ -391,7 +390,7 @@ func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath, policyUpdatePath 
 		pcrProfile = &PCRProtectionProfile{}
 	}
 	policyData, err := computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, data.version, data.keyPublic.NameAlg, authPublicKey.NameAlg,
-		authKey, pcrPolicyCounterPub, v0PinIndexAuthPolicies, pcrProfile, data.staticPolicyData.pcrPolicyRef, session)
+		authKey, pcrPolicyCounterPub, v0PinIndexAuthPolicies, pcrProfile, session)
 	if err != nil {
 		return xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}

--- a/seal_test.go
+++ b/seal_test.go
@@ -122,6 +122,12 @@ func TestSealKeyToTPM(t *testing.T) {
 		defer closeTPM(t, tpm)
 		run(t, tpm, false, &KeyCreationParams{PolicyCounterHandle: 0x01810000})
 	})
+
+	t.Run("NoPolicyCounterHandle", func(t *testing.T) {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: tpm2.HandleNull})
+	})
 }
 
 func TestSealKeyToTPMErrorHandling(t *testing.T) {

--- a/seal_test.go
+++ b/seal_test.go
@@ -77,19 +77,19 @@ func TestSealKeyToTPM(t *testing.T) {
 	t.Run("BothFiles", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
 	})
 
 	t.Run("NoPrivFile", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		run(t, tpm, false, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
 	})
 
-	t.Run("DifferentPINHandle", func(t *testing.T) {
+	t.Run("DifferentPolicyCounterHandle", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0})
 	})
 
 	t.Run("SealAfterProvision", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestSealKeyToTPM(t *testing.T) {
 		if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 			t.Errorf("Failed to provision TPM for test: %v", err)
 		}
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
 	})
 
 	t.Run("NoSRK", func(t *testing.T) {
@@ -114,13 +114,13 @@ func TestSealKeyToTPM(t *testing.T) {
 			t.Errorf("EvictControl failed: %v", err)
 		}
 
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PINHandle: 0x01810000})
+		run(t, tpm, false, &KeyCreationParams{PolicyCounterHandle: 0x01810000})
 	})
 }
 
@@ -150,9 +150,9 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 
 		origKeyFileInfo, _ := os.Stat(keyFile)
 		origPolicyUpdateFileInfo, _ := os.Stat(policyUpdateFile)
-		var pinIndex tpm2.ResourceContext
+		var policyCounter tpm2.ResourceContext
 		if params != nil {
-			pinIndex, _ = tpm.CreateResourceContextFromTPM(params.PINHandle)
+			policyCounter, _ = tpm.CreateResourceContextFromTPM(params.PolicyCounterHandle)
 		}
 
 		err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, params)
@@ -164,8 +164,8 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Errorf("SealKeyToTPM created a key file")
 		}
 		if params != nil {
-			if index, err := tpm.CreateResourceContextFromTPM(params.PINHandle); err == nil && (pinIndex == nil || !bytes.Equal(pinIndex.Name(), index.Name())) {
-				t.Errorf("SealKeyToTPM created a PIN NV index")
+			if index, err := tpm.CreateResourceContextFromTPM(params.PolicyCounterHandle); err == nil && (policyCounter == nil || !bytes.Equal(policyCounter.Name(), index.Name())) {
+				t.Errorf("SealKeyToTPM created a dynamic policy counter")
 			}
 		}
 		return err
@@ -190,7 +190,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			resetHierarchyAuth(t, tpm, tpm.OwnerHandleContext())
 		}()
 
-		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
 		if e, ok := err.(AuthFailError); !ok || e.Handle != tpm2.HandleOwner {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -216,7 +216,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}
 		}()
-		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}); err != ErrTPMProvisioning {
+		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000}); err != ErrTPMProvisioning {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
@@ -241,7 +241,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}
 		}()
-		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000}); err != ErrTPMProvisioning {
+		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000}); err != ErrTPMProvisioning {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
@@ -256,7 +256,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("OpenFile failed: %v", err)
 		}
 		defer f.Close()
-		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
 		var e *os.PathError
 		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keydata" || e.Err != syscall.EEXIST {
 			t.Errorf("Unexpected error: %v", err)
@@ -273,7 +273,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("OpenFile failed: %v", err)
 		}
 		defer f.Close()
-		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
 		var e *os.PathError
 		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keypolicyupdatedata" || e.Err != syscall.EEXIST {
 			t.Errorf("Unexpected error: %v", err)
@@ -291,7 +291,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("NVDefineSpace failed: %v", err)
 		}
 		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-		err = run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: public.Index})
+		err = run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: public.Index})
 		if e, ok := err.(TPMResourceExistsError); !ok || e.Handle != public.Index {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -303,7 +303,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			AddProfileOR(
 				NewPCRProtectionProfile(),
 				NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 8))
-		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PINHandle: 0x01810000})
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PolicyCounterHandle: 0x01810000})
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}
@@ -315,7 +315,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 
 	t.Run("InvalidPCRProfileSelection", func(t *testing.T) {
 		pcrProfile := NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 50, make([]byte, tpm2.HashAlgorithmSHA256.Size()))
-		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PINHandle: 0x01810000})
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PolicyCounterHandle: 0x01810000})
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}

--- a/seal_test.go
+++ b/seal_test.go
@@ -77,19 +77,19 @@ func TestSealKeyToTPM(t *testing.T) {
 	t.Run("BothFiles", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
 	})
 
 	t.Run("NoPrivFile", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
+		run(t, tpm, false, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
 	})
 
-	t.Run("DifferentPolicyCounterHandle", func(t *testing.T) {
+	t.Run("DifferentPCRPolicyCounterHandle", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x0181fff0})
 	})
 
 	t.Run("SealAfterProvision", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestSealKeyToTPM(t *testing.T) {
 		if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 			t.Errorf("Failed to provision TPM for test: %v", err)
 		}
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
 	})
 
 	t.Run("NoSRK", func(t *testing.T) {
@@ -114,19 +114,19 @@ func TestSealKeyToTPM(t *testing.T) {
 			t.Errorf("EvictControl failed: %v", err)
 		}
 
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PolicyCounterHandle: 0x01810000})
+		run(t, tpm, false, &KeyCreationParams{PCRPolicyCounterHandle: 0x01810000})
 	})
 
-	t.Run("NoPolicyCounterHandle", func(t *testing.T) {
+	t.Run("NoPCRPolicyCounterHandle", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: tpm2.HandleNull})
+		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	})
 }
 
@@ -158,7 +158,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		origPolicyUpdateFileInfo, _ := os.Stat(policyUpdateFile)
 		var policyCounter tpm2.ResourceContext
 		if params != nil {
-			policyCounter, _ = tpm.CreateResourceContextFromTPM(params.PolicyCounterHandle)
+			policyCounter, _ = tpm.CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
 		}
 
 		err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, params)
@@ -170,7 +170,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Errorf("SealKeyToTPM created a key file")
 		}
 		if params != nil {
-			if index, err := tpm.CreateResourceContextFromTPM(params.PolicyCounterHandle); err == nil && (policyCounter == nil || !bytes.Equal(policyCounter.Name(), index.Name())) {
+			if index, err := tpm.CreateResourceContextFromTPM(params.PCRPolicyCounterHandle); err == nil && (policyCounter == nil || !bytes.Equal(policyCounter.Name(), index.Name())) {
 				t.Errorf("SealKeyToTPM created a dynamic policy counter")
 			}
 		}
@@ -196,7 +196,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			resetHierarchyAuth(t, tpm, tpm.OwnerHandleContext())
 		}()
 
-		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
+		err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
 		if e, ok := err.(AuthFailError); !ok || e.Handle != tpm2.HandleOwner {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -222,7 +222,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}
 		}()
-		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000}); err != ErrTPMProvisioning {
+		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000}); err != ErrTPMProvisioning {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
@@ -247,7 +247,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}
 		}()
-		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000}); err != ErrTPMProvisioning {
+		if err := run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000}); err != ErrTPMProvisioning {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
@@ -262,7 +262,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("OpenFile failed: %v", err)
 		}
 		defer f.Close()
-		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
+		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
 		var e *os.PathError
 		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keydata" || e.Err != syscall.EEXIST {
 			t.Errorf("Unexpected error: %v", err)
@@ -279,7 +279,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("OpenFile failed: %v", err)
 		}
 		defer f.Close()
-		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x01810000})
+		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
 		var e *os.PathError
 		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keypolicyupdatedata" || e.Err != syscall.EEXIST {
 			t.Errorf("Unexpected error: %v", err)
@@ -297,7 +297,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Fatalf("NVDefineSpace failed: %v", err)
 		}
 		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-		err = run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: public.Index})
+		err = run(t, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: public.Index})
 		if e, ok := err.(TPMResourceExistsError); !ok || e.Handle != public.Index {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -309,7 +309,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			AddProfileOR(
 				NewPCRProtectionProfile(),
 				NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 8))
-		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PolicyCounterHandle: 0x01810000})
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: 0x01810000})
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}
@@ -321,7 +321,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 
 	t.Run("InvalidPCRProfileSelection", func(t *testing.T) {
 		pcrProfile := NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 50, make([]byte, tpm2.HashAlgorithmSHA256.Size()))
-		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PolicyCounterHandle: 0x01810000})
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: 0x01810000})
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}

--- a/secboot_test.go
+++ b/secboot_test.go
@@ -122,7 +122,7 @@ func undefineKeyNVSpace(t *testing.T, tpm *TPMConnection, path string) {
 	if err != nil {
 		t.Fatalf("ReadSealedKeyObject failed: %v", err)
 	}
-	rc, err := tpm.CreateResourceContextFromTPM(k.PINIndexHandle())
+	rc, err := tpm.CreateResourceContextFromTPM(k.PolicyCounterHandle())
 	if err != nil {
 		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 	}

--- a/secboot_test.go
+++ b/secboot_test.go
@@ -122,7 +122,11 @@ func undefineKeyNVSpace(t *testing.T, tpm *TPMConnection, path string) {
 	if err != nil {
 		t.Fatalf("ReadSealedKeyObject failed: %v", err)
 	}
-	rc, err := tpm.CreateResourceContextFromTPM(k.PolicyCounterHandle())
+	h := k.PolicyCounterHandle()
+	if h == tpm2.HandleNull {
+		return
+	}
+	rc, err := tpm.CreateResourceContextFromTPM(h)
 	if err != nil {
 		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 	}

--- a/secboot_test.go
+++ b/secboot_test.go
@@ -122,7 +122,7 @@ func undefineKeyNVSpace(t *testing.T, tpm *TPMConnection, path string) {
 	if err != nil {
 		t.Fatalf("ReadSealedKeyObject failed: %v", err)
 	}
-	h := k.PolicyCounterHandle()
+	h := k.PCRPolicyCounterHandle()
 	if h == tpm2.HandleNull {
 		return
 	}

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -184,8 +184,8 @@ func run() int {
 	rand.Read(key)
 
 	params := secboot.KeyCreationParams{
-		PCRProfile:          pcrProfile,
-		PolicyCounterHandle: 0x01801000,
+		PCRProfile:             pcrProfile,
+		PCRPolicyCounterHandle: 0x01801000,
 	}
 
 	keyFile := filepath.Join(outputDir, "key")

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -184,8 +184,8 @@ func run() int {
 	rand.Read(key)
 
 	params := secboot.KeyCreationParams{
-		PCRProfile: pcrProfile,
-		PINHandle:  0x01801000,
+		PCRProfile:          pcrProfile,
+		PolicyCounterHandle: 0x01801000,
 	}
 
 	keyFile := filepath.Join(outputDir, "key")

--- a/unseal.go
+++ b/unseal.go
@@ -140,7 +140,8 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) ([]byte,
 		return nil, err
 	}
 
-	// Required for metadata version > 0
+	// For metadata version > 0, the PIN is the auth value for the sealed key object, and the authorization
+	// policy asserts that this value is known when the policy session is used.
 	key.SetAuthValue([]byte(pin))
 
 	// Unseal

--- a/unseal.go
+++ b/unseal.go
@@ -122,7 +122,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) ([]byte,
 	}
 	defer tpm.FlushContext(policySession)
 
-	if err := executePolicySession(tpm.TPMContext, policySession, k.data.staticPolicyData, k.data.dynamicPolicyData, pin, hmacSession); err != nil {
+	if err := executePolicySession(tpm.TPMContext, policySession, k.data.version, k.data.staticPolicyData, k.data.dynamicPolicyData, pin, hmacSession); err != nil {
 		err = xerrors.Errorf("cannot complete authorization policy assertions: %w", err)
 		switch {
 		case isDynamicPolicyDataError(err):
@@ -140,11 +140,16 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) ([]byte,
 		return nil, err
 	}
 
+	// Required for metadata version > 0
+	key.SetAuthValue([]byte(pin))
+
 	// Unseal
 	keyData, err := tpm.Unseal(key, policySession, hmacSession.IncludeAttrs(tpm2.AttrResponseEncrypt))
 	switch {
 	case tpm2.IsTPMSessionError(err, tpm2.ErrorPolicyFail, tpm2.CommandUnseal, 1):
 		return nil, InvalidKeyFileError{"the authorization policy check failed during unsealing"}
+	case isAuthFailError(err, tpm2.CommandUnseal, 1):
+		return nil, ErrPINFail
 	case err != nil:
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
 	}

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -74,15 +74,15 @@ func TestUnsealWithNo2FA(t *testing.T) {
 	}
 
 	t.Run("SimplePCRProfile", func(t *testing.T) {
-		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0})
+		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x0181fff0})
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {
-		run(t, &KeyCreationParams{PolicyCounterHandle: 0x0181fff0})
+		run(t, &KeyCreationParams{PCRPolicyCounterHandle: 0x0181fff0})
 	})
 
-	t.Run("NoPolicyCounterHandle", func(t *testing.T) {
-		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: tpm2.HandleNull})
+	t.Run("NoPCRPolicyCounterHandle", func(t *testing.T) {
+		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	})
 }
 
@@ -105,7 +105,7 @@ func TestUnsealWithPIN(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0}); err != nil {
+	if err := SealKeyToTPM(tpm, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x0181fff0}); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer undefineKeyNVSpace(t, tpm, keyFile)
@@ -149,7 +149,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 		keyFile := tmpDir + "/keydata"
 		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
 
-		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0}); err != nil {
+		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x0181fff0}); err != nil {
 			t.Fatalf("SealKeyToTPM failed: %v", err)
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)
@@ -270,7 +270,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 			}
 		})
 		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot complete authorization policy "+
-			"assertions: the dynamic authorization policy has been revoked" {
+			"assertions: the PCR policy has been revoked" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -21,9 +21,11 @@ package secboot_test
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/go-tpm2"
@@ -72,11 +74,11 @@ func TestUnsealWithNo2FA(t *testing.T) {
 	}
 
 	t.Run("SimplePCRProfile", func(t *testing.T) {
-		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0})
+		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0})
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {
-		run(t, &KeyCreationParams{PINHandle: 0x0181fff0})
+		run(t, &KeyCreationParams{PolicyCounterHandle: 0x0181fff0})
 	})
 }
 
@@ -99,7 +101,7 @@ func TestUnsealWithPIN(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0}); err != nil {
+	if err := SealKeyToTPM(tpm, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0}); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer undefineKeyNVSpace(t, tpm, keyFile)
@@ -143,17 +145,17 @@ func TestUnsealErrorHandling(t *testing.T) {
 		keyFile := tmpDir + "/keydata"
 		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
 
-		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0}); err != nil {
+		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: 0x0181fff0}); err != nil {
 			t.Fatalf("SealKeyToTPM failed: %v", err)
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)
+
+		fn(keyFile, policyUpdateFile)
 
 		k, err := ReadSealedKeyObject(keyFile)
 		if err != nil {
 			t.Fatalf("ReadSealedKeyObject failed: %v", err)
 		}
-
-		fn(keyFile, policyUpdateFile)
 
 		_, err = k.UnsealFromTPM(tpm, "")
 		return err
@@ -244,7 +246,22 @@ func TestUnsealErrorHandling(t *testing.T) {
 		defer closeTPM(t, tpm)
 
 		err := run(t, tpm, func(keyFile, policyUpdateFile string) {
-			if err := UpdateKeyPCRProtectionPolicy(tpm, keyFile, policyUpdateFile, getTestPCRProfile()); err != nil {
+			src, err := os.Open(keyFile)
+			if err != nil {
+				t.Fatalf("Open failed: %v", err)
+			}
+			defer src.Close()
+
+			newKeyFile := filepath.Dir(keyFile) + "/newkeydata"
+			dst, err := os.OpenFile(newKeyFile, os.O_WRONLY|os.O_CREATE, 0644)
+			if err != nil {
+				t.Fatalf("Open failed: %v", err)
+			}
+			defer dst.Close()
+
+			io.Copy(dst, src)
+
+			if err := UpdateKeyPCRProtectionPolicy(tpm, newKeyFile, policyUpdateFile, getTestPCRProfile()); err != nil {
 				t.Fatalf("UpdateKeyPCRProtectionPolicy failed: %v", err)
 			}
 		})

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -80,6 +80,10 @@ func TestUnsealWithNo2FA(t *testing.T) {
 	t.Run("NilPCRProfile", func(t *testing.T) {
 		run(t, &KeyCreationParams{PolicyCounterHandle: 0x0181fff0})
 	})
+
+	t.Run("NoPolicyCounterHandle", func(t *testing.T) {
+		run(t, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PolicyCounterHandle: tpm2.HandleNull})
+	})
 }
 
 func TestUnsealWithPIN(t *testing.T) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -305,6 +305,12 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "53403b58ad1b561927d19068c655246f2db79d48",
 			"revisionTime": "2020-01-21T17:19:40Z"
+		},
+		{
+			"checksumSHA1": "tZ9GNzrjTZEPDhoJEkouGPKRmZk=",
+			"path": "maze.io/x/crypto/afis",
+			"revision": "9b94c9afe06676a7da39a608a48ed4e31f5d125f",
+			"revisionTime": "2019-01-31T09:06:03Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/secboot"


### PR DESCRIPTION
The current implementation uses a NV index for PIN integration using
the TPM2_PolicySecret assertion. In the original technical plan, PIN
integration was going to be achieved using a separate TPM object (and
TPM2_PolicySecret), although this was changed to a NV index instead.

There are a couple of reasons for this approach:
- The original plan didn't feature the use of the TPM2_PolicyAuthorize
assertion for allowing the PCR policy to be updated without having to
reseal - instead, updating the PCR policy was going to be achieved by
resealing (ie, creating a new sealed key object). Having a separate
object for PIN integration avoids the need to know the PIN in order to
perform a resealing operation.
- I initially thought that the sealed key object containing the disk
encryption key required the userWithAuth attribute in order to use the
object's auth value in its own authorization policy, and we can't set that
attribute on the sealed key object becuase it would mean it could be
unsealed without satisfying the authorization policy.

This last point isn't correct though - a sealed key object's auth value
can be used in its own authorization policy using the TPM2_PolicyAuthValue
assertion without requiring the userWithAuth attribute (it can't be used
in the authorization policy for another object with TPM2_PolicySecret
though).

The current implementation makes use of the TPM2_PolicyAuthorize assertion
so that the PCR policy can be updated without resealing (using
UpdateKeyPCRProtectionPolicy).

This refactors the PIN integration to no longer depend on a NV index,
although the NV index remains because it serves one other purpose (as an
optional counter for revoking PCR policies). The PIN is now implemented
by setting the auth value of the sealed key object with
TPM2_ObjectChangeAuth. As changing the PIN now involves the recreation
of the private part of the sealed key object, the key data file is now also
serialized through the same AF-splitter used by LUKS for storing binary
keyslot data.
