### PR TITLE
Update the vendored version of go-tpm2

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 
 	"golang.org/x/xerrors"
 )
@@ -370,7 +371,7 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 	}
 
 	// Marshal key name and cut-off time for writing to the NV index so that they can be used for verification in the future.
-	data, err := tpm2.MarshalToBytes(lockNVIndexVersion, keyName, time.ClockInfo.Clock)
+	data, err := mu.MarshalToBytes(lockNVIndexVersion, keyName, time.ClockInfo.Clock)
 	if err != nil {
 		panic(fmt.Sprintf("cannot marshal contents for policy data NV index: %v", err))
 	}
@@ -430,7 +431,7 @@ func readAndValidateLockNVIndexPublic(tpm *tpm2.TPMContext, index tpm2.ResourceC
 	var version uint8
 	var keyName tpm2.Name
 	var clock uint64
-	if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
+	if _, err := mu.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
 		return nil, xerrors.Errorf("cannot unmarshal policy data: %w", err)
 	}
 

--- a/policy_test.go
+++ b/policy_test.go
@@ -30,6 +30,7 @@ import (
 	"unsafe"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 	. "github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/testutil"
 )
@@ -76,7 +77,7 @@ func validateLockNVIndex(t *testing.T, tpm *tpm2.TPMContext) {
 	var version uint8
 	var keyName tpm2.Name
 	var clock uint64
-	if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
+	if _, err := mu.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
 		t.Fatalf("UnmarshalFromBytes failed: %v", err)
 	}
 
@@ -343,7 +344,7 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 		var version uint8
 		var keyName tpm2.Name
 		var clock uint64
-		if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
+		if _, err := mu.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
 			t.Fatalf("UnmarshalFromBytes failed: %v", err)
 		}
 
@@ -352,7 +353,7 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 			t.Fatalf("ReadClock failed: %v", err)
 		}
 
-		data, err = tpm2.MarshalToBytes(version, keyName, time.ClockInfo.Clock+3600000)
+		data, err = mu.MarshalToBytes(version, keyName, time.ClockInfo.Clock+3600000)
 		if err != nil {
 			t.Errorf("MarshalToBytes failed: %v", err)
 		}
@@ -472,7 +473,7 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 			t.Errorf("NVWrite failed: %v", err)
 		}
 
-		data, err := tpm2.MarshalToBytes(uint8(0), keyName, time.ClockInfo.Clock)
+		data, err := mu.MarshalToBytes(uint8(0), keyName, time.ClockInfo.Clock)
 		if err != nil {
 			t.Fatalf("MarshalToBytes failed: %v", err)
 		}

