### PR TITLE
Store the private part of the policy auth key inside the sealed key object

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -304,7 +304,7 @@ func activateWithRecoveryKey(volumeName, sourceDevicePath string, keyReader io.R
 			continue
 		}
 
-		if _, err := unix.AddKey("user", fmt.Sprintf("%s:%s:reason=%d", filepath.Base(os.Args[0]), volumeName, reason), key[:], userKeyring); err != nil {
+		if _, err := unix.AddKey("user", fmt.Sprintf("secboot-recover:%s?reason=%d", sourceDevicePath, reason), key[:], userKeyring); err != nil {
 			lastErr = xerrors.Errorf("cannot add recovery key to user keyring: %w", err)
 		}
 		break
@@ -408,7 +408,7 @@ func activateWithTPMKey(tpm *TPMConnection, volumeName, sourceDevicePath, keyPat
 
 	// Ignore errors - we've activated the volume and so we shouldn't return an error at this point unless we
 	// close the volume again.
-	unix.AddKey("user", fmt.Sprintf("%s:%s:auth", filepath.Base(os.Args[0]), volumeName), authPrivateKey, userKeyring)
+	unix.AddKey("user", fmt.Sprintf("secboot-tpmauth:%s", sourceDevicePath), authPrivateKey, userKeyring)
 
 	return nil
 }
@@ -462,7 +462,7 @@ type ActivateWithTPMSealedKeyOptions struct {
 // how many attempts should be made to activate the volume with the recovery key before failing. If this is set to 0, then no attempts
 // will be made to activate the encrypted volume with the fallback recovery key. If activation with the recovery key is successful,
 // the recovery key will be added to the root user keyring in the kernel with a description of the format
-// "<argv[0]>:<volumeName>:reason=<reason>" where reason is an integer that describes the recovery reason - see the
+// "secboot-recover:<sourceDevicePath>?reason=<reason>" where reason is an integer that describes the recovery reason - see the
 // RecoveryKeyUsageReason type.
 //
 // If either the PINTries or RecoveryKeyTries fields of options are less than zero, an error will be returned. If the ActivateOptions
@@ -478,7 +478,7 @@ type ActivateWithTPMSealedKeyOptions struct {
 //
 // If the volume is successfully activated with the TPM sealed key and the TPM sealed key has a version of greater than 1, the
 // private part of the key used for authorizing PCR policy updates with UpdateKeyPCRProtectionPolicy is added to the root user keyring
-// in the kernel with a description of the format "<argv[0]>:<volumeName>:auth".
+// in the kernel with a description of the format "secboot-tpmauth:<sourceDevicePath>".
 //
 // If the volume is successfully activated, either with the TPM sealed key or the fallback recovery key, this function returns true.
 // If it is not successfully activated, then this function returns false.
@@ -542,7 +542,7 @@ type ActivateWithRecoveryKeyOptions struct {
 // The ActivateOptions field of options can be used to specify additional options to pass to systemd-cryptsetup.
 //
 // If activation with the recovery key is successful, the recovery key will be added to the root user keyring in the kernel with a
-// description of the format "<argv[0]>:<volumeName>:reason=2".
+// description of the format "secboot-recover:<sourceDevicePath>?reason=2".
 //
 // If the Tries field of options is less than zero, an error will be returned. If the ActivateOptions field of options contains the
 // "tries=" option, then an error will be returned. This option cannot be used with this function.

--- a/crypt.go
+++ b/crypt.go
@@ -319,7 +319,7 @@ func activateWithRecoveryKey(volumeName, sourceDevicePath string, keyReader io.R
 		// Possessor Set Attribute / Possessor Link / Possessor Search / Possessor Write / Possessor Read / Possessor View / User View.
 		// Possessor permissions only apply to a process with a searchable link to the key from one of its own keyrings - just having the
 		// same UID is not sufficient. Read permission is required to read the contents of the key (view permission only permits viewing
-		// of the description and other public metadata that isn't the key payload).//
+		// of the description and other public metadata that isn't the key payload).
 		//
 		// Note that by default, systemd starts services with a private session keyring which does not contain a link to the user keyring.
 		// Therefore these services cannot access the contents of keys in the root user's user keyring if those keys only permit
@@ -431,7 +431,7 @@ func activateWithTPMKey(tpm *TPMConnection, volumeName, sourceDevicePath, keyPat
 	// Possessor Set Attribute / Possessor Link / Possessor Search / Possessor Write / Possessor Read / Possessor View / User View.
 	// Possessor permissions only apply to a process with a searchable link to the key from one of its own keyrings - just having the
 	// same UID is not sufficient. Read permission is required to read the contents of the key (view permission only permits viewing
-	// of the description and other public metadata that isn't the key payload).//
+	// of the description and other public metadata that isn't the key payload).
 	//
 	// Note that by default, systemd starts services with a private session keyring which does not contain a link to the user keyring.
 	// Therefore these services cannot access the contents of keys in the root user's user keyring if those keys only permit

--- a/crypt.go
+++ b/crypt.go
@@ -573,7 +573,6 @@ type RecoveryActivationData struct {
 // the ActivateVolume functions. The type of data returned is dependent on how the volume was activated - see the documentation for
 // each function, If no data is found for the specified device, a ErrNoActivationData error is returned.
 func GetActivationDataFromKernel(sourceDevicePath string) (ActivationData, error) {
-	fmt.Println("GetActivationDataFromKernel, sourceDevicePath:", sourceDevicePath)
 	var userKeys []int
 
 	sz, err := unix.KeyctlBuffer(unix.KEYCTL_READ, userKeyring, nil, 0)

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -225,12 +225,18 @@ func (ctb *cryptTestBase) checkRecoveryActivationData(c *C, path string, reason 
 		c.ExpectFailure("Cannot possess user keys because the user keyring isn't reachable from the session keyring")
 	}
 
-	data, err := GetActivationDataFromKernel(path)
+	data, err := GetActivationDataFromKernel(path, false)
 	c.Assert(err, IsNil)
 	recoveryData, ok := data.(*RecoveryActivationData)
 	c.Assert(ok, Equals, true)
 	c.Check(recoveryData.Key[:], DeepEquals, ctb.recoveryKey)
 	c.Check(recoveryData.Reason, Equals, reason)
+
+	data, err = GetActivationDataFromKernel(path, true)
+	c.Check(err, IsNil)
+	c.Check(data, NotNil)
+	_, err = GetActivationDataFromKernel(path, true)
+	c.Check(err, Equals, ErrNoActivationData)
 }
 
 type cryptTPMTestBase struct {
@@ -271,11 +277,17 @@ func (ctb *cryptTPMTestBase) checkTPMPolicyAuthKey(c *C, path string) {
 		c.ExpectFailure("Cannot possess user keys because the user keyring isn't reachable from the session keyring")
 	}
 
-	data, err := GetActivationDataFromKernel(path)
+	data, err := GetActivationDataFromKernel(path, false)
 	c.Assert(err, IsNil)
 	authKey, ok := data.(TPMPolicyAuthKey)
 	c.Check(ok, Equals, true)
 	c.Check(authKey, DeepEquals, ctb.authPrivateKey)
+
+	data, err = GetActivationDataFromKernel(path, true)
+	c.Check(err, IsNil)
+	c.Check(data, NotNil)
+	_, err = GetActivationDataFromKernel(path, true)
+	c.Check(err, Equals, ErrNoActivationData)
 }
 
 type cryptTPMSuite struct {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -235,8 +235,8 @@ func (ctb *cryptTestBase) checkUserKeyringEntry(c *C, desc string, payload []byt
 	c.Check(buf, DeepEquals, payload)
 }
 
-func (ctb *cryptTestBase) checkRecoveryKeyKeyringEntry(c *C, reason RecoveryKeyUsageReason) {
-	ctb.checkUserKeyringEntry(c, fmt.Sprintf("%s:data:reason=%d", filepath.Base(os.Args[0]), reason), ctb.recoveryKey)
+func (ctb *cryptTestBase) checkRecoveryKeyKeyringEntry(c *C, path string, reason RecoveryKeyUsageReason) {
+	ctb.checkUserKeyringEntry(c, fmt.Sprintf("secboot-recover:%s?reason=%d", path, reason), ctb.recoveryKey)
 }
 
 type cryptTPMTestBase struct {
@@ -270,8 +270,8 @@ func (ctb *cryptTPMTestBase) setUpTestBase(c *C, ttb *testutil.TPMTestBase) {
 	})
 }
 
-func (ctb *cryptTPMTestBase) checkAuthPrivateKeyKeyringEntry(c *C, volumeName string) {
-	ctb.checkUserKeyringEntry(c, fmt.Sprintf("%s:%s:auth", filepath.Base(os.Args[0]), volumeName), ctb.authPrivateKey)
+func (ctb *cryptTPMTestBase) checkAuthPrivateKeyKeyringEntry(c *C, path string) {
+	ctb.checkUserKeyringEntry(c, fmt.Sprintf("secboot-tpmauth:%s", path), ctb.authPrivateKey)
 }
 
 type cryptTPMSuite struct {
@@ -312,7 +312,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyNo2FA(c *C, data *test
 	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
 	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, strings.Join(append(data.activateOptions, "tries=1"), ","))
 
-	s.checkAuthPrivateKeyKeyringEntry(c, data.volumeName)
+	s.checkAuthPrivateKeyKeyringEntry(c, data.sourceDevicePath)
 }
 
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA1(c *C) {
@@ -396,7 +396,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPIN(c *C, data *tes
 	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
 	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
 
-	s.checkAuthPrivateKeyKeyringEntry(c, "data")
+	s.checkAuthPrivateKeyKeyringEntry(c, "/dev/sda1")
 }
 
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
@@ -451,7 +451,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c
 	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
 	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
 
-	s.checkAuthPrivateKeyKeyringEntry(c, "data")
+	s.checkAuthPrivateKeyKeyringEntry(c, "/dev/sda1")
 }
 
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(c *C) {
@@ -541,7 +541,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, da
 	}
 
 	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyKeyringEntry(c, data.recoveryReason)
+	s.checkRecoveryKeyKeyringEntry(c, "/dev/sda1", data.recoveryReason)
 }
 
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
@@ -744,7 +744,7 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyErrorHandling
 	}
 
 	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyKeyringEntry(c, data.recoveryReason)
+	s.checkRecoveryKeyKeyringEntry(c, "/dev/sda1", data.recoveryReason)
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
@@ -810,7 +810,7 @@ func (s *cryptSuite) testActivateVolumeWithRecoveryKey(c *C, data *testActivateV
 	}
 
 	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyKeyringEntry(c, RecoveryKeyUsageReasonRequested)
+	s.checkRecoveryKeyKeyringEntry(c, data.sourceDevicePath, RecoveryKeyUsageReasonRequested)
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKey1(c *C) {
@@ -920,7 +920,7 @@ func (s *cryptSuite) testActivateVolumeWithRecoveryKeyUsingKeyReader(c *C, data 
 	}
 
 	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyKeyringEntry(c, RecoveryKeyUsageReasonRequested)
+	s.checkRecoveryKeyKeyringEntry(c, "/dev/sda1", RecoveryKeyUsageReasonRequested)
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader1(c *C) {

--- a/errors.go
+++ b/errors.go
@@ -52,6 +52,10 @@ var (
 
 	// ErrNoTPM2Device is returned from ConnectToDefaultTPM or SecureConnectToDefaultTPM if no TPM2 device is avaiable.
 	ErrNoTPM2Device = errors.New("no TPM2 device is available")
+
+	// ErrNoActivationData is returned from GetActivationDataFromKernel if no activation data was found in the user keyring for
+	// the specified block device.
+	ErrNoActivationData = errors.New("no activation data found for the specified device")
 )
 
 // TPMResourceExistsError is returned from any function that creates a persistent TPM resource if a resource already exists

--- a/export_test.go
+++ b/export_test.go
@@ -262,7 +262,7 @@ func (p *PCRProtectionProfile) DumpValues(tpm *tpm2.TPMContext) string {
 	return s.String()
 }
 
-func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authPrivateKey []byte, session tpm2.SessionContext) error {
+func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authPrivateKey TPMPolicyAuthKey, session tpm2.SessionContext) error {
 	kf, err := os.Open(keyFile)
 	if err != nil {
 		return err

--- a/export_test.go
+++ b/export_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/canonical/go-tpm2"
@@ -48,7 +47,7 @@ var (
 	ComputeSnapModelDigest                   = computeSnapModelDigest
 	ComputeStaticPolicy                      = computeStaticPolicy
 	CreatePinNVIndex                         = createPinNVIndex
-	CreatePublicAreaForECDSAKey              = createPublicAreaForECDSAKey
+	CreateTPMPublicAreaForECDSAKey           = createTPMPublicAreaForECDSAKey
 	DecodeSecureBootDb                       = decodeSecureBootDb
 	DecodeWinCertificate                     = decodeWinCertificate
 	EFICertTypePkcs7Guid                     = efiCertTypePkcs7Guid
@@ -219,23 +218,13 @@ func (p *PCRProtectionProfile) DumpValues(tpm *tpm2.TPMContext) string {
 	return s.String()
 }
 
-func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile, privateFile string, session tpm2.SessionContext) error {
+func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authPrivateKey []byte, session tpm2.SessionContext) error {
 	kf, err := os.Open(keyFile)
 	if err != nil {
 		return err
 	}
 	defer kf.Close()
 
-	var pf io.Reader
-	if privateFile != "" {
-		f, err := os.Open(privateFile)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		pf = f
-	}
-
-	_, _, _, err = decodeAndValidateKeyData(tpm, kf, pf, session)
+	_, _, _, err = decodeAndValidateKeyData(tpm, kf, authPrivateKey, session)
 	return err
 }

--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -130,20 +130,44 @@ func (s *compatTestSuiteBase) replayPCRSequenceFromFile(c *C, path string) {
 	s.replayPCRSequenceFromReader(c, f)
 }
 
-func (s *compatTestSuiteBase) testUnseal(c *C, pcrEventsFile string) {
-	s.replayPCRSequenceFromFile(c, pcrEventsFile)
+func (s *compatTestSuiteBase) copyFile(c *C, path string) string {
+	src, err := os.Open(path)
+	c.Assert(err, IsNil)
+	defer src.Close()
 
+	dst, err := ioutil.TempFile(s.tmpDir, filepath.Base(path))
+	c.Assert(err, IsNil)
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	c.Assert(err, IsNil)
+
+	return dst.Name()
+}
+
+func (s *compatTestSuiteBase) testUnsealCommon(c *C, pin string) {
 	k, err := secboot.ReadSealedKeyObject(s.absPath("key"))
 	c.Assert(err, IsNil)
-	c.Check(k.AuthMode2F(), Equals, secboot.AuthModeNone)
 
-	key, err := k.UnsealFromTPM(s.TPM, "")
+	key, authPrivateKey, err := k.UnsealFromTPM(s.TPM, pin)
 	c.Check(err, IsNil)
 
 	expectedKey, err := ioutil.ReadFile(s.absPath("clearKey"))
 	c.Assert(err, IsNil)
-
 	c.Check(key, DeepEquals, expectedKey)
+
+	var expectedAuthPrivateKey []byte
+	authKeyPath := s.absPath("authKey")
+	if _, err := os.Stat(authKeyPath); err == nil {
+		expectedAuthPrivateKey, err = ioutil.ReadFile(authKeyPath)
+		c.Assert(err, IsNil)
+	}
+	c.Check(authPrivateKey, DeepEquals, expectedAuthPrivateKey)
+}
+
+func (s *compatTestSuiteBase) testUnseal(c *C, pcrEventsFile string) {
+	s.replayPCRSequenceFromFile(c, pcrEventsFile)
+	s.testUnsealCommon(c, "")
 }
 
 func (s *compatTestSuiteBase) TestChangePIN(c *C) {
@@ -164,75 +188,20 @@ func (s *compatTestSuiteBase) TestChangePIN(c *C) {
 
 func (s *compatTestSuiteBase) testUnsealWithPIN(c *C, pcrEventsFile string) {
 	c.Check(secboot.ChangePIN(s.TPM, s.absPath("key"), "", testPIN), IsNil)
-
 	s.replayPCRSequenceFromFile(c, pcrEventsFile)
-
-	k, err := secboot.ReadSealedKeyObject(s.absPath("key"))
-	c.Assert(err, IsNil)
-	c.Check(k.AuthMode2F(), Equals, secboot.AuthModePIN)
-
-	key, err := k.UnsealFromTPM(s.TPM, testPIN)
-	c.Check(err, IsNil)
-
-	expectedKey, err := ioutil.ReadFile(s.absPath("clearKey"))
-	c.Assert(err, IsNil)
-
-	c.Check(key, DeepEquals, expectedKey)
+	s.testUnsealCommon(c, testPIN)
 }
 
-func (s *compatTestSuiteBase) testUpdateKeyPCRProtectionPolicy(c *C, pcrProfile *secboot.PCRProtectionProfile) {
-	c.Check(secboot.UpdateKeyPCRProtectionPolicy(s.TPM, s.absPath("key"), s.absPath("pud"), pcrProfile), IsNil)
-}
-
-func (s *compatTestSuiteBase) testUpdateKeyPCRProtectionPolicyRevokes(c *C, pcrProfile *secboot.PCRProtectionProfile, pcrEventsFile string) {
-	tmpDir := c.MkDir()
-	keyFile, err := os.Open(s.absPath("key"))
-	c.Assert(err, IsNil)
-	defer keyFile.Close()
-
-	keyFileBackup, err := os.Create(filepath.Join(tmpDir, "key"))
-	c.Assert(err, IsNil)
-	defer keyFileBackup.Close()
-
-	_, err = io.Copy(keyFileBackup, keyFile)
-	c.Assert(err, IsNil)
-
-	c.Check(secboot.UpdateKeyPCRProtectionPolicy(s.TPM, s.absPath("key"), s.absPath("pud"), pcrProfile), IsNil)
-
-	s.replayPCRSequenceFromFile(c, pcrEventsFile)
-
-	k, err := secboot.ReadSealedKeyObject(filepath.Join(tmpDir, "key"))
-	c.Assert(err, IsNil)
-
-	_, err = k.UnsealFromTPM(s.TPM, "")
-	c.Check(err, ErrorMatches, "invalid key data file: cannot complete authorization policy assertions: the dynamic authorization policy has been revoked")
-}
-
-func (s *compatTestSuiteBase) testUpdateKeyPCRProtectionPolicyAndUnseal(c *C, pcrProfile *secboot.PCRProtectionProfile, pcrEvents io.Reader) {
-	c.Check(secboot.UpdateKeyPCRProtectionPolicy(s.TPM, s.absPath("key"), s.absPath("pud"), pcrProfile), IsNil)
-
-	s.replayPCRSequenceFromReader(c, pcrEvents)
-
+func (s *compatTestSuiteBase) testUnsealErrorMatchesCommon(c *C, pattern string) {
 	k, err := secboot.ReadSealedKeyObject(s.absPath("key"))
 	c.Assert(err, IsNil)
 
-	key, err := k.UnsealFromTPM(s.TPM, "")
-	c.Check(err, IsNil)
-
-	expectedKey, err := ioutil.ReadFile(s.absPath("clearKey"))
-	c.Assert(err, IsNil)
-
-	c.Check(key, DeepEquals, expectedKey)
+	_, _, err = k.UnsealFromTPM(s.TPM, "")
+	c.Check(err, ErrorMatches, pattern)
 }
 
 func (s *compatTestSuiteBase) testUnsealAfterLock(c *C, pcrEventsFile string) {
 	c.Assert(secboot.LockAccessToSealedKeys(s.TPM), IsNil)
-
 	s.replayPCRSequenceFromFile(c, pcrEventsFile)
-
-	k, err := secboot.ReadSealedKeyObject(s.absPath("key"))
-	c.Assert(err, IsNil)
-
-	_, err = k.UnsealFromTPM(s.TPM, "")
-	c.Check(err, ErrorMatches, "cannot access the sealed key object until the next TPM reset or restart")
+	s.testUnsealErrorMatchesCommon(c, "cannot access the sealed key object until the next TPM reset or restart")
 }

--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -156,7 +156,7 @@ func (s *compatTestSuiteBase) testUnsealCommon(c *C, pin string) {
 	c.Assert(err, IsNil)
 	c.Check(key, DeepEquals, expectedKey)
 
-	var expectedAuthPrivateKey []byte
+	var expectedAuthPrivateKey secboot.TPMPolicyAuthKey
 	authKeyPath := s.absPath("authKey")
 	if _, err := os.Stat(authKeyPath); err == nil {
 		expectedAuthPrivateKey, err = ioutil.ReadFile(authKeyPath)

--- a/internal/compattest/v0_test.go
+++ b/internal/compattest/v0_test.go
@@ -61,7 +61,7 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicy(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	s.testUpdateKeyPCRProtectionPolicy(c, profile)
+	c.Check(secboot.UpdateKeyPCRProtectionPolicyV0(s.TPM, s.absPath("key"), s.absPath("pud"), profile), IsNil)
 }
 
 func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyRevokes(c *C) {
@@ -69,7 +69,11 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyRevokes(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	s.testUpdateKeyPCRProtectionPolicyRevokes(c, profile, s.absPath("pcrSequence.1"))
+	key2 := s.copyFile(c, s.absPath("key"))
+
+	c.Check(secboot.UpdateKeyPCRProtectionPolicyV0(s.TPM, key2, s.absPath("pud"), profile), IsNil)
+	s.replayPCRSequenceFromFile(c, s.absPath("pcrSequence.1"))
+	s.testUnsealErrorMatchesCommon(c, "invalid key data file: cannot complete authorization policy assertions: the dynamic authorization policy has been revoked")
 }
 
 func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAndUnseal(c *C) {
@@ -77,11 +81,14 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAndUnseal(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
+	c.Check(secboot.UpdateKeyPCRProtectionPolicyV0(s.TPM, s.absPath("key"), s.absPath("pud"), profile), IsNil)
+
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "7 11 %x\n", testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	fmt.Fprintf(&b, "12 11 %x\n", testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
+	s.replayPCRSequenceFromReader(c, &b)
 
-	s.testUpdateKeyPCRProtectionPolicyAndUnseal(c, profile, &b)
+	s.testUnsealCommon(c, "")
 }
 
 func (s *compatTestV0Suite) TestUnsealAfterLock(c *C) {

--- a/keydata.go
+++ b/keydata.go
@@ -56,9 +56,12 @@ const (
 	AuthModePIN
 )
 
+// TPMPolicyAuthKey corresponds to the private part of the key used for signing updates to the authorization policy for a sealed key.
+type TPMPolicyAuthKey []byte
+
 type sealedData struct {
 	Key            []byte
-	AuthPrivateKey tpm2.ECCParameter
+	AuthPrivateKey TPMPolicyAuthKey
 }
 
 type afSplitDataRawHdr struct {
@@ -642,7 +645,7 @@ func decodeAndValidateKeyData(tpm *tpm2.TPMContext, keyFile io.Reader, authData 
 			return nil, nil, nil, keyFileError{errors.New("mismatched metadata versions")}
 		}
 		authKey = policyUpdateData.authKey
-	case []byte:
+	case TPMPolicyAuthKey:
 		if len(a) > 0 {
 			// If we were called with a byte slice, then we're expecting to load the current keydata version and the byte
 			// slice is the private part of the elliptic auth key.

--- a/keydata.go
+++ b/keydata.go
@@ -649,8 +649,7 @@ func decodeAndValidateKeyData(tpm *tpm2.TPMContext, keyFile io.Reader, authData 
 		if len(a) > 0 {
 			// If we were called with a byte slice, then we're expecting to load the current keydata version and the byte
 			// slice is the private part of the elliptic auth key.
-			authKey, err = createPrivateKeyFromTPM(data.staticPolicyData.authPublicKey,
-				&tpm2.Sensitive{Type: tpm2.ObjectTypeECC, Sensitive: tpm2.SensitiveCompositeU{Data: tpm2.ECCParameter(a)}})
+			authKey, err = createECDSAPrivateKeyFromTPM(data.staticPolicyData.authPublicKey, tpm2.ECCParameter(a))
 			if err != nil {
 				return nil, nil, nil, keyFileError{xerrors.Errorf("cannot create auth key: %w", err)}
 			}

--- a/keydata.go
+++ b/keydata.go
@@ -53,15 +53,17 @@ const (
 	AuthModePIN
 )
 
+type sealedData struct {
+	Key            []byte
+	AuthPrivateKey tpm2.ECCParameter
+}
+
 // keyPolicyUpdateDataRaw_v0 is version 0 of the on-disk format of keyPolicyUpdateData.
 type keyPolicyUpdateDataRaw_v0 struct {
 	AuthKey        []byte
 	CreationData   *tpm2.CreationData
 	CreationTicket *tpm2.TkCreation
 }
-
-// keyPolicyUpdateDataRaw_v1 is version 1 of the on-disk format of keyPolicyUpdateData.
-type keyPolicyUpdateDataRaw_v1 keyPolicyUpdateDataRaw_v0
 
 // keyPolicyUpdateData corresponds to the private part of a sealed key object that is required in order to create new dynamic
 // authorization policies.
@@ -74,15 +76,7 @@ type keyPolicyUpdateData struct {
 }
 
 func (d *keyPolicyUpdateData) Marshal(w io.Writer) (nbytes int, err error) {
-	authKey, err := x509.MarshalECPrivateKey(d.authKey.(*ecdsa.PrivateKey))
-	if err != nil {
-		return 0, xerrors.Errorf("cannot marshal private key: %w", err)
-	}
-	raw := &keyPolicyUpdateDataRaw_v1{
-		AuthKey:        authKey,
-		CreationData:   d.creationData,
-		CreationTicket: d.creationTicket}
-	return tpm2.MarshalToWriter(w, d.version, raw)
+	panic("not implemented")
 }
 
 func (d *keyPolicyUpdateData) Unmarshal(r io.Reader) (nbytes int, err error) {
@@ -118,47 +112,10 @@ func (d *keyPolicyUpdateData) Unmarshal(r io.Reader) (nbytes int, err error) {
 			creationInfo:   h.Sum(nil),
 			creationData:   raw.CreationData,
 			creationTicket: raw.CreationTicket}
-	case 1:
-		var raw keyPolicyUpdateDataRaw_v1
-		n, err := tpm2.UnmarshalFromReader(r, &raw)
-		nbytes += n
-		if err != nil {
-			return nbytes, xerrors.Errorf("cannot unmarshal data: %w", err)
-		}
-
-		authKey, err := x509.ParseECPrivateKey(raw.AuthKey)
-		if err != nil {
-			return nbytes, xerrors.Errorf("cannot parse dynamic authorization policy signing key: %w", err)
-		}
-
-		h := crypto.SHA256.New()
-		if _, err := tpm2.MarshalToWriter(h, raw.AuthKey); err != nil {
-			panic(fmt.Sprintf("cannot marshal dynamic authorization policy signing key: %v", err))
-		}
-
-		*d = keyPolicyUpdateData{
-			version:        version,
-			authKey:        authKey,
-			creationInfo:   h.Sum(nil),
-			creationData:   raw.CreationData,
-			creationTicket: raw.CreationTicket}
 	default:
 		return nbytes, fmt.Errorf("unexpected version number (%d)", version)
 	}
 	return
-}
-
-// write serializes keyPolicyUpdateData to the provided io.Writer.
-func (d *keyPolicyUpdateData) write(buf io.Writer) error {
-	if d.version != currentMetadataVersion {
-		return errors.New("writing old metadata versions is not supported")
-	}
-
-	if _, err := tpm2.MarshalToWriter(buf, keyPolicyUpdateDataHeader, d); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // decodeKeyPolicyUpdateData deserializes keyPolicyUpdateData from the provided io.Reader.
@@ -282,12 +239,7 @@ func (d *keyData) load(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.
 
 // validate performs some correctness checking on the provided keyData and keyPolicyUpdateData. On success, it returns the validated
 // public area for the PIN NV index.
-func (d *keyData) validate(tpm *tpm2.TPMContext, policyUpdateData *keyPolicyUpdateData, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
-	srkContext, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
-	}
-
+func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
 	sealedKeyTemplate := makeSealedKeyTemplate()
 
 	keyPublic := d.keyPublic
@@ -301,22 +253,12 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, policyUpdateData *keyPolicyUpda
 	}
 
 	// Load the sealed data object in to the TPM for integrity checking
-	keyContext, err := tpm.Load(srkContext, d.keyPrivate, keyPublic, session)
+	keyContext, err := d.load(tpm, session)
 	if err != nil {
-		invalidObject := false
-		switch {
-		case tpm2.IsTPMParameterError(err, tpm2.AnyErrorCode, tpm2.CommandLoad, tpm2.AnyParameterIndex):
-			invalidObject = true
-		case tpm2.IsTPMError(err, tpm2.ErrorSensitive, tpm2.CommandLoad):
-			invalidObject = true
-		}
-		if invalidObject {
-			return nil, keyFileError{errors.New("cannot load sealed key object in to TPM: bad sealed key object or TPM owner changed")}
-		}
-		return nil, xerrors.Errorf("cannot load sealed key object in to TPM: %w", err)
+		return nil, err
 	}
 	// It's loaded ok, so we know that the private and public parts are consistent.
-	defer tpm.FlushContext(keyContext)
+	tpm.FlushContext(keyContext)
 
 	lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
 	if err != nil {
@@ -418,60 +360,25 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, policyUpdateData *keyPolicyUpda
 	// At this point, we know that the sealed object is an object with an authorization policy created by this package and with
 	// matching static metadata and persistent TPM resources.
 
-	if policyUpdateData == nil {
-		// If we weren't passed a private data structure, we're done.
-		return pinIndexPublic, nil
-	}
-
-	if policyUpdateData.version != d.version {
-		return nil, keyFileError{errors.New("mismatched metadata versions")}
-	}
-
-	// Verify that the private data structure is bound to the key data structure.
-	h := keyPublic.NameAlg.NewHash()
-	if _, err := tpm2.MarshalToWriter(h, policyUpdateData.creationData); err != nil {
-		panic(fmt.Sprintf("cannot marshal creation data: %v", err))
-	}
-
-	if _, _, err := tpm.CertifyCreation(nil, keyContext, nil, h.Sum(nil), nil, policyUpdateData.creationTicket, nil,
-		session.IncludeAttrs(tpm2.AttrAudit)); err != nil {
-		if tpm2.IsTPMParameterError(err, tpm2.ErrorTicket, tpm2.CommandCertifyCreation, 4) {
-			return nil, keyFileError{errors.New("key data file and dynamic authorization policy update data file mismatch: invalid creation ticket")}
-		}
-		return nil, xerrors.Errorf("cannot validate creation data for sealed data object: %w", err)
-	}
-
-	if !bytes.Equal(policyUpdateData.creationInfo, policyUpdateData.creationData.OutsideInfo) {
-		return nil, keyFileError{errors.New("key data file and dynamic authorization policy update data file mismatch: digest doesn't match creation data")}
-	}
-
-	authKey := policyUpdateData.authKey
-	switch d.version {
-	case 0:
-		authKeyRSA, isRSA := authKey.(*rsa.PrivateKey)
-		if !isRSA {
-			return nil, keyFileError{errors.New("unexpected dynamic authorization policy signing private key type")}
-		}
+	switch k := authKey.(type) {
+	case *rsa.PrivateKey:
 		goAuthPublicKey := rsa.PublicKey{
 			N: new(big.Int).SetBytes(authPublicKey.Unique.RSA()),
 			E: int(authPublicKey.Params.RSADetail().Exponent)}
-		if authKeyRSA.E != goAuthPublicKey.E || authKeyRSA.N.Cmp(goAuthPublicKey.N) != 0 {
+		if k.E != goAuthPublicKey.E || k.N.Cmp(goAuthPublicKey.N) != 0 {
 			return nil, keyFileError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
 		}
-	default:
-		authKeyECDSA, isECDSA := authKey.(*ecdsa.PrivateKey)
-		if !isECDSA {
+	case *ecdsa.PrivateKey:
+		if d.version == 0 {
 			return nil, keyFileError{errors.New("unexpected dynamic authorization policy signing private key type")}
 		}
-		goAuthPublicKey := ecdsa.PublicKey{
-			Curve: authPublicKey.Params.ECCDetail().CurveID.GoCurve(),
-			X:     (&big.Int{}).SetBytes(authPublicKey.Unique.ECC().X),
-			Y:     (&big.Int{}).SetBytes(authPublicKey.Unique.ECC().Y)}
-		if authKeyECDSA.PublicKey.Curve != goAuthPublicKey.Curve ||
-			authKeyECDSA.PublicKey.X.Cmp(goAuthPublicKey.X) != 0 ||
-			authKeyECDSA.PublicKey.Y.Cmp(goAuthPublicKey.Y) != 0 {
+		expectedX, expectedY := k.Curve.ScalarBaseMult(k.D.Bytes())
+		if expectedX.Cmp(k.X) != 0 || expectedY.Cmp(k.Y) != 0 {
 			return nil, keyFileError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
 		}
+	case nil:
+	default:
+		return nil, keyFileError{errors.New("unexpected dynamic authorization policy signing private key type")}
 	}
 
 	return pinIndexPublic, nil
@@ -541,34 +448,59 @@ func isKeyFileError(err error) bool {
 
 // decodeAndValidateKeyData will deserialize keyData and keyPolicyUpdateData from the provided io.Readers and then perform some correctness
 // checking. On success, it returns the keyData, keyPolicyUpdateData and the validated public area of the PIN NV index.
-func decodeAndValidateKeyData(tpm *tpm2.TPMContext, keyFile, keyPolicyUpdateFile io.Reader, session tpm2.SessionContext) (*keyData, *keyPolicyUpdateData, *tpm2.NVPublic, error) {
+func decodeAndValidateKeyData(tpm *tpm2.TPMContext, keyFile io.Reader, authData interface{}, session tpm2.SessionContext) (*keyData, crypto.PrivateKey, *tpm2.NVPublic, error) {
 	// Read the key data
 	data, err := decodeKeyData(keyFile)
 	if err != nil {
 		return nil, nil, nil, keyFileError{xerrors.Errorf("cannot read key data: %w", err)}
 	}
 
-	var policyUpdateData *keyPolicyUpdateData
-	if keyPolicyUpdateFile != nil {
-		var err error
-		policyUpdateData, err = decodeKeyPolicyUpdateData(keyPolicyUpdateFile)
+	var authKey crypto.PrivateKey
+
+	switch a := authData.(type) {
+	case io.Reader:
+		// If we were called with an io.Reader, then we're expecting to load a legacy version-0 keydata and associated
+		// private key file.
+		policyUpdateData, err := decodeKeyPolicyUpdateData(a)
 		if err != nil {
 			return nil, nil, nil, keyFileError{xerrors.Errorf("cannot read dynamic policy update data: %w", err)}
 		}
+		if policyUpdateData.version != data.version {
+			return nil, nil, nil, keyFileError{errors.New("mismatched metadata versions")}
+		}
+		authKey = policyUpdateData.authKey
+	case []byte:
+		if len(a) > 0 {
+			// If we were called with a byte slice, then we're expecting to load the current keydata version and the byte
+			// slice is the private part of the elliptic auth key.
+			authKey, err = createPrivateKeyFromTPM(data.staticPolicyData.AuthPublicKey,
+				&tpm2.Sensitive{Type: tpm2.ObjectTypeECC, Sensitive: tpm2.SensitiveCompositeU{Data: tpm2.ECCParameter(a)}})
+			if err != nil {
+				return nil, nil, nil, keyFileError{xerrors.Errorf("cannot create auth key: %w", err)}
+			}
+		}
+	case nil:
+	default:
+		panic("invalid type")
 	}
 
-	pinNVPublic, err := data.validate(tpm, policyUpdateData, session)
+	pinNVPublic, err := data.validate(tpm, authKey, session)
 	if err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot validate key data: %w", err)
 	}
 
-	return data, policyUpdateData, pinNVPublic, nil
+	return data, authKey, pinNVPublic, nil
 }
 
 // SealedKeyObject corresponds to a sealed key data file and exists to provide access to some read only operations on the underlying
 // file without having to read and deserialize the key data file more than once.
 type SealedKeyObject struct {
 	data *keyData
+}
+
+// Version returns the version number that this sealed key object was created with.
+func (k *SealedKeyObject) Version() uint32 {
+	return k.data.version
 }
 
 // AuthMode2F indicates the 2nd-factor authentication type for this sealed key object.

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -46,14 +46,15 @@ func (s *keyDataSuite) TestValidateAfterLock(c *C) {
 
 	pinHandle := tpm2.Handle(0x0181fff0)
 
-	c.Assert(SealKeyToTPM(s.TPM, key, keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: tpm2.Handle(0x0181fff0)}), IsNil)
+	authPrivateKey, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: tpm2.Handle(0x0181fff0)})
+	c.Assert(err, IsNil)
 	pinIndex, err := s.TPM.CreateResourceContextFromTPM(pinHandle)
 	c.Assert(err, IsNil)
 	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), pinIndex)
 
-	c.Check(ValidateKeyDataFile(s.TPM.TPMContext, keyFile, "", s.TPM.HmacSession()), IsNil)
+	c.Check(ValidateKeyDataFile(s.TPM.TPMContext, keyFile, authPrivateKey, s.TPM.HmacSession()), IsNil)
 
 	c.Assert(LockAccessToSealedKeys(s.TPM), IsNil)
 	defer s.ResetTPMSimulator(c)
-	c.Check(ValidateKeyDataFile(s.TPM.TPMContext, keyFile, "", s.TPM.HmacSession()), IsNil)
+	c.Check(ValidateKeyDataFile(s.TPM.TPMContext, keyFile, authPrivateKey, s.TPM.HmacSession()), IsNil)
 }

--- a/pin.go
+++ b/pin.go
@@ -100,7 +100,7 @@ func createPinNVIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKeyName tp
 		return nil, nil, xerrors.Errorf("cannot create signing key for initializing NV index: %w", err)
 	}
 
-	initKeyPublic := createPublicAreaForECDSAKey(&initKey.PublicKey)
+	initKeyPublic := createTPMPublicAreaForECDSAKey(&initKey.PublicKey)
 	initKeyName, err := initKeyPublic.Name()
 	if err != nil {
 		return nil, nil, xerrors.Errorf("cannot compute name of signing key for initializing NV index: %w", err)

--- a/pin_test.go
+++ b/pin_test.go
@@ -42,7 +42,7 @@ func TestCreatePinNVIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
-	keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
+	keyPublic := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		t.Fatalf("Cannot compute key name: %v", err)
@@ -114,7 +114,7 @@ func TestPerformPinChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
-	keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
+	keyPublic := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		t.Fatalf("Cannot compute key name: %v", err)
@@ -178,7 +178,8 @@ func (s *pinSuite) SetUpTest(c *C) {
 	dir := c.MkDir()
 	s.keyFile = dir + "/keydata"
 
-	c.Assert(SealKeyToTPM(s.TPM, s.key, s.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: s.pinHandle}), IsNil)
+	_, err := SealKeyToTPM(s.TPM, s.key, s.keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: s.pinHandle})
+	c.Assert(err, IsNil)
 	pinIndex, err := s.TPM.CreateResourceContextFromTPM(s.pinHandle)
 	c.Assert(err, IsNil)
 	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), pinIndex)

--- a/policy.go
+++ b/policy.go
@@ -296,7 +296,7 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 		return xerrors.Errorf("cannot create signing key for initializing NV index: %w", err)
 	}
 
-	keyPublic := createPublicAreaForECDSAKey(&key.PublicKey)
+	keyPublic := createTPMPublicAreaForECDSAKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		return xerrors.Errorf("cannot compute name of signing key for initializing NV index: %w", err)

--- a/policy_test.go
+++ b/policy_test.go
@@ -107,7 +107,7 @@ func TestIncrementDynamicPolicyCounter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
-	keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
+	keyPublic := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		t.Fatalf("Cannot compute key name: %v", err)
@@ -169,7 +169,7 @@ func TestReadDynamicPolicyCounter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
-	keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
+	keyPublic := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		t.Fatalf("Cannot compute key name: %v", err)
@@ -401,7 +401,7 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 			t.Fatalf("GenerateKey failed: %v", err)
 		}
 
-		keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
+		keyPublic := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 		keyName, err := keyPublic.Name()
 		if err != nil {
 			t.Errorf("Cannot compute key name: %v", err)
@@ -520,7 +520,7 @@ AwEHoUQDQgAEkxoOhf6oe3ZE91Kl97qMH/WndK1B0gD7nuqXzPnwtxBBWhTF6pbw
 	if err != nil {
 		t.Fatalf("ParsePKCS1PrivateKey failed: %v", err)
 	}
-	publicKey := CreatePublicAreaForECDSAKey(&key.PublicKey)
+	publicKey := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 
 	// Generate an authorization policy for the PIN NV index public area below. For the purposes of this test, these digests could really
 	// be anything, although the ones here do actually correspond to valid authorization policies - the first one is for initialization
@@ -1147,7 +1147,7 @@ func TestExecutePolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
-	keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
+	keyPublic := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		t.Fatalf("Cannot compute key name: %v", err)
@@ -1197,7 +1197,7 @@ func TestExecutePolicy(t *testing.T) {
 			pinIndexAuthPoliciesCopy = append(pinIndexAuthPoliciesCopy, c)
 		}
 
-		staticPolicyData, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(CreatePublicAreaForECDSAKey(&key.PublicKey), pinIndexPub, pinIndexAuthPoliciesCopy, lockIndex.Name()))
+		staticPolicyData, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(CreateTPMPublicAreaForECDSAKey(&key.PublicKey), pinIndexPub, pinIndexAuthPoliciesCopy, lockIndex.Name()))
 		if err != nil {
 			t.Fatalf("ComputeStaticPolicy failed: %v", err)
 		}
@@ -2468,7 +2468,7 @@ func TestLockAccessToSealedKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey failed: %v", err)
 	}
-	keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
+	keyPublic := CreateTPMPublicAreaForECDSAKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		t.Fatalf("Cannot compute key name: %v", err)

--- a/seal.go
+++ b/seal.go
@@ -216,7 +216,7 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath string, params *KeyCre
 	// Create an asymmetric key for signing authorization policy updates, and authorizing dynamic authorization policy revocations.
 	goAuthKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot generate RSA key pair for signing dynamic authorization policies: %w", err)
+		return nil, xerrors.Errorf("cannot generate key for signing dynamic authorization policies: %w", err)
 	}
 	authPublicKey := createTPMPublicAreaForECDSAKey(&goAuthKey.PublicKey)
 	authKeyName, err := authPublicKey.Name()

--- a/seal.go
+++ b/seal.go
@@ -155,7 +155,7 @@ type KeyCreationParams struct {
 // UpdateKeyPCRProtectionPolicy. This key doesn't need to be stored anywhere, and certainly mustn't be stored outside of the encrypted
 // volume protected with this sealed key file. The key is stored encrypted inside this sealed key file and returned from future calls
 // to SealedKeyObject.UnsealFromTPM.
-func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath string, params *KeyCreationParams) (authKey []byte, err error) {
+func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath string, params *KeyCreationParams) (authKey TPMPolicyAuthKey, err error) {
 	// params is mandatory.
 	if params == nil {
 		return nil, errors.New("no KeyCreationParams provided")
@@ -390,6 +390,6 @@ func UpdateKeyPCRProtectionPolicyV0(tpm *TPMConnection, keyPath, policyUpdatePat
 //
 // On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
 // computed from the supplied PCRProtectionProfile.
-func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath string, authKey []byte, pcrProfile *PCRProtectionProfile) error {
+func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath string, authKey TPMPolicyAuthKey, pcrProfile *PCRProtectionProfile) error {
 	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, keyPath, authKey, pcrProfile, tpm.HmacSession())
 }

--- a/seal.go
+++ b/seal.go
@@ -24,7 +24,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"os"
@@ -122,11 +121,7 @@ type KeyCreationParams struct {
 
 // SealKeyToTPM seals the supplied disk encryption key to the storage hierarchy of the TPM. The sealed key object and associated
 // metadata that is required during early boot in order to unseal the key again and unlock the associated encrypted volume is written
-// to a file at the path specified by keyPath. Additional data that is required in order to update the authorization policy for the
-// sealed key is written to a file at the path specified by policyUpdatePath. This file must live inside the encrypted volume
-// protected by the sealed key.
-//
-// The supplied key must be 64-bytes long. An error will be returned if it isn't.
+// to a file at the path specified by keyPath.
 //
 // This function requires knowledge of the authorization value for the storage hierarchy, which must be provided by calling
 // TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the provided authorization value is incorrect,
@@ -135,9 +130,9 @@ type KeyCreationParams struct {
 // If the TPM is not correctly provisioned, a ErrTPMProvisioning error will be returned. In this case, ProvisionTPM must be called
 // before proceeding.
 //
-// This function expects there to be no files at the specified paths. If either path references a file that already exists, a wrapped
+// This function expects there to be no file at the specified path. If keyPath references a file that already exists, a wrapped
 // *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be returned if
-// either file cannot be created and opened for writing.
+// the file cannot be created and opened for writing.
 //
 // This function will create a NV index at the handle specified by the PINHandle field of the params argument. If the handle is already
 // in use, a TPMResourceExistsError error will be returned. In this case, the caller will need to either choose a different handle or
@@ -147,10 +142,15 @@ type KeyCreationParams struct {
 //
 // The key will be protected with a PCR policy computed from the PCRProtectionProfile supplied via the PCRProfile field of the params
 // argument.
-func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath string, params *KeyCreationParams) error {
+//
+// On success, this function returns the private part of the key used for authorizing PCR policy updates with
+// UpdateKeyPCRProtectionPolicy. This key doesn't need to be stored anywhere, and certainly mustn't be stored outside of the encrypted
+// volume protected with this sealed key file. The key is stored encrypted inside this sealed key file and returned from future calls
+// to SealedKeyObject.UnsealFromTPM.
+func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath string, params *KeyCreationParams) ([]byte, error) {
 	// params is mandatory.
 	if params == nil {
-		return errors.New("no KeyCreationParams provided")
+		return nil, errors.New("no KeyCreationParams provided")
 	}
 
 	// Use the HMAC session created when the connection was opened rather than creating a new one.
@@ -166,9 +166,9 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 		srk, err = provisionPrimaryKey(tpm.TPMContext, tpm.OwnerHandleContext(), tcg.SRKTemplate, tcg.SRKHandle, session)
 		switch {
 		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
-			return AuthFailError{tpm2.HandleOwner}
+			return nil, AuthFailError{tpm2.HandleOwner}
 		case err != nil:
-			return xerrors.Errorf("cannot provision storage root key: %w", err)
+			return nil, xerrors.Errorf("cannot provision storage root key: %w", err)
 		}
 	}
 
@@ -176,18 +176,18 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 	lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
 	switch {
 	case tpm2.IsResourceUnavailableError(err, lockNVHandle):
-		return ErrTPMProvisioning
+		return nil, ErrTPMProvisioning
 	case err != nil:
-		return xerrors.Errorf("cannot create context for lock NV index: %w", err)
+		return nil, xerrors.Errorf("cannot create context for lock NV index: %w", err)
 	}
 
 	lockIndexPub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session)
 	if err != nil {
-		return ErrTPMProvisioning
+		return nil, ErrTPMProvisioning
 	}
 	lockIndexName, err := lockIndexPub.Name()
 	if err != nil {
-		return xerrors.Errorf("cannot compute name of global lock NV index: %w", err)
+		return nil, xerrors.Errorf("cannot compute name of global lock NV index: %w", err)
 	}
 
 	succeeded := false
@@ -195,7 +195,7 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 	// Create destination files
 	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
-		return xerrors.Errorf("cannot create key data file: %w", err)
+		return nil, xerrors.Errorf("cannot create key data file: %w", err)
 	}
 	defer func() {
 		keyFile.Close()
@@ -205,42 +205,26 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 		os.Remove(keyPath)
 	}()
 
-	var policyUpdateFile *os.File
-	if policyUpdatePath != "" {
-		var err error
-		policyUpdateFile, err = os.OpenFile(policyUpdatePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-		if err != nil {
-			return xerrors.Errorf("cannot create private data file: %w", err)
-		}
-		defer func() {
-			policyUpdateFile.Close()
-			if succeeded {
-				return
-			}
-			os.Remove(policyUpdatePath)
-		}()
-	}
-
 	// Create an asymmetric key for signing authorization policy updates, and authorizing dynamic authorization policy revocations.
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return xerrors.Errorf("cannot generate RSA key pair for signing dynamic authorization policies: %w", err)
+		return nil, xerrors.Errorf("cannot generate RSA key pair for signing dynamic authorization policies: %w", err)
 	}
-	authPublicKey := createPublicAreaForECDSAKey(&authKey.PublicKey)
+	authPublicKey := createTPMPublicAreaForECDSAKey(&authKey.PublicKey)
 	authKeyName, err := authPublicKey.Name()
 	if err != nil {
-		return xerrors.Errorf("cannot compute name of signing key for dynamic policy authorization: %w", err)
+		return nil, xerrors.Errorf("cannot compute name of signing key for dynamic policy authorization: %w", err)
 	}
 
 	// Create pin NV index
 	pinIndexPub, pinIndexAuthPolicies, err := createPinNVIndex(tpm.TPMContext, params.PINHandle, authKeyName, session)
 	switch {
 	case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
-		return TPMResourceExistsError{params.PINHandle}
+		return nil, TPMResourceExistsError{params.PINHandle}
 	case isAuthFailError(err, tpm2.CommandNVDefineSpace, 1):
-		return AuthFailError{tpm2.HandleOwner}
+		return nil, AuthFailError{tpm2.HandleOwner}
 	case err != nil:
-		return xerrors.Errorf("cannot create new pin NV index: %w", err)
+		return nil, xerrors.Errorf("cannot create new pin NV index: %w", err)
 	}
 	defer func() {
 		if succeeded {
@@ -262,32 +246,25 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 		pinIndexAuthPolicies: pinIndexAuthPolicies,
 		lockIndexName:        lockIndexName})
 	if err != nil {
-		return xerrors.Errorf("cannot compute static authorization policy: %w", err)
+		return nil, xerrors.Errorf("cannot compute static authorization policy: %w", err)
 	}
 
 	// Define the template for the sealed key object, using the computed policy digest
 	template.AuthPolicy = authPolicy
-	sensitive := tpm2.SensitiveCreate{Data: key}
 
-	// Have the digest of the private data recorded in the creation data for the sealed data object.
-	authKeyBytes, err := x509.MarshalECPrivateKey(authKey)
+	// Create the sensitive data
+	sealedData, err := tpm2.MarshalToBytes(sealedData{Key: key, AuthPrivateKey: authKey.D.Bytes()})
 	if err != nil {
-		return xerrors.Errorf("cannot marshal key for signing authorization policy updates: %w", err)
+		panic(fmt.Sprintf("cannot marshal sensitive data: %v", err))
 	}
-
-	h := crypto.SHA256.New()
-	if _, err := tpm2.MarshalToWriter(h, authKeyBytes); err != nil {
-		panic(fmt.Sprintf("cannot marshal dynamic authorization policy update data: %v", err))
-	}
-	creationInfo := h.Sum(nil)
+	sensitive := tpm2.SensitiveCreate{Data: sealedData}
 
 	// Now create the sealed key object. The command is integrity protected so if the object at the handle we expect the SRK to reside
 	// at has a different name (ie, if we're connected via a resource manager and somebody swapped the object with another one), this
 	// command will fail. We take advantage of parameter encryption here too.
-	priv, pub, creationData, _, creationTicket, err :=
-		tpm.Create(srk, &sensitive, template, creationInfo, nil, session.IncludeAttrs(tpm2.AttrCommandEncrypt))
+	priv, pub, _, _, _, err := tpm.Create(srk, &sensitive, template, nil, nil, session.IncludeAttrs(tpm2.AttrCommandEncrypt))
 	if err != nil {
-		return xerrors.Errorf("cannot create sealed data object for key: %w", err)
+		return nil, xerrors.Errorf("cannot create sealed data object for key: %w", err)
 	}
 
 	// Create a dynamic authorization policy
@@ -298,7 +275,7 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 	dynamicPolicyData, err := computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, currentMetadataVersion, template.NameAlg,
 		authPublicKey.NameAlg, authKey, pinIndexPub, pinIndexAuthPolicies, pcrProfile, session)
 	if err != nil {
-		return xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
+		return nil, xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}
 
 	// Marshal the entire object (sealed key object and auxiliary data) to disk
@@ -311,45 +288,18 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 		dynamicPolicyData: dynamicPolicyData}
 
 	if err := data.write(keyFile); err != nil {
-		return xerrors.Errorf("cannot write key data file: %w", err)
-	}
-
-	if policyUpdateFile != nil {
-		policyUpdateData := keyPolicyUpdateData{
-			version:        currentMetadataVersion,
-			authKey:        authKey,
-			creationInfo:   creationInfo,
-			creationData:   creationData,
-			creationTicket: creationTicket}
-
-		// Marshal the private data to disk
-		if err := policyUpdateData.write(policyUpdateFile); err != nil {
-			return xerrors.Errorf("cannot write dynamic authorization policy update data file: %w", err)
-		}
+		return nil, xerrors.Errorf("cannot write key data file: %w", err)
 	}
 
 	if err := incrementDynamicPolicyCounter(tpm.TPMContext, pinIndexPub, pinIndexAuthPolicies, authKey, authPublicKey, session); err != nil {
-		return xerrors.Errorf("cannot increment dynamic policy counter: %w", err)
+		return nil, xerrors.Errorf("cannot increment dynamic policy counter: %w", err)
 	}
 
 	succeeded = true
-	return nil
+	return authKey.D.Bytes(), nil
 }
 
-// UpdateKeyPCRProtectionPolicy updates the PCR protection policy for the sealed key at the path specified by the keyPath argument
-// to the profile defined by the pcrProfile argument. In order to do this, the caller must also specify the path to the policy update
-// data file that was saved by SealKeyToTPM.
-//
-// If either file cannot be opened, a wrapped *os.PathError error will be returned.
-//
-// If either file cannot be deserialized correctly or validation of the files fails, a InvalidKeyFileError error will be returned.
-//
-// On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
-// computed from the supplied PCRProtectionProfile.
-func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath, policyUpdatePath string, pcrProfile *PCRProtectionProfile) error {
-	// Use the HMAC session created when the connection was opened rather than creating a new one.
-	session := tpm.HmacSession()
-
+func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keyPath string, authData interface{}, pcrProfile *PCRProtectionProfile, session tpm2.SessionContext) error {
 	// Open the key data file
 	keyFile, err := os.Open(keyPath)
 	if err != nil {
@@ -357,14 +307,7 @@ func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath, policyUpdatePath 
 	}
 	defer keyFile.Close()
 
-	// Open the policy update data file
-	policyUpdateFile, err := os.Open(policyUpdatePath)
-	if err != nil {
-		return xerrors.Errorf("cannot open private data file: %w", err)
-	}
-	defer policyUpdateFile.Close()
-
-	data, policyUpdateData, pinIndexPublic, err := decodeAndValidateKeyData(tpm.TPMContext, keyFile, policyUpdateFile, session)
+	data, authKey, pinIndexPublic, err := decodeAndValidateKeyData(tpm, keyFile, authData, session)
 	if err != nil {
 		if isKeyFileError(err) {
 			return InvalidKeyFileError{err.Error()}
@@ -374,15 +317,14 @@ func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath, policyUpdatePath 
 	}
 
 	authPublicKey := data.staticPolicyData.AuthPublicKey
-	authKey := policyUpdateData.authKey
 	pinIndexAuthPolicies := data.staticPolicyData.PinIndexAuthPolicies
 
 	// Compute a new dynamic authorization policy
 	if pcrProfile == nil {
 		pcrProfile = &PCRProtectionProfile{}
 	}
-	policyData, err := computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, data.version, data.keyPublic.NameAlg, authPublicKey.NameAlg,
-		authKey, pinIndexPublic, pinIndexAuthPolicies, pcrProfile, session)
+	policyData, err := computeSealedKeyDynamicAuthPolicy(tpm, data.version, data.keyPublic.NameAlg, authPublicKey.NameAlg, authKey,
+		pinIndexPublic, pinIndexAuthPolicies, pcrProfile, session)
 	if err != nil {
 		return xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}
@@ -394,10 +336,43 @@ func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath, policyUpdatePath 
 		return xerrors.Errorf("cannot write key data file: %v", err)
 	}
 
-	if err := incrementDynamicPolicyCounter(tpm.TPMContext, pinIndexPublic, pinIndexAuthPolicies, authKey, authPublicKey,
-		session); err != nil {
+	if err := incrementDynamicPolicyCounter(tpm, pinIndexPublic, pinIndexAuthPolicies, authKey, authPublicKey, session); err != nil {
 		return xerrors.Errorf("cannot revoke old dynamic authorization policies: %w", err)
 	}
 
 	return nil
+}
+
+// UpdateKeyPCRProtectionPolicyV0 updates the PCR protection policy for the sealed key at the path specified by the keyPath argument
+// to the profile defined by the pcrProfile argument. This function only works with version 0 sealed key files. In order to do this,
+// the caller must also specify the path to the policy update data file that was originally saved by SealKeyToTPM.
+//
+// If either file cannot be opened, a wrapped *os.PathError error will be returned.
+//
+// If either file cannot be deserialized correctly or validation of the files fails, a InvalidKeyFileError error will be returned.
+//
+// On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
+// computed from the supplied PCRProtectionProfile.
+func UpdateKeyPCRProtectionPolicyV0(tpm *TPMConnection, keyPath, policyUpdatePath string, pcrProfile *PCRProtectionProfile) error {
+	policyUpdateFile, err := os.Open(policyUpdatePath)
+	if err != nil {
+		return xerrors.Errorf("cannot open private data file: %w", err)
+	}
+	defer policyUpdateFile.Close()
+
+	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, keyPath, policyUpdateFile, pcrProfile, tpm.HmacSession())
+}
+
+// UpdateKeyPCRProtectionPolicy updates the PCR protection policy for the sealed key at the path specified by the keyPath argument
+// to the profile defined by the pcrProfile argument. In order to do this, the caller must also specify the private part of the
+// authorization key that was either returned by SealKeyToTPM or SealedKeyObject.UnsealFromTPM.
+//
+// If the file cannot be opened, a wrapped *os.PathError error will be returned.
+//
+// If the file cannot be deserialized correctly or validation of the file fails, a InvalidKeyFileError error will be returned.
+//
+// On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
+// computed from the supplied PCRProtectionProfile.
+func UpdateKeyPCRProtectionPolicy(tpm *TPMConnection, keyPath string, authKey []byte, pcrProfile *PCRProtectionProfile) error {
+	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, keyPath, authKey, pcrProfile, tpm.HmacSession())
 }

--- a/seal_test.go
+++ b/seal_test.go
@@ -51,7 +51,7 @@ func TestSealKeyToTPM(t *testing.T) {
 	key := make([]byte, 64)
 	rand.Read(key)
 
-	run := func(t *testing.T, tpm *TPMConnection, withPolicyUpdateFile bool, params *KeyCreationParams) {
+	run := func(t *testing.T, tpm *TPMConnection, params *KeyCreationParams) {
 		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPM_")
 		if err != nil {
 			t.Fatalf("Creating temporary directory failed: %v", err)
@@ -59,37 +59,28 @@ func TestSealKeyToTPM(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 
 		keyFile := tmpDir + "/keydata"
-		policyUpdateFile := ""
-		if withPolicyUpdateFile {
-			policyUpdateFile = tmpDir + "/keypolicyupdatedata"
-		}
 
-		if err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, params); err != nil {
+		authPrivateKey, err := SealKeyToTPM(tpm, key, keyFile, params)
+		if err != nil {
 			t.Errorf("SealKeyToTPM failed: %v", err)
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)
 
-		if err := ValidateKeyDataFile(tpm.TPMContext, keyFile, policyUpdateFile, tpm.HmacSession()); err != nil {
+		if err := ValidateKeyDataFile(tpm.TPMContext, keyFile, authPrivateKey, tpm.HmacSession()); err != nil {
 			t.Errorf("ValidateKeyDataFile failed: %v", err)
 		}
 	}
 
-	t.Run("BothFiles", func(t *testing.T) {
+	t.Run("Standard", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
-	})
-
-	t.Run("NoPrivFile", func(t *testing.T) {
-		tpm := openTPMForTesting(t)
-		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		run(t, tpm, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 	})
 
 	t.Run("DifferentPINHandle", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0})
+		run(t, tpm, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x0181fff0})
 	})
 
 	t.Run("SealAfterProvision", func(t *testing.T) {
@@ -99,7 +90,7 @@ func TestSealKeyToTPM(t *testing.T) {
 		if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 			t.Errorf("Failed to provision TPM for test: %v", err)
 		}
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		run(t, tpm, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 	})
 
 	t.Run("NoSRK", func(t *testing.T) {
@@ -114,13 +105,13 @@ func TestSealKeyToTPM(t *testing.T) {
 			t.Errorf("EvictControl failed: %v", err)
 		}
 
-		run(t, tpm, true, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
+		run(t, tpm, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
-		run(t, tpm, false, &KeyCreationParams{PINHandle: 0x01810000})
+		run(t, tpm, &KeyCreationParams{PINHandle: 0x01810000})
 	})
 }
 
@@ -146,21 +137,16 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 
 		keyFile := tmpDir + "/keydata"
-		policyUpdateFile := tmpDir + "/keypolicyupdatedata"
 
 		origKeyFileInfo, _ := os.Stat(keyFile)
-		origPolicyUpdateFileInfo, _ := os.Stat(policyUpdateFile)
 		var pinIndex tpm2.ResourceContext
 		if params != nil {
 			pinIndex, _ = tpm.CreateResourceContextFromTPM(params.PINHandle)
 		}
 
-		err := SealKeyToTPM(tpm, key, keyFile, policyUpdateFile, params)
+		_, err := SealKeyToTPM(tpm, key, keyFile, params)
 
 		if fi, err := os.Stat(keyFile); err == nil && (origKeyFileInfo == nil || origKeyFileInfo.ModTime() != fi.ModTime()) {
-			t.Errorf("SealKeyToTPM created a key file")
-		}
-		if fi, err := os.Stat(policyUpdateFile); err == nil && (origPolicyUpdateFileInfo == nil || origPolicyUpdateFileInfo.ModTime() != fi.ModTime()) {
 			t.Errorf("SealKeyToTPM created a key file")
 		}
 		if params != nil {
@@ -246,7 +232,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		}
 	})
 
-	t.Run("FileExists/1", func(t *testing.T) {
+	t.Run("FileExists", func(t *testing.T) {
 		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPMErrors_")
 		if err != nil {
 			t.Fatalf("Creating temporary directory failed: %v", err)
@@ -259,23 +245,6 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
 		var e *os.PathError
 		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keydata" || e.Err != syscall.EEXIST {
-			t.Errorf("Unexpected error: %v", err)
-		}
-	})
-
-	t.Run("FileExists/2", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPMErrors_")
-		if err != nil {
-			t.Fatalf("Creating temporary directory failed: %v", err)
-		}
-		f, err := os.OpenFile(tmpDir+"/keypolicyupdatedata", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-		if err != nil {
-			t.Fatalf("OpenFile failed: %v", err)
-		}
-		defer f.Close()
-		err = run(t, tmpDir, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PINHandle: 0x01810000})
-		var e *os.PathError
-		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keypolicyupdatedata" || e.Err != syscall.EEXIST {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -194,13 +194,19 @@ func run() int {
 		os.Remove(f)
 	}
 
-	if err := secboot.SealKeyToTPM(tpm, key, keyFile, pudFile, &params); err != nil {
+	authKey, err := secboot.SealKeyToTPM(tpm, key, keyFile, &params)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot seal key: %v\n", err)
 		return 1
 	}
 
 	if err := ioutil.WriteFile(filepath.Join(outputDir, "clearKey"), key, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot write cleartext key: %v\n", err)
+		return 1
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(outputDir, "authKey"), authKey, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot write policy update auth key: %v\n", err)
 		return 1
 	}
 

--- a/unseal.go
+++ b/unseal.go
@@ -70,7 +70,7 @@ import (
 //
 // On success, the unsealed cleartext key is returned as the first return value, and the private part of the key used for
 // authorizing PCR policy updates with UpdateKeyPCRProtectionPolicy is returned as the second return value.
-func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) (key []byte, authKey []byte, err error) {
+func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) (key []byte, authKey TPMPolicyAuthKey, err error) {
 	// Check if the TPM is in lockout mode
 	props, err := tpm.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1)
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -21,7 +21,6 @@ package secboot
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"errors"
@@ -167,8 +166,8 @@ func createTPMPublicAreaForECDSAKey(key *ecdsa.PublicKey) *tpm2.Public {
 				Y: bigIntToBytesZeroExtended(key.Y, key.Params().BitSize/8)}}}
 }
 
-func createPrivateKeyFromTPM(public *tpm2.Public, sensitive *tpm2.Sensitive) (crypto.PrivateKey, error) {
-	if public.Type != tpm2.ObjectTypeECC || sensitive.Type != tpm2.ObjectTypeECC {
+func createECDSAPrivateKeyFromTPM(public *tpm2.Public, private tpm2.ECCParameter) (*ecdsa.PrivateKey, error) {
+	if public.Type != tpm2.ObjectTypeECC {
 		return nil, errors.New("unsupported type")
 	}
 
@@ -191,7 +190,7 @@ func createPrivateKeyFromTPM(public *tpm2.Public, sensitive *tpm2.Sensitive) (cr
 			Curve: curve,
 			X:     new(big.Int).SetBytes(public.Unique.ECC().X),
 			Y:     new(big.Int).SetBytes(public.Unique.ECC().Y)},
-		D: new(big.Int).SetBytes(sensitive.Sensitive.ECC())}, nil
+		D: new(big.Int).SetBytes(private)}, nil
 }
 
 // digestListContains indicates whether the specified digest is present in the list of digests.


### PR DESCRIPTION
Now that an elliptic curve key is used to authorize PCR policy updates and
this is significantly smaller than the previous RSA key, store the private
part of the key inside the sealed key object and have it returned from
SealedKeyObject.UnsealFromTPM rather than storing it inside a file inside
the encrypted volume.

This removes the need to store an additional file in order to use
UpdateKeyPCRProtectionPolicy.

ActivateVolumeWithTPMSealedKey now adds the private part of the key to
the root user's keyring. Callers to UpdateKeyPCRProtectionPolicy will
need to retrieve the key data from there using the keyctl syscall.