### PR TITLE
Move some functions to SealedKeyObject

### DIFF
--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -183,19 +183,24 @@ func (s *compatTestSuiteBase) TestChangePIN(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(k.AuthMode2F(), Equals, secboot.AuthModeNone)
 
-	c.Check(secboot_tpm2.ChangePIN(s.TPM, s.absPath("key"), "", testPIN), IsNil)
+	c.Check(k.ChangePIN(s.TPM, "", testPIN), IsNil)
+	c.Check(k.AuthMode2F(), Equals, secboot.AuthModePassphrase)
 	k, err = secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.AuthMode2F(), Equals, secboot.AuthModePassphrase)
 
-	c.Check(secboot_tpm2.ChangePIN(s.TPM, s.absPath("key"), testPIN, ""), IsNil)
+	c.Check(k.ChangePIN(s.TPM, testPIN, ""), IsNil)
+	c.Check(k.AuthMode2F(), Equals, secboot.AuthModeNone)
 	k, err = secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.AuthMode2F(), Equals, secboot.AuthModeNone)
 }
 
 func (s *compatTestSuiteBase) testUnsealWithPIN(c *C, pcrEventsFile string) {
-	c.Check(secboot_tpm2.ChangePIN(s.TPM, s.absPath("key"), "", testPIN), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	c.Assert(err, IsNil)
+	c.Check(k.ChangePIN(s.TPM, "", testPIN), IsNil)
+
 	s.replayPCRSequenceFromFile(c, pcrEventsFile)
 	s.testUnsealCommon(c, testPIN)
 }

--- a/internal/compattest/v0_test.go
+++ b/internal/compattest/v0_test.go
@@ -79,7 +79,9 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicy(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicyV0(s.TPM, s.absPath("key"), s.absPath("pud"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	c.Assert(err, IsNil)
+	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
 }
 
 func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyRevokes(c *C) {
@@ -89,7 +91,10 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyRevokes(c *C) {
 
 	key2 := s.copyFile(c, s.absPath("key"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicyV0(s.TPM, key2, s.absPath("pud"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(key2)
+	c.Assert(err, IsNil)
+
+	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
 	s.replayPCRSequenceFromFile(c, s.absPath("pcrSequence.1"))
 	s.testUnsealErrorMatchesCommon(c, "invalid key data file: cannot complete authorization policy assertions: the PCR policy has been revoked")
 }
@@ -99,7 +104,9 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAndUnseal(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicyV0(s.TPM, s.absPath("key"), s.absPath("pud"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	c.Assert(err, IsNil)
+	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
 
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "7 11 %x\n", testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
@@ -116,7 +123,9 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAfterLock(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicyV0(s.TPM, s.absPath("key"), s.absPath("pud"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	c.Assert(err, IsNil)
+	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
 }
 
 func (s *compatTestV0Suite) TestUnsealAfterLock(c *C) {

--- a/internal/compattest/v1_test.go
+++ b/internal/compattest/v1_test.go
@@ -68,7 +68,9 @@ func (s *compatTestV1Suite) TestUpdateKeyPCRProtectionPolicy(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicy(s.TPM, s.absPath("key"), s.readFile(c, "authKey"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	c.Assert(err, IsNil)
+	c.Check(k.UpdatePCRProtectionPolicy(s.TPM, s.readFile(c, "authKey"), profile), IsNil)
 }
 
 func (s *compatTestV1Suite) TestUpdateKeyPCRProtectionPolicyRevokes(c *C) {
@@ -78,7 +80,10 @@ func (s *compatTestV1Suite) TestUpdateKeyPCRProtectionPolicyRevokes(c *C) {
 
 	key2 := s.copyFile(c, s.absPath("key"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicy(s.TPM, key2, s.readFile(c, "authKey"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(key2)
+	c.Assert(err, IsNil)
+
+	c.Check(k.UpdatePCRProtectionPolicy(s.TPM, s.readFile(c, "authKey"), profile), IsNil)
 	s.replayPCRSequenceFromFile(c, s.absPath("pcrSequence.1"))
 	s.testUnsealErrorMatchesCommon(c, "invalid key data file: cannot complete authorization policy assertions: the PCR policy has been revoked")
 }
@@ -88,7 +93,9 @@ func (s *compatTestV1Suite) TestUpdateKeyPCRProtectionPolicyAndUnseal(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicy(s.TPM, s.absPath("key"), s.readFile(c, "authKey"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	c.Assert(err, IsNil)
+	c.Check(k.UpdatePCRProtectionPolicy(s.TPM, s.readFile(c, "authKey"), profile), IsNil)
 
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "7 11 %x\n", testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
@@ -105,7 +112,9 @@ func (s *compatTestV1Suite) TestUpdateKeyPCRProtectionPolicyAfterLock(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	c.Check(secboot_tpm2.UpdateKeyPCRProtectionPolicy(s.TPM, s.absPath("key"), s.readFile(c, "authKey"), profile), IsNil)
+	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	c.Assert(err, IsNil)
+	c.Check(k.UpdatePCRProtectionPolicy(s.TPM, s.readFile(c, "authKey"), profile), IsNil)
 }
 
 func (s *compatTestV1Suite) TestUnsealAfterLock(c *C) {

--- a/tpm2/crypt_test.go
+++ b/tpm2/crypt_test.go
@@ -366,7 +366,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeys6(c *C)
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
-	c.Assert(ChangePIN(s.TPM, keyFile, "", "1234"), IsNil)
+
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleSealedKeys(c, &testActivateVolumeWithMultipleSealedKeysData{
 		volumeName:       "data",
@@ -386,8 +389,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeys7(c *C)
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
-	c.Assert(ChangePIN(s.TPM, keyFile, "", "1234"), IsNil)
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+
+	for _, p := range []string{keyFile, s.keyFile} {
+		k, err := ReadSealedKeyObject(p)
+		c.Assert(err, IsNil)
+		c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
+	}
 
 	s.testActivateVolumeWithMultipleSealedKeys(c, &testActivateVolumeWithMultipleSealedKeysData{
 		volumeName:       "data",
@@ -410,8 +417,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeys8(c *C)
 
 	authPrivateKey, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
-	c.Assert(ChangePIN(s.TPM, keyFile, "", "1234"), IsNil)
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+
+	for _, p := range []string{keyFile, s.keyFile} {
+		k, err := ReadSealedKeyObject(p)
+		c.Assert(err, IsNil)
+		c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
+	}
 
 	s.testActivateVolumeWithMultipleSealedKeys(c, &testActivateVolumeWithMultipleSealedKeysData{
 		volumeName:       "data",
@@ -434,8 +445,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeys9(c *C)
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
-	c.Assert(ChangePIN(s.TPM, keyFile, "", "1234"), IsNil)
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+
+	for _, p := range []string{keyFile, s.keyFile} {
+		k, err := ReadSealedKeyObject(p)
+		c.Assert(err, IsNil)
+		c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
+	}
 
 	s.testActivateVolumeWithMultipleSealedKeys(c, &testActivateVolumeWithMultipleSealedKeysData{
 		volumeName:       "data",
@@ -459,7 +474,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeys10(c *C
 	pcrProfile := NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7).ExtendPCR(tpm2.HashAlgorithmSHA256, 7, make([]byte, 32))
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleSealedKeys(c, &testActivateVolumeWithMultipleSealedKeysData{
 		volumeName:       "data",
@@ -672,8 +690,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeysErrorHa
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
-	c.Assert(ChangePIN(s.TPM, keyFile, "", "1234"), IsNil)
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+
+	for _, path := range []string{keyFile, s.keyFile} {
+		k, err := ReadSealedKeyObject(path)
+		c.Assert(err, IsNil)
+		c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
+	}
 
 	s.testActivateVolumeWithMultipleSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleSealedKeysErrorHandlingData{
 		keyFiles:         []string{s.keyFile, keyFile},
@@ -732,7 +754,9 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeysErrorHa
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
 
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleSealedKeysErrorHandlingData{
 		keyFiles:         []string{s.keyFile, keyFile},
@@ -931,8 +955,11 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithSealedKeyAndPIN(c *C, dat
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPIN1(c *C) {
 	// Test with a single PIN attempt.
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", testPIN), IsNil)
 	s.testActivateVolumeWithSealedKeyAndPIN(c, &testActivateVolumeWithSealedKeyAndPINData{
 		pins:     []string{testPIN},
 		pinTries: 1,
@@ -941,8 +968,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPIN1(c *C) {
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPIN2(c *C) {
 	// Test with 2 PIN attempts.
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", testPIN), IsNil)
 	s.testActivateVolumeWithSealedKeyAndPIN(c, &testActivateVolumeWithSealedKeyAndPINData{
 		pins:     []string{"", testPIN},
 		pinTries: 2,
@@ -983,8 +1013,11 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithSealedKeyAndPINUsingPINRe
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPINUsingPINReader1(c *C) {
 	// Test with the correct PIN provided via the io.Reader.
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithSealedKeyAndPINUsingPINReaderData{
 		pinFileContents: testPIN + "\n",
@@ -994,8 +1027,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPINUsingPINRe
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPINUsingPINReader2(c *C) {
 	// Test with the correct PIN provided via the io.Reader when the file doesn't end in a newline.
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithSealedKeyAndPINUsingPINReaderData{
 		pinFileContents: testPIN,
@@ -1005,8 +1041,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPINUsingPINRe
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPINUsingPINReader3(c *C) {
 	// Test falling back to asking for a PIN if the wrong PIN is provided via the io.Reader.
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithSealedKeyAndPINUsingPINReaderData{
 		pins:            []string{testPIN},
@@ -1017,8 +1056,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPINUsingPINRe
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyAndPINUsingPINReader4(c *C) {
 	// Test falling back to asking for a PIN without using a try if the io.Reader has no contents.
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithSealedKeyAndPINUsingPINReaderData{
 		pins:     []string{testPIN},
@@ -1184,8 +1226,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyErrorHandling7(c
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyErrorHandling8(c *C) {
 	// Test that recovery fallback works if the wrong PIN is supplied.
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(k.ChangePIN(s.TPM, "", testPIN), IsNil)
 	s.testActivateVolumeWithSealedKeyErrorHandling(c, &testActivateVolumeWithSealedKeyErrorHandlingData{
 		pinTries:         1,
 		recoveryKeyTries: 1,
@@ -1203,7 +1248,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyErrorHandling8(c
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyErrorHandling9(c *C) {
 	// Test that recovery fallback works if a PIN is set but no PIN attempts are permitted.
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+	k, err := ReadSealedKeyObject(s.keyFile)
+	c.Assert(err, IsNil)
+
+	c.Assert(k.ChangePIN(s.TPM, "", "1234"), IsNil)
 	s.testActivateVolumeWithSealedKeyErrorHandling(c, &testActivateVolumeWithSealedKeyErrorHandlingData{
 		recoveryKeyTries: 1,
 		passphrases:      []string{s.recoveryKey.String()},

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -731,8 +731,7 @@ func decodeAndValidateKeyData(tpm *tpm2.TPMContext, keyFile io.Reader, authData 
 	return data, authKey, pcrPolicyCounterPub, nil
 }
 
-// SealedKeyObject corresponds to a sealed key data file and exists to provide access to some read only operations on the underlying
-// file without having to read and deserialize the key data file more than once.
+// SealedKeyObject corresponds to a sealed key data file.
 type SealedKeyObject struct {
 	path string // XXX: This is here temporarily and will be removed in a future PR
 	data *keyData

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -734,6 +734,7 @@ func decodeAndValidateKeyData(tpm *tpm2.TPMContext, keyFile io.Reader, authData 
 // SealedKeyObject corresponds to a sealed key data file and exists to provide access to some read only operations on the underlying
 // file without having to read and deserialize the key data file more than once.
 type SealedKeyObject struct {
+	path string // XXX: This is here temporarily and will be removed in a future PR
 	data *keyData
 }
 
@@ -772,5 +773,5 @@ func ReadSealedKeyObject(path string) (*SealedKeyObject, error) {
 		return nil, InvalidKeyFileError{err.Error()}
 	}
 
-	return &SealedKeyObject{data: data}, nil
+	return &SealedKeyObject{path: path, data: data}, nil
 }

--- a/tpm2/pin.go
+++ b/tpm2/pin.go
@@ -138,14 +138,12 @@ func performPinChange(tpm *tpm2.TPMContext, keyPrivate tpm2.Private, keyPublic *
 	return newKeyPrivate, nil
 }
 
-// ChangePIN changes the PIN for the key data file at the specified path. The existing PIN must be supplied via the oldPIN argument.
+// ChangePIN changes the PIN for this sealed key object. The existing PIN must be supplied via the oldPIN argument.
 // Setting newPIN to an empty string will clear the PIN and set a hint on the key data file that no PIN is set.
 //
 // If the TPM's dictionary attack logic has been triggered, a ErrTPMLockout error will be returned.
 //
-// If the file at the specified path cannot be opened, then a wrapped *os.PathError error will be returned.
-//
-// If the supplied key data file fails validation checks, an InvalidKeyFileError error will be returned.
+// If validation of the sealed key object fails, an InvalidKeyFileError error will be returned.
 //
 // If oldPIN is incorrect, then a ErrPINFail error will be returned and the TPM's dictionary attack counter will be incremented.
 func (k *SealedKeyObject) ChangePIN(tpm *Connection, oldPIN, newPIN string) error {

--- a/tpm2/pin.go
+++ b/tpm2/pin.go
@@ -165,7 +165,7 @@ func (k *SealedKeyObject) ChangePIN(tpm *Connection, oldPIN, newPIN string) erro
 		if isKeyFileError(err) {
 			return InvalidKeyFileError{err.Error()}
 		}
-		return xerrors.Errorf("cannot read and validate key data file: %w", err)
+		return xerrors.Errorf("cannot validate key data: %w", err)
 	}
 
 	// Change the PIN

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -618,13 +618,13 @@ func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keys []*SealedKeyO
 	return nil
 }
 
-// UpdatePCRProtectionPolicyV0 updates the PCR protection policy for the sealed key at the path specified by the keyPath argument
-// to the profile defined by the pcrProfile argument. This function only works with version 0 sealed key files. In order to do this,
-// the caller must also specify the path to the policy update data file that was originally saved by SealKeyToTPM.
+// UpdatePCRProtectionPolicyV0 updates the PCR protection policy for this sealed key object to the profile defined by the
+// pcrProfile argument. This function only works with version 0 sealed key data objects. In order to do this, the caller
+// must also specify the path to the policy update data file that was originally saved by SealKeyToTPM.
 //
-// If either file cannot be opened, a wrapped *os.PathError error will be returned.
+// If the policy update data file cannot be opened, a wrapped *os.PathError error will be returned.
 //
-// If either file cannot be deserialized correctly or validation of the files fails, a InvalidKeyFileError error will be returned.
+// If validation of the sealed key data fails, a InvalidKeyFileError error will be returned.
 //
 // On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
 // computed from the supplied PCRProtectionProfile.
@@ -646,13 +646,11 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicyV0(tpm *Connection, policyUpd
 	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, []*SealedKeyObject{k}, policyUpdateData.authKey, pcrProfile, tpm.HmacSession())
 }
 
-// UpdatePCRProtectionPolicy updates the PCR protection policy for the sealed key at the path specified by the keyPath argument
-// to the profile defined by the pcrProfile argument. In order to do this, the caller must also specify the private part of the
-// authorization key that was either returned by SealKeyToTPM or SealedKeyObject.UnsealFromTPM.
+// UpdatePCRProtectionPolicy updates the PCR protection policy for this sealed key object to the profile defined by the
+// pcrProfile argument. In order to do this, the caller must also specify the private part of the authorization key
+// that was either returned by SealKeyToTPM or SealedKeyObject.UnsealFromTPM.
 //
-// If the file cannot be opened, a wrapped *os.PathError error will be returned.
-//
-// If the file cannot be deserialized correctly or validation of the file fails, a InvalidKeyFileError error will be returned.
+// If validation of the sealed key data fails, a InvalidKeyFileError error will be returned.
 //
 // On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
 // computed from the supplied PCRProtectionProfile. If the sealed key data file was created with a PCR policy counter, the
@@ -665,14 +663,11 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey Pol
 	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, []*SealedKeyObject{k}, ecdsaAuthKey, pcrProfile, tpm.HmacSession())
 }
 
-// UpdateKeyPCRProtectionPolicyMultiple updates the PCR protection policy for the sealed keys at the paths specified
-// by the keyPaths argument to the profile defined by the pcrProfile argument. The keys must all be related (ie, they
-// were created using SealKeyToTPMMultiple). If any key in the supplied set is not related, an error will be returned.
+// UpdateKeyPCRProtectionPolicyMultiple updates the PCR protection policy for the supplied sealed key objects to the
+// profile defined by the pcrProfile argument. The keys must all be related (ie, they were created using
+// SealKeyToTPMMultiple). If any key in the supplied set is not related, an error will be returned.
 //
-// If any file cannot be opened, a wrapped *os.PathError error will be returned.
-//
-// If any file cannot be deserialized correctly or validation of a file fails, a InvalidKeyFileError error will
-// be returned.
+// If validation of any sealed key object fails, a InvalidKeyFileError error will be returned.
 //
 // On success, each sealed key data file is updated atomically with an updated authorization policy that includes a PCR
 // policy computed from the supplied PCRProtectionProfile. If the sealed key data files were created with a PCR policy

--- a/tpm2/unseal.go
+++ b/tpm2/unseal.go
@@ -51,8 +51,8 @@ import (
 //
 // If the TPM is missing any persistent resources associated with this key file, then a InvalidKeyFileError error will be returned.
 //
-// If the key file has been superceded (eg, by a call to UpdateKeyPCRProtectionPolicy), then a InvalidKeyFileError error will be
-// returned.
+// If the key file has been superceded (eg, by a call to SealedKeyObject.UpdatePCRProtectionPolicy), then a InvalidKeyFileError error
+// will be returned.
 //
 // If the signature of the updatable part of the key file's authorization policy is invalid, then a InvalidKeyFileError error will
 // be returned.

--- a/tpm2/unseal_test.go
+++ b/tpm2/unseal_test.go
@@ -232,15 +232,15 @@ func TestUnsealWithPIN(t *testing.T) {
 	}
 	defer undefineKeyNVSpace(t, tpm, keyFile)
 
-	testPIN := "1234"
-
-	if err := ChangePIN(tpm, keyFile, "", testPIN); err != nil {
-		t.Errorf("ChangePIN failed: %v", err)
-	}
-
 	k, err := ReadSealedKeyObject(keyFile)
 	if err != nil {
 		t.Fatalf("ReadSealedKeyObject failed: %v", err)
+	}
+
+	testPIN := "1234"
+
+	if err := k.ChangePIN(tpm, "", testPIN); err != nil {
+		t.Errorf("ChangePIN failed: %v", err)
 	}
 
 	keyUnsealed, _, err := k.UnsealFromTPM(tpm, testPIN)
@@ -402,7 +402,11 @@ func TestUnsealErrorHandling(t *testing.T) {
 
 	t.Run("PINFail", func(t *testing.T) {
 		err := run(t, func(tpm *Connection, keyFile string, _ []byte) {
-			if err := ChangePIN(tpm, keyFile, "", "1234"); err != nil {
+			k, err := ReadSealedKeyObject(keyFile)
+			if err != nil {
+				t.Fatalf("ReadSealedKeyObject failed: %v", err)
+			}
+			if err := k.ChangePIN(tpm, "", "1234"); err != nil {
 				t.Errorf("ChangePIN failed: %v", err)
 			}
 		})

--- a/tpm2/unseal_test.go
+++ b/tpm2/unseal_test.go
@@ -377,8 +377,13 @@ func TestUnsealErrorHandling(t *testing.T) {
 
 			io.Copy(dst, src)
 
-			if err := UpdateKeyPCRProtectionPolicy(tpm, newKeyFile, authKey, getTestPCRProfile()); err != nil {
-				t.Fatalf("UpdateKeyPCRProtectionPolicy failed: %v", err)
+			k, err := ReadSealedKeyObject(newKeyFile)
+			if err != nil {
+				t.Fatalf("ReadSealedKeyObject failed: %v", err)
+			}
+
+			if err := k.UpdatePCRProtectionPolicy(tpm, authKey, getTestPCRProfile()); err != nil {
+				t.Fatalf("UpdatePCRProtectionPolicy failed: %v", err)
 			}
 		})
 		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot complete authorization policy "+


### PR DESCRIPTION
SealedKeyObject was originally intended to provide some read-only interaction with a sealed key file to avoid having to decode it more than once. There are some additional functions in the global namespace that modify a keyfile (ChangePIN and UpdateKeyPCRProtectionPolicy).

In order to create a tpm2 KeyData platform implementation, the functions that interact with TPM sealed keys need to be updated to work with bytes without having to care about how the bytes are stored. The current functions have a hard dependency on file storage because file paths are exposed via the APIs.

As a prerequisite to removing the hard dependency on file storage, the existing global functions that modify a keyfile should be converted to methods of SealedKeyObject. Future PRs will then work towards removing the file dependency, and adding in some helper functions for reading / writing existing key files.

For additional context of where things are going, see https://github.com/snapcore/secboot/pull/154, https://github.com/snapcore/secboot/pull/158, https://github.com/snapcore/secboot/pull/159 and https://github.com/snapcore/secboot/pull/161, which get to the point of being able to unlock volumes
using the new secboot.ActivateVolumeWithKeyData API with existing TPM key files - the next step
after this is to make the code in tpm2/ a proper KeyData implementation.

(I'll rebase this on https://github.com/snapcore/secboot/pull/160 once it lands so that the tests pass)