### PR TITLE
Switch to use Container.RandomAccessFile's result Size

### DIFF
--- a/efi.go
+++ b/efi.go
@@ -88,6 +88,7 @@ func (p FileEFIImage) Open() (interface {
 	}
 	fi, err := f.Stat()
 	if err != nil {
+		f.Close()
 		return nil, err
 	}
 	return &fileEFIImageHandle{File: f, size: fi.Size()}, nil

--- a/efi.go
+++ b/efi.go
@@ -38,26 +38,9 @@ type EFIImage interface {
 	Open() (interface {
 		io.ReaderAt
 		io.Closer
-		Size() (int64, error)
+		Size() int64
 	}, error) // Open a handle to the image for reading
 }
-
-type snapFileEFIImageHandle struct {
-	h interface {
-		io.ReaderAt
-		io.Closer
-	}
-}
-
-func (h *snapFileEFIImageHandle) ReadAt(p []byte, off int64) (int, error) {
-	return h.h.ReadAt(p, off)
-}
-
-func (h *snapFileEFIImageHandle) Close() error {
-	return h.h.Close()
-}
-
-func (h *snapFileEFIImageHandle) Size() (int64, error) { panic("not implemented") }
 
 // SnapFileEFIImage corresponds to a binary contained within a snap file that is loaded, verified and executed before ExitBootServices.
 type SnapFileEFIImage struct {
@@ -73,25 +56,18 @@ func (f SnapFileEFIImage) String() string {
 func (f SnapFileEFIImage) Open() (interface {
 	io.ReaderAt
 	io.Closer
-	Size() (int64, error)
+	Size() int64
 }, error) {
-	h, err := f.Container.RandomAccessFile(f.FileName)
-	if err != nil {
-		return nil, err
-	}
-	return &snapFileEFIImageHandle{h}, nil
+	return f.Container.RandomAccessFile(f.FileName)
 }
 
 type fileEFIImageHandle struct {
 	*os.File
+	size int64
 }
 
-func (h *fileEFIImageHandle) Size() (int64, error) {
-	fi, err := h.Stat()
-	if err != nil {
-		return 0, err
-	}
-	return fi.Size(), nil
+func (h *fileEFIImageHandle) Size() int64 {
+	return h.size
 }
 
 // FileEFIImage corresponds to a file on disk that is loaded, verified and executed before ExitBootServices.
@@ -104,13 +80,17 @@ func (p FileEFIImage) String() string {
 func (p FileEFIImage) Open() (interface {
 	io.ReaderAt
 	io.Closer
-	Size() (int64, error)
+	Size() int64
 }, error) {
 	f, err := os.Open(string(p))
 	if err != nil {
 		return nil, err
 	}
-	return &fileEFIImageHandle{f}, nil
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return &fileEFIImageHandle{File: f, size: fi.Size()}, nil
 }
 
 // EFIImageLoadEventSource corresponds to the source of a EFIImageLoadEvent.

--- a/efibootmanager_policy.go
+++ b/efibootmanager_policy.go
@@ -179,10 +179,7 @@ func computePeImageDigest(alg tpm2.HashAlgorithmId, image EFIImage) (tpm2.Digest
 	// greater than sumOfBytesHashed, the file contains extra data that must be added to the hash. This data begins at the
 	// sumOfBytesHashed file offset, and its length is:
 	// fileSize – (certTable.Size + sumOfBytesHashed)
-	fileSize, err := r.Size()
-	if err != nil {
-		return nil, xerrors.Errorf("cannot obtain image size: %w", err)
-	}
+	fileSize := r.Size()
 
 	if fileSize > sumOfBytesHashed {
 		var certSize int64

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -145,10 +145,10 @@
 			"revisionTime": "2020-04-20T18:59:55Z"
 		},
 		{
-			"checksumSHA1": "f01gqazrvoATUzX2njKnzd+c1O0=",
+			"checksumSHA1": "TOoWW8rGy9VaSreHsF41wC9AKZo=",
 			"path": "github.com/snapcore/snapd/snap",
-			"revision": "cba748d1244e6861a5e407f7abe90fb2f76b6f80",
-			"revisionTime": "2020-04-20T18:59:55Z"
+			"revision": "fb087b94699cd51acf7b3fe14585c3b24f37873e",
+			"revisionTime": "2020-08-27T07:31:38Z"
 		},
 		{
 			"checksumSHA1": "o5TwzS0cwJNV8HNIIZrRfZPANLU=",


### PR DESCRIPTION
make the EFIImage interface follow that as well