### PR TITLE
Use LUKS tokens to identify keyslots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-
+dist: bionic
 install:
   - sudo apt-get update
   - sudo apt-get install -y sbsigntool

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-dist: bionic
+dist: focal
 install:
   - sudo apt-get update
   - sudo apt-get install -y sbsigntool

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: bionic
 install:
   - sudo apt-get update
   - sudo apt-get install -y sbsigntool
-  - sudo snap install core core18
   - sudo snap install --edge tpm2-simulator-chrisccoulson
   - ./get-deps
 script:

--- a/crypt.go
+++ b/crypt.go
@@ -447,7 +447,7 @@ func InitializeLUKS2Container(devicePath, label string, key []byte) error {
 		return xerrors.Errorf("cannot set keyslot priority: %w", err)
 	}
 
-	if err := luks2.ImportToken(devicePath, &luks2.Token{Type: masterTokenType, Keyslots: []luks2.Ints{0}}); err != nil {
+	if err := luks2.ImportToken(devicePath, &luks2.Token{Type: masterTokenType, Keyslots: []int{0}}); err != nil {
 		return xerrors.Errorf("cannot add token: %w", err)
 	}
 
@@ -489,7 +489,7 @@ func setLUKS2ContainerKey(devicePath string, existingKey, newKey []byte, tokenTy
 		return 0, errors.New("cannot determine new keyslot ID")
 	}
 
-	if err := luks2.ImportToken(devicePath, &luks2.Token{Type: tokenType, Keyslots: []luks2.Ints{luks2.Ints(newSlotId)}}); err != nil {
+	if err := luks2.ImportToken(devicePath, &luks2.Token{Type: tokenType, Keyslots: []int{newSlotId}}); err != nil {
 		return 0, xerrors.Errorf("cannot add new token: %w", err)
 	}
 
@@ -497,8 +497,8 @@ func setLUKS2ContainerKey(devicePath string, existingKey, newKey []byte, tokenTy
 		return newSlotId, nil
 	}
 
-	if len(startInfo.Metadata.Tokens[luks2.Ints(oldTokenId)].Keyslots) > 0 {
-		if err := luks2.KillSlot(devicePath, int(startInfo.Metadata.Tokens[luks2.Ints(oldTokenId)].Keyslots[0]), newKey); err != nil {
+	if len(startInfo.Metadata.Tokens[oldTokenId].Keyslots) > 0 {
+		if err := luks2.KillSlot(devicePath, int(startInfo.Metadata.Tokens[oldTokenId].Keyslots[0]), newKey); err != nil {
 			return 0, xerrors.Errorf("cannot delete old keyslot: %w", err)
 		}
 	}

--- a/crypt.go
+++ b/crypt.go
@@ -435,8 +435,9 @@ func ActivateVolumeWithRecoveryKey(volumeName, sourceDevicePath string, keyReade
 // InitializeLUKS2Container will initialize the partition at the specified devicePath as a new LUKS2 container. This can only
 // be called on a partition that isn't mapped. The label for the new LUKS2 container is provided via the label argument.
 //
-// The initial key used for unlocking the container is provided via the key argument, and must be a cryptographically secure
-// 64-byte random number. The key should be stored encrypted by using SealKeyToTPM.
+// The initial master key used for unlocking the container is provided via the key argument, and must be a cryptographically secure
+// 64-byte random number. The key should be stored encrypted by using SealKeyToTPM. Note that "master key" in this context refers
+// to the main key used to activate the volume, and is not the same as the LUKS volume key.
 //
 // The container will be configured to encrypt data with AES-256 and XTS block cipher mode.
 //

--- a/crypt.go
+++ b/crypt.go
@@ -517,7 +517,7 @@ func setLUKS2ContainerKey(devicePath string, existingKey, newKey []byte, tokenTy
 	}
 
 	if len(startInfo.Metadata.Tokens[luks2.Ints(oldTokenId)].Keyslots) > 0 {
-		if err := luks2.KillSlot(devicePath, int(startInfo.Metadata.Tokens[luks2.Ints(oldTokenId)].Keyslots[0]), existingKey); err != nil {
+		if err := luks2.KillSlot(devicePath, int(startInfo.Metadata.Tokens[luks2.Ints(oldTokenId)].Keyslots[0]), newKey); err != nil {
 			return 0, xerrors.Errorf("cannot delete old keyslot: %w", err)
 		}
 	}

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1185,9 +1185,7 @@ func (s *cryptSuite) testInitializeLUKS2Container(c *C, data *testInitializeLUKS
 	c.Assert(token.Keyslots, HasLen, 1)
 	c.Check(int(token.Keyslots[0]), Equals, 0)
 
-	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", devicePath)
-	cmd.Stdin = bytes.NewReader(data.key)
-	c.Check(cmd.Run(), IsNil)
+	testutil.CheckLUKS2Passphrase(c, devicePath, data.key)
 }
 
 func (s *cryptSuite) TestInitializeLUKS2Container1(c *C) {
@@ -1255,9 +1253,7 @@ func (s *cryptSuite) testSetLUKS2ContainerRecoveryKey(c *C, data *testSetLUKS2Co
 	c.Assert(keyslot.KDF, NotNil)
 	c.Check(keyslot.KDF.Type, Equals, "argon2i")
 
-	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", devicePath)
-	cmd.Stdin = bytes.NewReader(data.recoveryKey)
-	c.Check(cmd.Run(), IsNil)
+	testutil.CheckLUKS2Passphrase(c, devicePath, data.recoveryKey)
 }
 
 func (s *cryptSuite) TestSetLUKS2ContainerRecoveryKey1(c *C) {
@@ -1326,9 +1322,7 @@ func (s *cryptSuite) testSetLUKS2ContainerMasterKey(c *C, data *testSetLUKS2Cont
 	c.Check(keyslot.KDF.Time, Equals, 4)
 	c.Check(keyslot.KDF.Memory, Equals, 32)
 
-	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", devicePath)
-	cmd.Stdin = bytes.NewReader(data.key)
-	c.Check(cmd.Run(), IsNil)
+	testutil.CheckLUKS2Passphrase(c, devicePath, data.key)
 }
 
 func (s *cryptSuite) TestSetLUKS2ContainerMasterKey1(c *C) {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1279,7 +1279,7 @@ func (s *cryptSuite) TestInitializeLUKS2Container3(c *C) {
 }
 
 func (s *cryptSuite) TestInitializeLUKS2ContainerInvalidKeySize(c *C) {
-	c.Check(InitializeLUKS2Container("/dev/sda1", "data", s.masterKey[0:32]), ErrorMatches, "expected a key length of 512-bits \\(got 256\\)")
+	c.Check(InitializeLUKS2Container("/dev/sda1", "data", s.masterKey[0:32]), ErrorMatches, "cannot format device: expected a key length of 512-bits \\(got 256\\)")
 }
 
 type testAddRecoveryKeyToLUKS2ContainerData struct {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -163,18 +163,7 @@ fi
 		}
 	})
 
-	cryptsetupWrapperBottom := `
-# Set max locked memory to 0. Without this and without CAP_IPC_LOCK, mlockall will
-# succeed but subsequent calls to mmap will fail because the limit is too low. Setting
-# this to 0 here will cause mlockall to fail, which cryptsetup ignores.
-ulimit -l 0
-exec %[1]s "$@" </dev/stdin
-`
-
-	cryptsetup, err := exec.LookPath("cryptsetup")
-	c.Assert(err, IsNil)
-
-	cryptsetupWrapper := snapd_testutil.MockCommand(c, "cryptsetup", fmt.Sprintf(cryptsetupWrapperBottom, cryptsetup))
+	cryptsetupWrapper := testutil.WrapCryptsetup(c)
 	ctb.base.AddCleanup(cryptsetupWrapper.Restore)
 }
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -113,7 +113,7 @@ func (ctb *cryptTestBase) setUpSuiteBase(c *C) {
 
 func (ctb *cryptTestBase) setUpTestBase(c *C, bt *snapd_testutil.BaseTest) {
 	ctb.dir = c.MkDir()
-	bt.AddCleanup(MockRunDir(ctb.dir))
+	bt.AddCleanup(testutil.MockRunDir(ctb.dir))
 
 	ctb.passwordFile = filepath.Join(ctb.dir, "password")                       // passwords to be returned by the mock sd-ask-password
 	ctb.expectedTpmKeyFile = filepath.Join(ctb.dir, "expectedtpmkey")           // TPM key expected by the mock systemd-cryptsetup
@@ -139,7 +139,7 @@ fi
 `
 	ctb.mockSdCryptsetup = snapd_testutil.MockCommand(c, c.MkDir()+"/systemd-cryptsetup", fmt.Sprintf(sdCryptsetupBottom, ctb.expectedTpmKeyFile, ctb.expectedRecoveryKeyFile))
 	bt.AddCleanup(ctb.mockSdCryptsetup.Restore)
-	bt.AddCleanup(MockSystemdCryptsetupPath(ctb.mockSdCryptsetup.Exe()))
+	bt.AddCleanup(testutil.MockSystemdCryptsetupPath(ctb.mockSdCryptsetup.Exe()))
 
 	cryptsetupBottom := `
 keyfile=""
@@ -611,8 +611,8 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
 		success:           true,
 		recoveryReason:    RecoveryKeyUsageReasonInvalidKeyFile,
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() +
-			" failed: exit status 1\\) but activation with recovery key was successful"},
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot activate volume: exit status 1\\) but activation " +
+			"with recovery key was successful"},
 	})
 }
 
@@ -645,7 +645,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
 		success:           false,
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is in DA lockout mode\\) " +
-			"and activation with recovery key failed \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 1\\)"},
+			"and activation with recovery key failed \\(cannot activate volume: exit status 1\\)"},
 	})
 }
 