--- a/seal.go
+++ b/seal.go
@@ -29,6 +29,7 @@ import (
 	"os"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 	"github.com/snapcore/secboot/internal/tcg"
 
 	"golang.org/x/xerrors"
@@ -271,7 +272,7 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 	// Have the digest of the private data recorded in the creation data for the sealed data object.
 	authKeyBytes := x509.MarshalPKCS1PrivateKey(authKey)
 	h := crypto.SHA256.New()
-	if _, err := tpm2.MarshalToWriter(h, authKeyBytes); err != nil {
+	if _, err := mu.MarshalToWriter(h, authKeyBytes); err != nil {
 		panic(fmt.Sprintf("cannot marshal dynamic authorization policy update data: %v", err))
 	}
 	creationInfo := h.Sum(nil)

--- a/tpm.go
+++ b/tpm.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 	"github.com/snapcore/secboot/internal/tcg"
 	"github.com/snapcore/secboot/internal/tcti"
 	"github.com/snapcore/secboot/internal/truststore"
@@ -148,8 +149,8 @@ func verifyEk(cert *x509.Certificate, ek tpm2.ResourceContext) error {
 
 	// Insert the RSA public key in to the EK template to compute the name of the EK object we expected to read back from the TPM.
 	var ekPublic *tpm2.Public
-	b, _ := tpm2.MarshalToBytes(tcg.EKTemplate)
-	tpm2.UnmarshalFromBytes(b, &ekPublic)
+	b, _ := mu.MarshalToBytes(tcg.EKTemplate)
+	mu.UnmarshalFromBytes(b, &ekPublic)
 
 	// The default exponent of 2^^16-1 is indicated by the value of 0 in the public area.
 	if pubKey.E != 65537 {
@@ -745,7 +746,7 @@ func saveEkCertificateChain(data *ekCertData, dest string) error {
 	}
 	defer f.Cancel()
 
-	if _, err := tpm2.MarshalToWriter(f, data); err != nil {
+	if _, err := mu.MarshalToWriter(f, data); err != nil {
 		return xerrors.Errorf("cannot marshal cert chain: %w", err)
 	}
 
@@ -816,7 +817,7 @@ func EncodeEKCertificateChain(ekCert *x509.Certificate, parents []*x509.Certific
 		data.Parents = append(data.Parents, c.Raw)
 	}
 
-	if _, err := tpm2.MarshalToWriter(w, &data); err != nil {
+	if _, err := mu.MarshalToWriter(w, &data); err != nil {
 		return xerrors.Errorf("cannot marshal cert chain: %w", err)
 	}
 
@@ -908,7 +909,7 @@ func SecureConnectToDefaultTPM(ekCertDataReader io.Reader, endorsementAuth []byt
 
 	var certData *ekCertData
 	// Unmarshal supplied EK cert data
-	if _, err := tpm2.UnmarshalFromReader(ekCertDataReader, &certData); err != nil {
+	if _, err := mu.UnmarshalFromReader(ekCertDataReader, &certData); err != nil {
 		return nil, EKCertVerificationError{fmt.Sprintf("cannot unmarshal supplied EK certificate data: %v", err)}
 	}
 	if len(certData.Cert) == 0 {

--- a/utils.go
+++ b/utils.go
@@ -26,6 +26,7 @@ import (
 	"os"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 
 	"golang.org/x/xerrors"
 )
@@ -84,16 +85,16 @@ func isObjectPrimaryKeyWithTemplate(tpm *tpm2.TPMContext, hierarchy, object tpm2
 
 	pub.Unique = template.Unique
 
-	pubBytes, _ := tpm2.MarshalToBytes(pub)
-	templateBytes, _ := tpm2.MarshalToBytes(template)
+	pubBytes, _ := mu.MarshalToBytes(pub)
+	templateBytes, _ := mu.MarshalToBytes(template)
 	if !bytes.Equal(pubBytes, templateBytes) {
 		// For RSA keys, the default exponent (2^^16 - 1) is normally indicated by the value 0, but handle a TPM that actually
 		// returns 65537 by trying again.
 		if template.Type == tpm2.ObjectTypeRSA && template.Params.RSADetail().Exponent == 0 {
 			var templateCopy *tpm2.Public
-			tpm2.UnmarshalFromBytes(templateBytes, &templateCopy)
+			mu.UnmarshalFromBytes(templateBytes, &templateCopy)
 			templateCopy.Params.RSADetail().Exponent = 65537
-			templateBytes, _ = tpm2.MarshalToBytes(templateCopy)
+			templateBytes, _ = mu.MarshalToBytes(templateCopy)
 			if !bytes.Equal(pubBytes, templateBytes) {
 				return false, nil
 			}
@@ -110,7 +111,7 @@ func isObjectPrimaryKeyWithTemplate(tpm *tpm2.TPMContext, hierarchy, object tpm2
 	h.Write(hierarchy.Name())
 	h.Write(object.Name())
 
-	expectedQualifiedName, _ := tpm2.MarshalToBytes(pub.NameAlg, tpm2.RawBytes(h.Sum(nil)))
+	expectedQualifiedName, _ := mu.MarshalToBytes(pub.NameAlg, mu.RawBytes(h.Sum(nil)))
 	if !bytes.Equal(expectedQualifiedName, qualifiedName) {
 		return false, nil
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,16 +3,22 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "s0Ow9uk/0H2Pmfq4JAGpzy5x6T0=",
+			"checksumSHA1": "inZOuvF07VvZnsj1HvApM8Uf7qY=",
 			"path": "github.com/canonical/go-tpm2",
-			"revision": "aaf158ed20ca23c48b446f78fb0bbaf4055e7123",
-			"revisionTime": "2020-05-14T15:04:06Z"
+			"revision": "fb781d04d0dea72f916cc68b637b7be6bcb3ccd4",
+			"revisionTime": "2020-08-24T18:49:43Z"
 		},
 		{
 			"checksumSHA1": "bT/rC7K8St3lNRXf/XJGpB4wNJU=",
 			"path": "github.com/canonical/go-tpm2/internal",
 			"revision": "16307201a54dc51583440f9416cfa836bcf0b3fc",
 			"revisionTime": "2020-04-16T00:17:14Z"
+		},
+		{
+			"checksumSHA1": "fGle5W3B2jSAsLeOQnRbGG7uyV8=",
+			"path": "github.com/canonical/go-tpm2/mu",
+			"revision": "8f372d7de1b07c887e388874555d48f9161feaed",
+			"revisionTime": "2020-08-24T11:54:14Z"
 		},
 		{
 			"checksumSHA1": "eDjzake0GpHm9kfTH7FMUWX8zVA=",


### PR DESCRIPTION
This simplifies the CustomMarshaller interface so that implementations
don't need to keep track of the number of bytes read or written.