@@ -1156,7 +1156,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling6(c *C) {
 		recoveryPassphrases: []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
 		sdCryptsetupCalls:   1,
 		errChecker:          ErrorMatches,
-		errCheckerArgs:      []interface{}{"cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 1"},
+		errCheckerArgs:      []interface{}{"cannot activate volume: exit status 1"},
 	})
 }
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1127,9 +1127,10 @@ func (s *cryptSuite) testInitializeLUKS2Container(c *C, data *testInitializeLUKS
 	c.Check(info.Metadata.Tokens, HasLen, 1)
 	token, ok := info.Metadata.Tokens[0]
 	c.Assert(ok, Equals, true)
-	c.Check(token.Type, Equals, "secboot-master-detached")
+	c.Check(token.Type, Equals, "secboot")
 	c.Assert(token.Keyslots, HasLen, 1)
 	c.Check(int(token.Keyslots[0]), Equals, 0)
+	c.Check(token.Params["secboot-type"], Equals, "master-detached")
 
 	testutil.CheckLUKS2Passphrase(c, devicePath, data.key)
 }
@@ -1182,7 +1183,7 @@ func (s *cryptSuite) TestSetLUKS2ContainerRecoveryKey(c *C) {
 		c.Check(info.Metadata.Tokens, HasLen, 2)
 		var token *luks2.Token
 		for _, t := range info.Metadata.Tokens {
-			if t.Type == "secboot-recovery" {
+			if t.Type == "secboot" && t.Params["secboot-type"] == "recovery" {
 				token = t
 				break
 			}
@@ -1227,7 +1228,7 @@ func (s *cryptSuite) TestChangeLUKS2ContainerRecoveryKey(c *C) {
 	c.Check(info.Metadata.Tokens, HasLen, 2)
 	var token *luks2.Token
 	for _, t := range info.Metadata.Tokens {
-		if t.Type == "secboot-recovery" {
+		if t.Type == "secboot" && t.Params["secboot-type"] == "recovery" {
 			token = t
 			break
 		}
@@ -1270,7 +1271,7 @@ func (s *cryptSuite) TestSetLUKS2ContainerMasterKey(c *C) {
 		c.Check(info.Metadata.Tokens, HasLen, 2)
 		var token *luks2.Token
 		for _, t := range info.Metadata.Tokens {
-			if t.Type == "secboot-master-detached" {
+			if t.Type == "secboot" && t.Params["secboot-type"] == "master-detached" {
 				token = t
 				break
 			}
@@ -1312,7 +1313,7 @@ func (s *cryptSuite) TestChangeLUKS2ContainerMasterKey(c *C) {
 	c.Check(info.Metadata.Tokens, HasLen, 1)
 	var token *luks2.Token
 	for _, t := range info.Metadata.Tokens {
-		if t.Type == "secboot-master-detached" {
+		if t.Type == "secboot" && t.Params["secboot-type"] == "master-detached" {
 			token = t
 			break
 		}

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -488,17 +488,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling2(c *C) {
 	})
 }
 
-// TODO:
-//func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling3(c *C) {
-//	// Test that adding "tries=" to ActivateOptions fails.
-//	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
-//		activateOptions: []string{"tries=2"},
-//		errChecker:      ErrorMatches,
-//		errCheckerArgs:  []interface{}{"cannot specify the \"tries=\" option for systemd-cryptsetup"},
-//	})
-//}
-
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling3(c *C) {
 	// Test that recovery fallback works with the TPM in DA lockout mode.
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	defer func() {
@@ -517,7 +507,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
 	// Test that recovery fallback works when there is no SRK and a new one can't be created.
 	srk, err := s.TPM.CreateResourceContextFromTPM(tcg.SRKHandle)
 	c.Assert(err, IsNil)
@@ -542,7 +532,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
 	// Test that recovery fallback works when the unsealed key is incorrect.
 	incorrectKey := make([]byte, 32)
 	rand.Read(incorrectKey)
@@ -560,7 +550,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling7(c *C) {
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
 	// Test that activation fails if RecoveryKeyTries is zero.
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	defer func() {
@@ -575,7 +565,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling7(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling7(c *C) {
 	// Test that activation fails if the wrong recovery key is provided.
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	defer func() {
@@ -593,7 +583,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
 	// Test that recovery fallback works if the wrong PIN is supplied.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -613,7 +603,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling10(c *C) {
+func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 	// Test that recovery fallback works if a PIN is set but no PIN attempts are permitted.
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
@@ -745,17 +735,16 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKey1(c *C) {
 	})
 }
 
-// TODO:
-//func (s *cryptSuite) TestActivateVolumeWithRecoveryKey2(c *C) {
-//	// Test with a recovery key which is entered without a hyphen between each group of 5 digits.
-//	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
-//		volumeName:          "data",
-//		sourceDevicePath:    "/dev/sda1",
-//		tries:               1,
-//		recoveryPassphrases: []string{strings.Join(s.recoveryKeyAscii, "")},
-//		activateCalls:   1,
-//	})
-//}
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey2(c *C) {
+	// Test with a recovery key which is entered without a hyphen between each group of 5 digits.
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		volumeName:          "data",
+		sourceDevicePath:    "/dev/sda1",
+		tries:               1,
+		recoveryPassphrases: []string{strings.ReplaceAll(s.recoveryKey.String(), "-", "")},
+		activateCalls:       1,
+	})
+}
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKey3(c *C) {
 	// Test that activation succeeds when the correct recovery key is provided on the second attempt.
@@ -853,15 +842,14 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader1(c *C) {
 	})
 }
 
-// TODO:
-//func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader2(c *C) {
-//	// Test with the correct recovery key supplied via a io.Reader, without a hyphen separating each group of 5 digits.
-//	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
-//		tries:                   1,
-//		recoveryKeyFileContents: strings.Join(s.recoveryKeyAscii, "") + "\n",
-//		activateCalls:       1,
-//	})
-//}
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader2(c *C) {
+	// Test with the correct recovery key supplied via a io.Reader, without a hyphen separating each group of 5 digits.
+	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
+		tries:                   1,
+		recoveryKeyFileContents: strings.ReplaceAll(s.recoveryKey.String(), "-", "") + "\n",
+		activateCalls:           1,
+	})
+}
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader3(c *C) {
 	// Test with the correct recovery key supplied via a io.Reader when the key doesn't end in a newline.
@@ -1054,19 +1042,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling2(c *C) {
 	})
 }
 
-// TODO:
-//func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling3(c *C) {
-//	// Test that adding "tries=" to ActivateOptions fails.
-//	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
-//		tries:           1,
-//		activateOptions: []string{"tries=2"},
-//		recoveryPassphrases: []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
-//		errChecker:      ErrorMatches,
-//		errCheckerArgs:  []interface{}{"cannot specify the \"tries=\" option for systemd-cryptsetup"},
-//	})
-//}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling4(c *C) {
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling3(c *C) {
 	// Test with a badly formatted recovery key.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
 		tries:               1,
@@ -1076,7 +1052,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling4(c *C) {
 	})
 }
 
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling5(c *C) {
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling4(c *C) {
 	// Test with a badly formatted recovery key.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
 		tries:               1,
@@ -1086,7 +1062,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling5(c *C) {
 	})
 }
 
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling6(c *C) {
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling5(c *C) {
 	// Test with the wrong recovery key.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
 		tries:               1,
@@ -1097,7 +1073,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling6(c *C) {
 	})
 }
 
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling7(c *C) {
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling6(c *C) {
 	// Test that the last error is returned when there are consecutive failures for different reasons.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
 		tries:               2,
@@ -1108,7 +1084,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling7(c *C) {
 	})
 }
 
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling8(c *C) {
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling7(c *C) {
 	// Test with a badly formatted recovery key.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
 		tries:               1,

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1137,8 +1137,7 @@ func (s *cryptSuite) testInitializeLUKS2Container(c *C, data *testInitializeLUKS
 	keyslot, ok := info.Metadata.Keyslots[0]
 	c.Assert(ok, Equals, true)
 	c.Check(keyslot.KeySize, Equals, 64)
-	c.Assert(keyslot.Priority, NotNil)
-	c.Check(*keyslot.Priority, Equals, 2)
+	c.Check(keyslot.Priority, Equals, 2)
 	c.Assert(keyslot.KDF, NotNil)
 	c.Check(keyslot.KDF.Type, Equals, "argon2i")
 	c.Check(keyslot.KDF.Time, Equals, 4)
@@ -1220,7 +1219,7 @@ func (s *cryptSuite) TestSetLUKS2ContainerRecoveryKey(c *C) {
 		keyslot, ok := info.Metadata.Keyslots[keyslotId]
 		c.Assert(ok, Equals, true)
 		c.Check(keyslot.KeySize, Equals, 64)
-		c.Check(keyslot.Priority, IsNil)
+		c.Check(keyslot.Priority, Equals, 1)
 		c.Assert(keyslot.KDF, NotNil)
 		c.Check(keyslot.KDF.Type, Equals, "argon2i")
 
@@ -1264,7 +1263,7 @@ func (s *cryptSuite) TestChangeLUKS2ContainerRecoveryKey(c *C) {
 	keyslot, ok := info.Metadata.Keyslots[keyslotId]
 	c.Assert(ok, Equals, true)
 	c.Check(keyslot.KeySize, Equals, 64)
-	c.Check(keyslot.Priority, IsNil)
+	c.Check(keyslot.Priority, Equals, 1)
 	c.Assert(keyslot.KDF, NotNil)
 	c.Check(keyslot.KDF.Type, Equals, "argon2i")
 
@@ -1308,8 +1307,7 @@ func (s *cryptSuite) TestSetLUKS2ContainerMasterKey(c *C) {
 		keyslot, ok := info.Metadata.Keyslots[keyslotId]
 		c.Assert(ok, Equals, true)
 		c.Check(keyslot.KeySize, Equals, 64)
-		c.Assert(keyslot.Priority, NotNil)
-		c.Check(*keyslot.Priority, Equals, 2)
+		c.Check(keyslot.Priority, Equals, 2)
 		c.Assert(keyslot.KDF, NotNil)
 		c.Check(keyslot.KDF.Type, Equals, "argon2i")
 		c.Check(keyslot.KDF.Time, Equals, 4)
@@ -1350,8 +1348,7 @@ func (s *cryptSuite) TestChangeLUKS2ContainerMasterKey(c *C) {
 	keyslot, ok := info.Metadata.Keyslots[keyslotId]
 	c.Assert(ok, Equals, true)
 	c.Check(keyslot.KeySize, Equals, 64)
-	c.Assert(keyslot.Priority, NotNil)
-	c.Check(*keyslot.Priority, Equals, 2)
+	c.Check(keyslot.Priority, Equals, 2)
 	c.Assert(keyslot.KDF, NotNil)
 	c.Check(keyslot.KDF.Type, Equals, "argon2i")
 	c.Check(keyslot.KDF.Time, Equals, 4)

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1286,7 +1286,8 @@ func (s *cryptSuite) TestInitializeLUKS2Container3(c *C) {
 }
 
 func (s *cryptSuite) TestInitializeLUKS2ContainerInvalidKeySize(c *C) {
-	c.Check(InitializeLUKS2Container("/dev/sda1", "data", s.masterKey[0:32]), ErrorMatches, "cannot format device: expected a key length of 512-bits \\(got 256\\)")
+	devicePath := s.createEmptyDiskImage(c)
+	c.Check(InitializeLUKS2Container(devicePath, "data", s.masterKey[0:32]), ErrorMatches, "cannot format device: expected a key length of 512-bits \\(got 256\\)")
 }
 
 type testSetLUKS2ContainerRecoveryKeyData struct {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -741,7 +741,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKey2(c *C) {
 		volumeName:          "data",
 		sourceDevicePath:    "/dev/sda1",
 		tries:               1,
-		recoveryPassphrases: []string{strings.ReplaceAll(s.recoveryKey.String(), "-", "")},
+		recoveryPassphrases: []string{strings.Replace(s.recoveryKey.String(), "-", "", -1)},
 		activateCalls:       1,
 	})
 }
@@ -846,7 +846,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader2(c *C) {
 	// Test with the correct recovery key supplied via a io.Reader, without a hyphen separating each group of 5 digits.
 	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
 		tries:                   1,
-		recoveryKeyFileContents: strings.ReplaceAll(s.recoveryKey.String(), "-", "") + "\n",
+		recoveryKeyFileContents: strings.Replace(s.recoveryKey.String(), "-", "", -1) + "\n",
 		activateCalls:           1,
 	})
 }

--- a/export_test.go
+++ b/export_test.go
@@ -167,22 +167,6 @@ func MakeMockPolicyPCRValuesFull(params []MockPolicyPCRParam) (out []tpm2.PCRVal
 	return
 }
 
-func MockRunDir(path string) (restore func()) {
-	origRunDir := runDir
-	runDir = path
-	return func() {
-		runDir = origRunDir
-	}
-}
-
-func MockSystemdCryptsetupPath(path string) (restore func()) {
-	origSystemdCryptsetupPath := systemdCryptsetupPath
-	systemdCryptsetupPath = path
-	return func() {
-		systemdCryptsetupPath = origSystemdCryptsetupPath
-	}
-}
-
 func NewDynamicPolicyComputeParams(key *rsa.PrivateKey, signAlg tpm2.HashAlgorithmId, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCountIndexName tpm2.Name, policyCount uint64) *dynamicPolicyComputeParams {
 	return &dynamicPolicyComputeParams{
 		key:                  key,

--- a/export_test.go
+++ b/export_test.go
@@ -167,6 +167,14 @@ func MakeMockPolicyPCRValuesFull(params []MockPolicyPCRParam) (out []tpm2.PCRVal
 	return
 }
 
+func MockLUKS2Activate(fn func(string, string, []byte, []string) error) (restore func()) {
+	origFn := luks2Activate
+	luks2Activate = fn
+	return func() {
+		luks2Activate = origFn
+	}
+}
+
 func NewDynamicPolicyComputeParams(key *rsa.PrivateKey, signAlg tpm2.HashAlgorithmId, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCountIndexName tpm2.Name, policyCount uint64) *dynamicPolicyComputeParams {
 	return &dynamicPolicyComputeParams{
 		key:                  key,

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+func MockCryptsetupLockDir(path string) (restore func()) {
+	origDir := cryptsetupLockDir
+	cryptsetupLockDir = path
+	return func() {
+		cryptsetupLockDir = origDir
+	}
+}

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -19,10 +19,29 @@
 
 package luks2
 
-func MockCryptsetupLockDir(path string) (restore func()) {
-	origDir := cryptsetupLockDir
-	cryptsetupLockDir = path
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func MockDataDeviceFstatResult(stMock *unix.Stat_t) (restore func()) {
+	origFn := dataDeviceFstat
+	dataDeviceFstat = func(fd int, st *unix.Stat_t) error {
+		*st = *stMock
+		return nil
+	}
 	return func() {
-		cryptsetupLockDir = origDir
+		dataDeviceFstat = origFn
+	}
+}
+
+func MockIsBlockDeviceArgs(mode os.FileMode) (restore func()) {
+	origFn := isBlockDevice
+	isBlockDevice = func(os.FileMode) bool {
+		return origFn(mode)
+	}
+	return func() {
+		isBlockDevice = origFn
 	}
 }

--- a/internal/luks2/luks2.go
+++ b/internal/luks2/luks2.go
@@ -22,8 +22,17 @@ package luks2
 import (
 	"bufio"
 	"bytes"
+	"crypto"
+	_ "crypto/sha1"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -70,6 +79,300 @@ func mkFifo() (string, func(), error) {
 
 	succeeded = true
 	return fifo, cleanup, nil
+}
+
+type binaryHdr struct {
+	Magic       [6]byte
+	Version     uint16
+	HdrSize     uint64
+	SeqId       uint64
+	Label       [48]byte
+	CsumAlg     [32]byte
+	Salt        [64]byte
+	Uuid        [40]byte
+	Subsystem   [48]byte
+	HdrOffset   uint64
+	Padding     [184]byte
+	Csum        [64]byte
+	Padding4096 [7 * 512]byte
+}
+
+type Uint64s uint64
+
+func (u *Uint64s) UnmarshalText(text []byte) error {
+	n, err := strconv.ParseUint(string(text), 10, 64)
+	if err != nil {
+		return err
+	}
+	*u = Uint64s(n)
+	return nil
+}
+
+type Ints int
+
+func (i *Ints) UnmarshalText(text []byte) error {
+	n, err := strconv.Atoi(string(text))
+	if err != nil {
+		return err
+	}
+	*i = Ints(n)
+	return nil
+}
+
+type Config struct {
+	JSONSize     Uint64s `json:"json_size"`
+	KeyslotsSize Uint64s `json:"keyslots_size"`
+	Flags        []string
+	Requirements []string
+}
+
+type Token struct {
+	Type     string
+	Keyslots []Ints
+	Params   map[string]interface{}
+}
+
+func (t *Token) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &t); err != nil {
+		return err
+	}
+
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+
+	for k, v := range m {
+		switch k {
+		case "type", "keyslots":
+		default:
+			t.Params[k] = v
+		}
+	}
+
+	return nil
+}
+
+type Digest struct {
+	Type       string
+	Keyslots   []Ints
+	Segments   []Ints
+	Salt       []byte
+	Digest     []byte
+	Hash       string
+	Iterations int
+}
+
+type Segment struct {
+	Type        string
+	Offset      uint64
+	Size        uint64
+	DynamicSize bool
+	Encryption  string
+}
+
+func (s *Segment) UnmarshalJSON(data []byte) error {
+	var d struct {
+		Type       string
+		Offset     Uint64s
+		Size       string
+		Encryption string
+	}
+
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+
+	*s = Segment{
+		Type:       d.Type,
+		Offset:     uint64(d.Offset),
+		Encryption: d.Encryption}
+	if d.Size == "dynamic" {
+		s.DynamicSize = true
+	} else {
+		n, err := strconv.ParseUint(d.Size, 10, 64)
+		if err != nil {
+			return err
+		}
+		s.Size = n
+	}
+
+	return nil
+}
+
+type Area struct {
+	Type       string
+	Offset     Uint64s
+	Size       Uint64s
+	Encryption string
+	KeySize    int `json:"key_size"`
+}
+
+type AF struct {
+	Type    string
+	Stripes int
+	Hash    string
+}
+
+type KDF struct {
+	Type       string
+	Salt       []byte
+	Hash       string
+	Iterations int
+	Time       int
+	Memory     int
+	CPUs       int
+}
+
+type Keyslot struct {
+	Type     string
+	KeySize  int `json:"key_size"`
+	Area     Area
+	KDF      KDF
+	AF       AF
+	Priority *int
+}
+
+type Metadata struct {
+	Keyslots map[Ints]*Keyslot
+	Segments map[Ints]*Segment
+	Digests  map[Ints]*Digest
+	Tokens   map[Ints]*Token
+	Config   Config
+}
+
+type HdrInfo struct {
+	HdrSize  uint64
+	Label    string
+	Metadata Metadata
+}
+
+func toString(b []byte) string {
+	return strings.TrimRight(string(b), "\x00")
+}
+
+func getHash(alg string) crypto.Hash {
+	switch alg {
+	case "sha1":
+		return crypto.SHA1
+	case "sha224":
+		return crypto.SHA224
+	case "sha256":
+		return crypto.SHA256
+	case "sha384":
+		return crypto.SHA384
+	case "sha512":
+		return crypto.SHA512
+	default:
+		return 0
+	}
+}
+
+func decodeAndCheckHeader(r io.ReadSeeker, offset int64, primary bool) (*binaryHdr, error) {
+	if _, err := r.Seek(offset, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	var hdr binaryHdr
+	if err := binary.Read(r, binary.BigEndian, &hdr); err != nil {
+		return nil, xerrors.Errorf("cannot read header: %w", err)
+	}
+	switch {
+	case primary && bytes.Equal(hdr.Magic[:], []byte("LUKS\xba\xbe")):
+	case !primary && bytes.Equal(hdr.Magic[:], []byte("SKUL\xba\xbe")):
+	default:
+		return nil, errors.New("invalid magic")
+	}
+	if hdr.Version != 2 {
+		return nil, errors.New("invalid version")
+	}
+	if hdr.HdrSize > uint64(math.MaxInt64) {
+		return nil, errors.New("header size too large")
+	}
+	if hdr.HdrOffset > uint64(math.MaxInt64) {
+		return nil, errors.New("header offset too large")
+	}
+	if int64(hdr.HdrOffset) != offset {
+		return nil, errors.New("invalid header offset")
+	}
+
+	csumHash := getHash(toString(hdr.CsumAlg[:]))
+	if csumHash == 0 {
+		return nil, errors.New("unsupported checksum alg")
+	}
+
+	h := csumHash.New()
+
+	hdrTmp := hdr
+	hdrTmp.Csum = [64]byte{}
+
+	if err := binary.Write(h, binary.BigEndian, &hdrTmp); err != nil {
+		return nil, xerrors.Errorf("cannot calculate checksum, error serializing header: %w", err)
+	}
+	if _, err := io.CopyN(h, r, int64(hdr.HdrSize)-int64(binary.Size(hdr))); err != nil {
+		return nil, xerrors.Errorf("cannot calculate checksum, error reading JSON metadata: %w", err)
+	}
+
+	if !bytes.Equal(h.Sum(nil), hdr.Csum[0:csumHash.Size()]) {
+		return nil, errors.New("invalid header checksum")
+	}
+
+	return &hdr, nil
+}
+
+func DecodeHdr(path string) (*HdrInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	primaryHdr, primaryErr := decodeAndCheckHeader(f, 0, true)
+
+	var secondaryHdr *binaryHdr
+	if primaryErr != nil {
+		for _, off := range []int64{0x4000, 0x8000, 0x10000, 0x20000, 0x40000, 0x80000, 0x100000, 0x200000, 0x400000} {
+			secondaryHdr, err = decodeAndCheckHeader(f, off, false)
+			if err == nil {
+				break
+			}
+		}
+	} else {
+		secondaryHdr, _ = decodeAndCheckHeader(f, int64(primaryHdr.HdrSize), false)
+	}
+
+	// TODO: Check both JSON areas
+
+	var hdr *binaryHdr
+	switch {
+	case primaryHdr != nil && secondaryHdr != nil:
+		hdr = primaryHdr
+		if secondaryHdr.SeqId > primaryHdr.SeqId {
+			hdr = secondaryHdr
+		}
+	case primaryHdr != nil:
+		hdr = primaryHdr
+	case secondaryHdr != nil:
+		hdr = secondaryHdr
+	default:
+		return nil, xerrors.Errorf("no valid header found, error from decoding primary header: %w", err)
+	}
+
+	info := &HdrInfo{
+		HdrSize: hdr.HdrSize,
+		Label:   toString(hdr.Label[:])}
+
+	if _, err := f.Seek(int64(hdr.HdrOffset)+int64(binary.Size(hdr)), io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(f)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&info.Metadata); err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }
 
 func Activate(volumeName, sourceDevicePath string, key []byte, options []string) error {

--- a/internal/luks2/luks2.go
+++ b/internal/luks2/luks2.go
@@ -1,0 +1,194 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/snapcore/snapd/osutil"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
+)
+
+var (
+	RunDir                = "/run"
+	SystemdCryptsetupPath = "/lib/systemd/systemd-cryptsetup"
+)
+
+func mkFifo() (string, func(), error) {
+	// /run is not world writable but we create a unique directory here because this
+	// code can be invoked by a public API and we shouldn't fail if more than one
+	// process reaches here at the same time.
+	dir, err := ioutil.TempDir(RunDir, filepath.Base(os.Args[0])+".")
+	if err != nil {
+		return "", nil, xerrors.Errorf("cannot create temporary directory: %w", err)
+	}
+
+	cleanup := func() {
+		os.RemoveAll(dir)
+	}
+
+	succeeded := false
+	defer func() {
+		if succeeded {
+			return
+		}
+		cleanup()
+	}()
+
+	fifo := filepath.Join(dir, "fifo")
+	if err := unix.Mkfifo(fifo, 0600); err != nil {
+		return "", nil, xerrors.Errorf("cannot create FIFO: %w", err)
+	}
+
+	succeeded = true
+	return fifo, cleanup, nil
+}
+
+func Activate(volumeName, sourceDevicePath string, key []byte, options []string) error {
+	fifoPath, cleanupFifo, err := mkFifo()
+	if err != nil {
+		return xerrors.Errorf("cannot create FIFO for passing key to systemd-cryptsetup: %w", err)
+	}
+	defer cleanupFifo()
+
+	cmd := exec.Command(SystemdCryptsetupPath, "attach", volumeName, sourceDevicePath, fifoPath, strings.Join(options, ","))
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "SYSTEMD_LOG_TARGET=console")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return xerrors.Errorf("cannot create stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return xerrors.Errorf("cannot create stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		rd := bufio.NewScanner(stdout)
+		for rd.Scan() {
+			fmt.Printf("systemd-cryptsetup: %s\n", rd.Text())
+		}
+		wg.Done()
+	}()
+	go func() {
+		rd := bufio.NewScanner(stderr)
+		for rd.Scan() {
+			fmt.Fprintf(os.Stderr, "systemd-cryptsetup: %s\n", rd.Text())
+		}
+		wg.Done()
+	}()
+
+	f, err := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+	if err != nil {
+		// If we fail to open the write end, the read end will be blocked in open()
+		cmd.Process.Kill()
+		return xerrors.Errorf("cannot open FIFO for passing key to systemd-cryptsetup: %w", err)
+	}
+
+	if _, err := f.Write(key); err != nil {
+		f.Close()
+		// The read end is open and blocked inside read(). Closing our write end will result in the
+		// read end returning 0 bytes (EOF) and exitting cleanly.
+		cmd.Wait()
+		return xerrors.Errorf("cannot pass key to systemd-cryptsetup: %w", err)
+	}
+
+	f.Close()
+	wg.Wait()
+
+	return cmd.Wait()
+}
+
+func AddKey(devicePath string, existingKey, key []byte, extraOptionArgs []string) error {
+	fifoPath, cleanupFifo, err := mkFifo()
+	if err != nil {
+		return xerrors.Errorf("cannot create FIFO for passing existing key to cryptsetup: %w", err)
+	}
+	defer cleanupFifo()
+
+	args := []string{
+		// add a new key
+		"luksAddKey",
+		// read existing key from named pipe
+		"--key-file", fifoPath}
+	args = append(args, extraOptionArgs...)
+	args = append(args,
+		// container to add key to
+		devicePath,
+		// read new key from stdin
+		"-")
+	cmd := exec.Command("cryptsetup", args...)
+	cmd.Stdin = bytes.NewReader(key)
+
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	cmd.Stderr = &b
+
+	if err := cmd.Start(); err != nil {
+		return xerrors.Errorf("cannot start cryptsetup: %w", err)
+	}
+
+	f, err := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+	if err != nil {
+		// If we fail to open the write end, the read end will be blocked in open()
+		cmd.Process.Kill()
+		return xerrors.Errorf("cannot open FIFO for passing existing key to cryptsetup: %w", err)
+	}
+
+	if _, err := f.Write(existingKey); err != nil {
+		f.Close()
+		// The read end is open and blocked inside read(). Closing our write end will result in the
+		// read end returning 0 bytes (EOF) and exitting cleanly.
+		cmd.Wait()
+		return xerrors.Errorf("cannot pass existing key to cryptsetup: %w", err)
+	}
+
+	f.Close()
+	if err := cmd.Wait(); err != nil {
+		return osutil.OutputErr(b.Bytes(), err)
+	}
+	return nil
+}
+
+func SetKeyslotPreferred(devicePath string, slot int) error {
+	cmd := exec.Command("cryptsetup", "config", "--priority", "prefer", "--key-slot", strconv.Itoa(slot), devicePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+
+	return nil
+}

--- a/internal/luks2/luks2_test.go
+++ b/internal/luks2/luks2_test.go
@@ -232,7 +232,7 @@ func (s *luks2Suite) testFormat(c *C, data *testFormatData) {
 	keyslot, ok := info.Metadata.Keyslots[0]
 	c.Assert(ok, Equals, true)
 	c.Check(keyslot.KeySize, Equals, 64)
-	c.Assert(keyslot.Priority, IsNil)
+	c.Check(keyslot.Priority, Equals, 1)
 	c.Assert(keyslot.KDF, NotNil)
 	c.Check(keyslot.KDF.Type, Equals, "argon2i")
 	if data.kdf.Master {
@@ -308,10 +308,10 @@ func (s *luks2Suite) testAddKey(c *C, data *testAddKeyData) {
 
 	c.Assert(newSlotId, snapd_testutil.IntGreaterThan, -1)
 	c.Check(endInfo.Metadata.Keyslots, HasLen, 2)
-	keyslot, ok := endInfo.Metadata.Keyslots[Ints(newSlotId)]
+	keyslot, ok := endInfo.Metadata.Keyslots[newSlotId]
 	c.Assert(ok, Equals, true)
 	c.Check(keyslot.KeySize, Equals, 64)
-	c.Assert(keyslot.Priority, IsNil)
+	c.Check(keyslot.Priority, Equals, 1)
 	c.Assert(keyslot.KDF, NotNil)
 	c.Check(keyslot.KDF.Type, Equals, "argon2i")
 	if data.kdf.Master {
@@ -391,7 +391,7 @@ func (s *luks2Suite) TestImportToken1(c *C) {
 	s.testImportToken(c, &testImportTokenData{
 		token: &Token{
 			Type:     "secboot-test",
-			Keyslots: []Ints{Ints(0)},
+			Keyslots: []int{0},
 			Params: map[string]interface{}{
 				"secboot-a": 50,
 				"secboot-b": data}},
@@ -407,7 +407,7 @@ func (s *luks2Suite) TestImportToken2(c *C) {
 	s.testImportToken(c, &testImportTokenData{
 		token: &Token{
 			Type:     "secboot-test-2",
-			Keyslots: []Ints{Ints(1)},
+			Keyslots: []int{1},
 			Params: map[string]interface{}{
 				"secboot-a": true,
 				"secboot-b": data}},
@@ -423,7 +423,7 @@ func (s *luks2Suite) TestImportToken3(c *C) {
 	s.testImportToken(c, &testImportTokenData{
 		token: &Token{
 			Type:     "secboot-test",
-			Keyslots: []Ints{Ints(0), Ints(1)},
+			Keyslots: []int{0, 1},
 			Params: map[string]interface{}{
 				"secboot-a": 50,
 				"secboot-b": data}},
@@ -438,13 +438,13 @@ func (s *luks2Suite) testRemoveToken(c *C, tokenId int) {
 	c.Assert(err, IsNil)
 	c.Assert(Format(devicePath, "", make([]byte, 64), &KDFOptions{Master: true}), IsNil)
 	c.Assert(AddKey(devicePath, make([]byte, 64), make([]byte, 64), &KDFOptions{Master: true}), IsNil)
-	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []Ints{Ints(0)}}), IsNil)
-	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-bar", Keyslots: []Ints{Ints(1)}}), IsNil)
+	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []int{0}}), IsNil)
+	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-bar", Keyslots: []int{1}}), IsNil)
 
 	info, err := DecodeHdr(devicePath)
 	c.Assert(err, IsNil)
 	c.Check(info.Metadata.Tokens, HasLen, 2)
-	_, ok := info.Metadata.Tokens[Ints(tokenId)]
+	_, ok := info.Metadata.Tokens[tokenId]
 	c.Check(ok, Equals, true)
 
 	c.Check(RemoveToken(devicePath, tokenId), IsNil)
@@ -452,7 +452,7 @@ func (s *luks2Suite) testRemoveToken(c *C, tokenId int) {
 	info, err = DecodeHdr(devicePath)
 	c.Assert(err, IsNil)
 	c.Check(info.Metadata.Tokens, HasLen, 1)
-	_, ok = info.Metadata.Tokens[Ints(tokenId)]
+	_, ok = info.Metadata.Tokens[tokenId]
 	c.Check(ok, Equals, false)
 }
 
@@ -467,7 +467,7 @@ func (s *luks2Suite) TestRemoveToken2(c *C) {
 func (s *luks2Suite) TestRemoveNonExistantToken(c *C) {
 	devicePath := s.createEmptyDiskImage(c)
 	c.Assert(Format(devicePath, "", make([]byte, 64), &KDFOptions{Master: true}), IsNil)
-	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []Ints{Ints(0)}}), IsNil)
+	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []int{0}}), IsNil)
 
 	c.Check(RemoveToken(devicePath, 10), ErrorMatches, "Token 10 is not in use.")
 
@@ -496,7 +496,7 @@ func (s *luks2Suite) testKillSlot(c *C, data *testKillSlotData) {
 	info, err := DecodeHdr(devicePath)
 	c.Assert(err, IsNil)
 	c.Check(info.Metadata.Keyslots, HasLen, 2)
-	_, ok := info.Metadata.Keyslots[Ints(data.slotId)]
+	_, ok := info.Metadata.Keyslots[data.slotId]
 	c.Check(ok, Equals, true)
 
 	c.Check(KillSlot(devicePath, data.slotId, data.key), IsNil)
@@ -504,7 +504,7 @@ func (s *luks2Suite) testKillSlot(c *C, data *testKillSlotData) {
 	info, err = DecodeHdr(devicePath)
 	c.Assert(err, IsNil)
 	c.Check(info.Metadata.Keyslots, HasLen, 1)
-	_, ok = info.Metadata.Keyslots[Ints(data.slotId)]
+	_, ok = info.Metadata.Keyslots[data.slotId]
 	c.Check(ok, Equals, false)
 
 	releaseLock()
@@ -588,18 +588,17 @@ func (s *luks2Suite) testSetKeyslotPriority(c *C, data *testSetKeyslotPriorityDa
 
 	info, err := DecodeHdr(devicePath)
 	c.Assert(err, IsNil)
-	keyslot, ok := info.Metadata.Keyslots[Ints(data.slotId)]
+	keyslot, ok := info.Metadata.Keyslots[data.slotId]
 	c.Assert(ok, Equals, true)
-	c.Assert(keyslot.Priority, IsNil)
+	c.Check(keyslot.Priority, Equals, 1)
 
 	c.Check(SetKeyslotPriority(devicePath, data.slotId, data.priority), IsNil)
 
 	info, err = DecodeHdr(devicePath)
 	c.Assert(err, IsNil)
-	keyslot, ok = info.Metadata.Keyslots[Ints(data.slotId)]
+	keyslot, ok = info.Metadata.Keyslots[data.slotId]
 	c.Assert(ok, Equals, true)
-	c.Assert(keyslot.Priority, NotNil)
-	c.Check(*keyslot.Priority, Equals, data.expected)
+	c.Check(keyslot.Priority, Equals, data.expected)
 }
 
 func (s *luks2Suite) TestSetKeyslotPriority1(c *C) {

--- a/internal/luks2/luks2_test.go
+++ b/internal/luks2/luks2_test.go
@@ -1,0 +1,540 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2_test
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/testutil"
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+
+	"golang.org/x/sys/unix"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type luks2Suite struct {
+	snapd_testutil.BaseTest
+}
+
+func (s *luks2Suite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.AddCleanup(testutil.MockRunDir(c.MkDir()))
+
+	cryptsetupWrapper := testutil.WrapCryptsetup(c)
+	s.AddCleanup(cryptsetupWrapper.Restore)
+}
+
+func (s *luks2Suite) createEmptyDiskImage(c *C) string {
+	f, err := os.OpenFile(filepath.Join(c.MkDir(), "disk.img"), os.O_RDWR|os.O_CREATE, 0600)
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	c.Assert(f.Truncate(20*1024*1024), IsNil)
+	return f.Name()
+}
+
+var _ = Suite(&luks2Suite{})
+
+func (s *luks2Suite) TestAcquireSharedLockOnFile(c *C) {
+	path := filepath.Join(c.MkDir(), "disk")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	release, err := AcquireLock(path, LockModeShared)
+	c.Assert(err, IsNil)
+
+	err = unix.Flock(int(f.Fd()), unix.LOCK_SH|unix.LOCK_NB)
+	c.Check(err, IsNil)
+
+	err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	c.Check(err, ErrorMatches, "resource temporarily unavailable")
+
+	release()
+
+	err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	c.Check(err, IsNil)
+}
+
+func (s *luks2Suite) TestAcquireExclusiveLockOnFile(c *C) {
+	path := filepath.Join(c.MkDir(), "disk")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	release, err := AcquireLock(path, LockModeExclusive)
+	c.Assert(err, IsNil)
+
+	err = unix.Flock(int(f.Fd()), unix.LOCK_SH|unix.LOCK_NB)
+	c.Check(err, ErrorMatches, "resource temporarily unavailable")
+
+	release()
+
+	err = unix.Flock(int(f.Fd()), unix.LOCK_SH|unix.LOCK_NB)
+	c.Check(err, IsNil)
+}
+
+func (s *luks2Suite) TestTryAcquireExclusiveLockOnFile(c *C) {
+	path := filepath.Join(c.MkDir(), "disk")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	err = unix.Flock(int(f.Fd()), unix.LOCK_SH|unix.LOCK_NB)
+	c.Assert(err, IsNil)
+
+	_, err = AcquireLock(path, LockModeExclusive|LockModeTry)
+	c.Check(err, ErrorMatches, "cannot obtain lock: resource temporarily unavailable")
+
+	err = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	c.Assert(err, IsNil)
+
+	_, err = AcquireLock(path, LockModeExclusive|LockModeTry)
+	c.Check(err, IsNil)
+}
+
+func (s *luks2Suite) TestAcquireLockOnUnsupportedFile(c *C) {
+	_, err := AcquireLock("/dev/null", LockModeShared)
+	c.Check(err, ErrorMatches, "unsupported file type")
+}
+
+// TODO: Figure out how to test locking against block devices
+
+type testFormatData struct {
+	label string
+	key   []byte
+	kdf   *KDFOptions
+}
+
+func (s *luks2Suite) testFormat(c *C, data *testFormatData) {
+	devicePath := s.createEmptyDiskImage(c)
+	releaseLock, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+
+	c.Check(Format(devicePath, data.label, data.key, data.kdf), IsNil)
+
+	info, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+
+	c.Check(info.Label, Equals, data.label)
+
+	c.Check(info.Metadata.Keyslots, HasLen, 1)
+	keyslot, ok := info.Metadata.Keyslots[0]
+	c.Assert(ok, Equals, true)
+	c.Check(keyslot.KeySize, Equals, 64)
+	c.Assert(keyslot.Priority, IsNil)
+	c.Assert(keyslot.KDF, NotNil)
+	c.Check(keyslot.KDF.Type, Equals, "argon2i")
+	if data.kdf.Master {
+		c.Check(keyslot.KDF.Time, Equals, 4)
+		c.Check(keyslot.KDF.Memory, Equals, 32)
+	}
+
+	c.Check(info.Metadata.Segments, HasLen, 1)
+	segment, ok := info.Metadata.Segments[0]
+	c.Assert(ok, Equals, true)
+	c.Check(segment.Encryption, Equals, "aes-xts-plain64")
+
+	c.Check(info.Metadata.Tokens, HasLen, 0)
+
+	releaseLock()
+	testutil.CheckLUKS2Passphrase(c, devicePath, data.key)
+}
+
+func (s *luks2Suite) TestFormat1(c *C) {
+	key := make([]byte, 64)
+	rand.Read(key)
+	s.testFormat(c, &testFormatData{
+		label: "test",
+		key:   key,
+		kdf:   &KDFOptions{Master: true}})
+}
+
+func (s *luks2Suite) TestFormat2(c *C) {
+	key := make([]byte, 64)
+	rand.Read(key)
+	s.testFormat(c, &testFormatData{
+		label: "data",
+		key:   key,
+		kdf:   &KDFOptions{Master: true}})
+}
+
+func (s *luks2Suite) TestFormat3(c *C) {
+	s.testFormat(c, &testFormatData{
+		label: "test",
+		key:   []byte("foo"),
+		kdf:   &KDFOptions{}})
+}
+
+type testAddKeyData struct {
+	key []byte
+	kdf *KDFOptions
+}
+
+func (s *luks2Suite) testAddKey(c *C, data *testAddKeyData) {
+	masterKey := make([]byte, 64)
+	rand.Read(masterKey)
+
+	devicePath := s.createEmptyDiskImage(c)
+	releaseLock, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", masterKey, &KDFOptions{Master: true}), IsNil)
+
+	startInfo, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+
+	c.Check(AddKey(devicePath, masterKey, data.key, data.kdf), IsNil)
+
+	endInfo, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+
+	newSlotId := -1
+	for s := range endInfo.Metadata.Keyslots {
+		if _, ok := startInfo.Metadata.Keyslots[s]; !ok {
+			newSlotId = int(s)
+			break
+		}
+	}
+
+	c.Assert(newSlotId, snapd_testutil.IntGreaterThan, -1)
+	c.Check(endInfo.Metadata.Keyslots, HasLen, 2)
+	keyslot, ok := endInfo.Metadata.Keyslots[Ints(newSlotId)]
+	c.Assert(ok, Equals, true)
+	c.Check(keyslot.KeySize, Equals, 64)
+	c.Assert(keyslot.Priority, IsNil)
+	c.Assert(keyslot.KDF, NotNil)
+	c.Check(keyslot.KDF.Type, Equals, "argon2i")
+	if data.kdf.Master {
+		c.Check(keyslot.KDF.Time, Equals, 4)
+		c.Check(keyslot.KDF.Memory, Equals, 32)
+	}
+
+	releaseLock()
+	testutil.CheckLUKS2Passphrase(c, devicePath, data.key)
+}
+
+func (s *luks2Suite) TestAddKey1(c *C) {
+	key := make([]byte, 64)
+	rand.Read(key)
+
+	s.testAddKey(c, &testAddKeyData{
+		key: key,
+		kdf: &KDFOptions{Master: true}})
+}
+
+func (s *luks2Suite) TestAddKey2(c *C) {
+	s.testAddKey(c, &testAddKeyData{
+		key: []byte("foo"),
+		kdf: &KDFOptions{}})
+}
+
+func (s *luks2Suite) TestAddKeyWithIncorrectExistingKey(c *C) {
+	masterKey := make([]byte, 64)
+	rand.Read(masterKey)
+
+	devicePath := s.createEmptyDiskImage(c)
+	releaseLock, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", masterKey, &KDFOptions{Master: true}), IsNil)
+
+	c.Check(AddKey(devicePath, make([]byte, 64), []byte("foo"), &KDFOptions{}), ErrorMatches, "No key available with this passphrase.")
+
+	info, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	c.Check(info.Metadata.Keyslots, HasLen, 1)
+	_, ok := info.Metadata.Keyslots[0]
+	c.Check(ok, Equals, true)
+
+	releaseLock()
+	testutil.CheckLUKS2Passphrase(c, devicePath, masterKey)
+}
+
+type testImportTokenData struct {
+	token          *Token
+	expectedParams map[string]interface{}
+}
+
+func (s *luks2Suite) testImportToken(c *C, data *testImportTokenData) {
+	devicePath := s.createEmptyDiskImage(c)
+	_, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", make([]byte, 64), &KDFOptions{Master: true}), IsNil)
+	c.Assert(AddKey(devicePath, make([]byte, 64), make([]byte, 64), &KDFOptions{Master: true}), IsNil)
+
+	c.Check(ImportToken(devicePath, data.token), IsNil)
+
+	info, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+
+	c.Assert(info.Metadata.Tokens, HasLen, 1)
+	token, ok := info.Metadata.Tokens[0]
+	c.Assert(ok, Equals, true)
+	c.Check(token.Type, Equals, data.token.Type)
+	c.Check(token.Keyslots, DeepEquals, data.token.Keyslots)
+	c.Check(token.Params, DeepEquals, data.expectedParams)
+}
+
+func (s *luks2Suite) TestImportToken1(c *C) {
+	data := make([]byte, 128)
+	rand.Read(data)
+
+	s.testImportToken(c, &testImportTokenData{
+		token: &Token{
+			Type:     "secboot-test",
+			Keyslots: []Ints{Ints(0)},
+			Params: map[string]interface{}{
+				"secboot-a": 50,
+				"secboot-b": data}},
+		expectedParams: map[string]interface{}{
+			"secboot-a": float64(50),
+			"secboot-b": base64.StdEncoding.EncodeToString(data)}})
+}
+
+func (s *luks2Suite) TestImportToken2(c *C) {
+	data := make([]byte, 128)
+	rand.Read(data)
+
+	s.testImportToken(c, &testImportTokenData{
+		token: &Token{
+			Type:     "secboot-test-2",
+			Keyslots: []Ints{Ints(1)},
+			Params: map[string]interface{}{
+				"secboot-a": true,
+				"secboot-b": data}},
+		expectedParams: map[string]interface{}{
+			"secboot-a": true,
+			"secboot-b": base64.StdEncoding.EncodeToString(data)}})
+}
+
+func (s *luks2Suite) TestImportToken3(c *C) {
+	data := make([]byte, 128)
+	rand.Read(data)
+
+	s.testImportToken(c, &testImportTokenData{
+		token: &Token{
+			Type:     "secboot-test",
+			Keyslots: []Ints{Ints(0), Ints(1)},
+			Params: map[string]interface{}{
+				"secboot-a": 50,
+				"secboot-b": data}},
+		expectedParams: map[string]interface{}{
+			"secboot-a": float64(50),
+			"secboot-b": base64.StdEncoding.EncodeToString(data)}})
+}
+
+func (s *luks2Suite) testRemoveToken(c *C, tokenId int) {
+	devicePath := s.createEmptyDiskImage(c)
+	_, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", make([]byte, 64), &KDFOptions{Master: true}), IsNil)
+	c.Assert(AddKey(devicePath, make([]byte, 64), make([]byte, 64), &KDFOptions{Master: true}), IsNil)
+	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []Ints{Ints(0)}}), IsNil)
+	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-bar", Keyslots: []Ints{Ints(1)}}), IsNil)
+
+	info, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	c.Check(info.Metadata.Tokens, HasLen, 2)
+	_, ok := info.Metadata.Tokens[Ints(tokenId)]
+	c.Check(ok, Equals, true)
+
+	c.Check(RemoveToken(devicePath, tokenId), IsNil)
+
+	info, err = DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	c.Check(info.Metadata.Tokens, HasLen, 1)
+	_, ok = info.Metadata.Tokens[Ints(tokenId)]
+	c.Check(ok, Equals, false)
+}
+
+func (s *luks2Suite) TestRemoveToken1(c *C) {
+	s.testRemoveToken(c, 0)
+}
+
+func (s *luks2Suite) TestRemoveToken2(c *C) {
+	s.testRemoveToken(c, 1)
+}
+
+func (s *luks2Suite) TestRemoveNonExistantToken(c *C) {
+	devicePath := s.createEmptyDiskImage(c)
+	c.Assert(Format(devicePath, "", make([]byte, 64), &KDFOptions{Master: true}), IsNil)
+	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []Ints{Ints(0)}}), IsNil)
+
+	c.Check(RemoveToken(devicePath, 10), ErrorMatches, "Token 10 is not in use.")
+
+	info, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	c.Check(info.Metadata.Tokens, HasLen, 1)
+	_, ok := info.Metadata.Tokens[0]
+	c.Check(ok, Equals, true)
+}
+
+type testKillSlotData struct {
+	key1    []byte
+	key2    []byte
+	key     []byte
+	slotId  int
+	testKey []byte
+}
+
+func (s *luks2Suite) testKillSlot(c *C, data *testKillSlotData) {
+	devicePath := s.createEmptyDiskImage(c)
+	releaseLock, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", data.key1, &KDFOptions{Master: true}), IsNil)
+	c.Assert(AddKey(devicePath, data.key1, data.key2, &KDFOptions{Master: true}), IsNil)
+
+	info, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	c.Check(info.Metadata.Keyslots, HasLen, 2)
+	_, ok := info.Metadata.Keyslots[Ints(data.slotId)]
+	c.Check(ok, Equals, true)
+
+	c.Check(KillSlot(devicePath, data.slotId, data.key), IsNil)
+
+	info, err = DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	c.Check(info.Metadata.Keyslots, HasLen, 1)
+	_, ok = info.Metadata.Keyslots[Ints(data.slotId)]
+	c.Check(ok, Equals, false)
+
+	releaseLock()
+	testutil.CheckLUKS2Passphrase(c, devicePath, data.testKey)
+}
+
+func (s *luks2Suite) TestKillSlot1(c *C) {
+	key1 := make([]byte, 64)
+	rand.Read(key1)
+	key2 := make([]byte, 64)
+	rand.Read(key2)
+
+	s.testKillSlot(c, &testKillSlotData{
+		key1:    key1,
+		key2:    key2,
+		key:     key1,
+		slotId:  1,
+		testKey: key1})
+}
+
+func (s *luks2Suite) TestKillSlot2(c *C) {
+	key1 := make([]byte, 64)
+	rand.Read(key1)
+	key2 := make([]byte, 64)
+	rand.Read(key2)
+
+	s.testKillSlot(c, &testKillSlotData{
+		key1:    key1,
+		key2:    key2,
+		key:     key2,
+		slotId:  0,
+		testKey: key2})
+}
+
+func (s *luks2Suite) TestKillSlotWithWrongPassphrase(c *C) {
+	key1 := make([]byte, 64)
+	rand.Read(key1)
+	key2 := make([]byte, 64)
+	rand.Read(key2)
+
+	devicePath := s.createEmptyDiskImage(c)
+	releaseLock, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", key1, &KDFOptions{Master: true}), IsNil)
+	c.Assert(AddKey(devicePath, key1, key2, &KDFOptions{Master: true}), IsNil)
+
+	c.Check(KillSlot(devicePath, 1, key2), ErrorMatches, "No key available with this passphrase.")
+
+	releaseLock()
+	testutil.CheckLUKS2Passphrase(c, devicePath, key1)
+	testutil.CheckLUKS2Passphrase(c, devicePath, key2)
+}
+
+func (s *luks2Suite) TestKillNonExistantSlot(c *C) {
+	key := make([]byte, 64)
+	rand.Read(key)
+
+	devicePath := s.createEmptyDiskImage(c)
+	releaseLock, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", key, &KDFOptions{Master: true}), IsNil)
+
+	c.Check(KillSlot(devicePath, 8, key), ErrorMatches, "Keyslot 8 is not active.")
+
+	releaseLock()
+	testutil.CheckLUKS2Passphrase(c, devicePath, key)
+}
+
+type testSetKeyslotPriorityData struct {
+	slotId   int
+	priority string
+	expected int
+}
+
+func (s *luks2Suite) testSetKeyslotPriority(c *C, data *testSetKeyslotPriorityData) {
+	devicePath := s.createEmptyDiskImage(c)
+	_, err := AcquireLock(devicePath, LockModeExclusive)
+	c.Assert(err, IsNil)
+	c.Assert(Format(devicePath, "", make([]byte, 64), &KDFOptions{Master: true}), IsNil)
+	c.Assert(AddKey(devicePath, make([]byte, 64), make([]byte, 64), &KDFOptions{Master: true}), IsNil)
+
+	info, err := DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	keyslot, ok := info.Metadata.Keyslots[Ints(data.slotId)]
+	c.Assert(ok, Equals, true)
+	c.Assert(keyslot.Priority, IsNil)
+
+	c.Check(SetKeyslotPriority(devicePath, data.slotId, data.priority), IsNil)
+
+	info, err = DecodeHdr(devicePath)
+	c.Assert(err, IsNil)
+	keyslot, ok = info.Metadata.Keyslots[Ints(data.slotId)]
+	c.Assert(ok, Equals, true)
+	c.Assert(keyslot.Priority, NotNil)
+	c.Check(*keyslot.Priority, Equals, data.expected)
+}
+
+func (s *luks2Suite) TestSetKeyslotPriority1(c *C) {
+	s.testSetKeyslotPriority(c, &testSetKeyslotPriorityData{
+		slotId:   0,
+		priority: "prefer",
+		expected: 2})
+}
+
+func (s *luks2Suite) TestSetKeyslotPriority2(c *C) {
+	s.testSetKeyslotPriority(c, &testSetKeyslotPriorityData{
+		slotId:   1,
+		priority: "prefer",
+		expected: 2})
+}
+
+func (s *luks2Suite) TestSetKeyslotPriority3(c *C) {
+	s.testSetKeyslotPriority(c, &testSetKeyslotPriorityData{
+		slotId:   1,
+		priority: "ignore",
+		expected: 0})
+}

--- a/internal/luks2/luks2_test.go
+++ b/internal/luks2/luks2_test.go
@@ -145,6 +145,10 @@ func (s *luks2Suite) TestActivateWrongKey(c *C) {
 	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
 }
 
+func (s *luks2Suite) TestActivateWithInvalidOptions(c *C) {
+	c.Check(Activate("data", "/dev/sda1", nil, []string{"tries=2"}), ErrorMatches, "cannot specify the \"tries=\" option")
+}
+
 func (s *luks2Suite) TestAcquireSharedLockOnFile(c *C) {
 	path := filepath.Join(c.MkDir(), "disk")
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)

--- a/internal/testutil/luks2.go
+++ b/internal/testutil/luks2.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"github.com/snapcore/secboot/internal/luks2"
+)
+
+func MockRunDir(path string) (restore func()) {
+	origRunDir := luks2.RunDir
+	luks2.RunDir = path
+	return func() {
+		luks2.RunDir = origRunDir
+	}
+}
+
+func MockSystemdCryptsetupPath(path string) (restore func()) {
+	origSystemdCryptsetupPath := luks2.SystemdCryptsetupPath
+	luks2.SystemdCryptsetupPath = path
+	return func() {
+		luks2.SystemdCryptsetupPath = origSystemdCryptsetupPath
+	}
+}

--- a/internal/testutil/luks2.go
+++ b/internal/testutil/luks2.go
@@ -20,6 +20,7 @@
 package testutil
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
 
@@ -58,4 +59,10 @@ exec %[1]s "$@" </dev/stdin
 	c.Assert(err, IsNil)
 
 	return snapd_testutil.MockCommand(c, "cryptsetup", fmt.Sprintf(cryptsetupWrapperBottom, cryptsetup))
+}
+
+func CheckLUKS2Passphrase(c *C, path string, key []byte) {
+	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", path)
+	cmd.Stdin = bytes.NewReader(key)
+	c.Check(cmd.Run(), IsNil)
 }


### PR DESCRIPTION
This makes several changes to the code that manages LUKS containers:

- A new internal package is created that exports APIs for low-level cryptsetup operations, and is consumed by the code in crypt.go.
- The new internal package contains a LUKS metadata decoder for decoding the LUKS metadata without having to depend on parsing the output of "cryptsetup luksDump". The cryptsetup binary isn't shipped in the initramfs anyway which would make it difficult to consume the metadata during early boot, and we might want this in the future in order to export tokens containing embedded key metadata.
- Adds tokens to identify the master and recovery keyslots.
- Renames AddRecoveryKeyToLUKS2Container to SetLUKS2ContainerRecoveryKey and updates its behaviour accordingly - the new function allows a single recovery key to be set using any other key, and removes the previous recovery key if it was set.
- Renames ChangeLUKS2KeyUsingRecoveryKey to SetLUKS2ContainerMasterKey and updates its behaviour accordingly - the new function allows a single "master" key (where "master" in this context is the key that is protected by a hardware-backed keystore) to be set using any other key, and removes the previous master key if it was set.
- Makes transactions that span multiple cryptsetup operations atomic by implementing the cryptsetup locking in the calling process and then calling cryptsetup with its own locking disabled. This will make it safer for snapd to perform maintenance operations without clashing with an administrator that might be using cryptsetup to make changes to the same container. An example might be calling SetLUKS2ContainerMasterKey after a recovery scenario - here we decode the current metadata, find the ID of the token corresponding to the existing keyslot, identify the existing keyslot ID from the token, add a new keyslot, decode the metadata again, identify the ID of the newly added keyslot, import a new token for the new keyslot, delete the old token using its ID and then remove the old keyslot using its ID. If an administrator uses cryptsetup separately to add another keyslot at just the wrong moment, then we might identify and tag the wrong keyslot with our token.