### PR TITLE
Use the PIN to derive additional key material

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -387,7 +387,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPIN(c *C, data *tes
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
 	// Test with a single PIN attempt.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", testPIN), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyAndPIN(c, &testActivateVolumeWithTPMSealedKeyAndPINData{
 		pins:     []string{testPIN},
 		pinTries: 1,
@@ -397,7 +397,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN2(c *C) {
 	// Test with 2 PIN attempts.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", testPIN), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyAndPIN(c, &testActivateVolumeWithTPMSealedKeyAndPINData{
 		pins:     []string{"", testPIN},
 		pinTries: 2,
@@ -440,7 +440,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(c *C) {
 	// Test with the correct PIN provided via the io.Reader.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pinFileContents: testPIN + "\n",
@@ -451,7 +451,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader2(c *C) {
 	// Test with the correct PIN provided via the io.Reader when the file doesn't end in a newline.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pinFileContents: testPIN,
@@ -462,7 +462,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader2(
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader3(c *C) {
 	// Test falling back to asking for a PIN if the wrong PIN is provided via the io.Reader.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pins:            []string{testPIN},
@@ -474,7 +474,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader3(
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader4(c *C) {
 	// Test falling back to asking for a PIN without using a try if the io.Reader has no contents.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", testPIN), IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c, &testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData{
 		pins:     []string{testPIN},
@@ -652,7 +652,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 	// Test that recovery fallback works if the wrong PIN is supplied.
 	testPIN := "1234"
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", testPIN), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
 		pinTries:         1,
 		recoveryKeyTries: 1,
@@ -671,7 +671,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 
 func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling10(c *C) {
 	// Test that recovery fallback works if a PIN is set but no PIN attempts are permitted.
-	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
+	c.Assert(ChangePIN(s.TPM, s.keyFile, &testPINParams, "", "1234"), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
 		recoveryKeyTries:  1,
 		passphrases:       []string{strings.Join(s.recoveryKeyAscii, "-")},

--- a/export_test.go
+++ b/export_test.go
@@ -63,7 +63,7 @@ var (
 	IsDynamicPolicyDataError                 = isDynamicPolicyDataError
 	IsStaticPolicyDataError                  = isStaticPolicyDataError
 	LockNVIndexAttrs                         = lockNVIndexAttrs
-	PerformPinChange                         = performPinChange
+	PerformTPMPinChange                      = performTPMPinChange
 	ReadAndValidateLockNVIndexPublic         = readAndValidateLockNVIndexPublic
 	ReadPcrPolicyCounter                     = readPcrPolicyCounter
 	ReadShimVendorCert                       = readShimVendorCert

--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -146,24 +146,24 @@ func (s *compatTestSuiteBase) testUnseal(c *C, pcrEventsFile string) {
 	c.Check(key, DeepEquals, expectedKey)
 }
 
-func (s *compatTestSuiteBase) TestChangePIN(c *C) {
+func (s *compatTestSuiteBase) testChangePIN(c *C, pinParams *secboot.PINParams) {
 	k, err := secboot.ReadSealedKeyObject(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.AuthMode2F(), Equals, secboot.AuthModeNone)
 
-	c.Check(secboot.ChangePIN(s.TPM, s.absPath("key"), "", testPIN), IsNil)
+	c.Check(secboot.ChangePIN(s.TPM, s.absPath("key"), pinParams, "", testPIN), IsNil)
 	k, err = secboot.ReadSealedKeyObject(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.AuthMode2F(), Equals, secboot.AuthModePIN)
 
-	c.Check(secboot.ChangePIN(s.TPM, s.absPath("key"), testPIN, ""), IsNil)
+	c.Check(secboot.ChangePIN(s.TPM, s.absPath("key"), pinParams, testPIN, ""), IsNil)
 	k, err = secboot.ReadSealedKeyObject(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.AuthMode2F(), Equals, secboot.AuthModeNone)
 }
 
-func (s *compatTestSuiteBase) testUnsealWithPIN(c *C, pcrEventsFile string) {
-	c.Check(secboot.ChangePIN(s.TPM, s.absPath("key"), "", testPIN), IsNil)
+func (s *compatTestSuiteBase) testUnsealWithPIN(c *C, pinParams *secboot.PINParams, pcrEventsFile string) {
+	c.Check(secboot.ChangePIN(s.TPM, s.absPath("key"), pinParams, "", testPIN), IsNil)
 
 	s.replayPCRSequenceFromFile(c, pcrEventsFile)
 

--- a/internal/compattest/v0_test.go
+++ b/internal/compattest/v0_test.go
@@ -48,12 +48,24 @@ func (s *compatTestV0Suite) TestUnseal2(c *C) {
 	s.testUnseal(c, s.absPath("pcrSequence.2"))
 }
 
+func (s *compatTestV0Suite) TestChangePIN1(c *C) {
+	s.testChangePIN(c, nil)
+}
+
+func (s *compatTestV0Suite) TestChangePIN2(c *C) {
+	s.testChangePIN(c, &secboot.PINParams{})
+}
+
 func (s *compatTestV0Suite) TestUnsealWithPIN1(c *C) {
-	s.testUnsealWithPIN(c, s.absPath("pcrSequence.1"))
+	s.testUnsealWithPIN(c, nil, s.absPath("pcrSequence.1"))
 }
 
 func (s *compatTestV0Suite) TestUnsealWithPIN2(c *C) {
-	s.testUnsealWithPIN(c, s.absPath("pcrSequence.2"))
+	s.testUnsealWithPIN(c, nil, s.absPath("pcrSequence.2"))
+}
+
+func (s *compatTestV0Suite) TestUnsealWithPIN3(c *C) {
+	s.testUnsealWithPIN(c, &secboot.PINParams{}, s.absPath("pcrSequence.1"))
 }
 
 func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicy(c *C) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -1243,7 +1243,7 @@ func TestExecutePolicy(t *testing.T) {
 		}
 		defer flushContext(t, tpm, session)
 
-		policyErr := ExecutePolicySession(tpm.TPMContext, session, CurrentMetadataVersion, staticPolicyData, dynamicPolicyData, "", tpm.HmacSession())
+		policyErr := ExecutePolicySession(tpm.TPMContext, session, CurrentMetadataVersion, staticPolicyData, dynamicPolicyData, nil, tpm.HmacSession())
 		digest, err := tpm.PolicyGetDigest(session)
 		if err != nil {
 			t.Errorf("PolicyGetDigest failed: %v", err)
@@ -2469,7 +2469,7 @@ func TestLockAccessToSealedKeys(t *testing.T) {
 			}
 			defer flushContext(t, tpm, policySession)
 
-			err = ExecutePolicySession(tpm.TPMContext, policySession, CurrentMetadataVersion, staticPolicyData, dynamicPolicyData, "", tpm.HmacSession())
+			err = ExecutePolicySession(tpm.TPMContext, policySession, CurrentMetadataVersion, staticPolicyData, dynamicPolicyData, nil, tpm.HmacSession())
 			if err != nil {
 				t.Errorf("ExecutePolicySession failed: %v", err)
 			}
@@ -2491,7 +2491,7 @@ func TestLockAccessToSealedKeys(t *testing.T) {
 				t.Errorf("PolicyRestart failed: %v", err)
 			}
 
-			err = ExecutePolicySession(tpm.TPMContext, policySession, CurrentMetadataVersion, staticPolicyData, dynamicPolicyData, "", tpm.HmacSession())
+			err = ExecutePolicySession(tpm.TPMContext, policySession, CurrentMetadataVersion, staticPolicyData, dynamicPolicyData, nil, tpm.HmacSession())
 			if !tpm2.IsTPMError(err, tpm2.ErrorNVLocked, tpm2.CommandPolicyNV) {
 				t.Errorf("Unexpected error: %v", err)
 			}

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -112,7 +112,7 @@ func TestUnsealWithPIN(t *testing.T) {
 
 	testPIN := "1234"
 
-	if err := ChangePIN(tpm, keyFile, "", testPIN); err != nil {
+	if err := ChangePIN(tpm, keyFile, &testPINParams, "", testPIN); err != nil {
 		t.Errorf("ChangePIN failed: %v", err)
 	}
 
@@ -297,7 +297,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 		defer closeTPM(t, tpm)
 
 		err := run(t, tpm, func(keyFile, _ string) {
-			if err := ChangePIN(tpm, keyFile, "", "1234"); err != nil {
+			if err := ChangePIN(tpm, keyFile, &testPINParams, "", "1234"); err != nil {
 				t.Errorf("ChangePIN failed: %v", err)
 			}
 		})

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -217,6 +217,18 @@
 			"revisionTime": "2020-01-28T12:03:23Z"
 		},
 		{
+			"checksumSHA1": "FwW3Vv4jW0Nv7V2SZC7x/Huj5M4=",
+			"path": "golang.org/x/crypto/argon2",
+			"revision": "4b2356b1ed79e6be3deca3737a3db3d132d2847a",
+			"revisionTime": "2020-04-23T13:34:55Z"
+		},
+		{
+			"checksumSHA1": "jBA6C2r4EBCfIA8B8C71Lr3MMEk=",
+			"path": "golang.org/x/crypto/blake2b",
+			"revision": "4b2356b1ed79e6be3deca3737a3db3d132d2847a",
+			"revisionTime": "2020-04-23T13:34:55Z"
+		},
+		{
 			"checksumSHA1": "zJybXQZcPAht+soLp/ozc9q5teE=",
 			"path": "golang.org/x/crypto/cast5",
 			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",


### PR DESCRIPTION
The default configuration of having no PIN set protects data from
opportunistic attackers. Setting a PIN protects data from more
determined attackers. This is the case even if the PIN is fairly low
entropy, because we use the TPM to assert that the provided PIN is
correct and this benefits from the TPM's dictionary attack logic. It is
beyond the ability even for most determined attackers to compromise the
actual TPM hardware to defeat this mechanism.

However, this may not be sufficient to protect your data from 3 letter
agencies with the means to compromise the TPM hardware in a way that
allows them access to a shielded location without the use of a protected
capability (a function that operates on a shielded location) - the type
of thing that would only be possible by state actors. Setting a higher
entropy PIN or passhprase doesn't help here, because the TPM just asserts
that the supplied PIN or passphrase is correct - it doesn't provide any
additional key material required for unsealing the disk encryption key.
The PIN is stored inside the sealed key file, encrypted to the TPM's
storage hierarchy. All of the key material required to unlock an encrypted
volume lives on the device.

In the future, we may want to support a network unlocking feature, where a
trusted server can work with the existing TPM protected key object to
authorize disk unlocking as long as the device is physically attached to
a specific network. An implementation of this should require that the
trusted server contributes key material required to unlock an encrypted
volume, but this doesn't fit well with the current design.

Some use cases for network unlocking are:
- Preventing automatic unlocking of devices that are detached from a
specific network (ie, if they are stolen).
- Bypassing the requirement for a PIN in enterprise environments when
devices are physically attached to a corporate network (where a PIN is
required when the device isn't physically attached to it).

This commit changes how the PIN is used to protect a key in order to
improve this.

During SealKeyToTPM, rather than sealing the disk encryption key (DEK) to
the TPM, it now:
- Generates an intermediate key (IK).
- Encrypts DEK with IK and an initialization vector (DEKiv) to produce
DEKenc.
- Seals DEKenc to the TPM.
- Saves DEKiv and IK to the metadata of the sealed key object.

During unsealing when a PIN hasn't been set, the following happens:
- The TPM unseals DEKenc if the PCR values match the PCR policy.
- DEKiv and IK are used to decrypt DEKenc to recover DEK.

When a PIN is set, the following happens:
- The PIN and a salt are passed through Argon2i to create a derived key
(DK).
- The upper 32-bits of DK are used for the authorization value of the
sealed key object, which is updated accordingly.
- The lower 32-bits of DK are used with an initialization vector (IKiv) to
encrypt IK to produce IKenc.
- IKenc is written to the sealed key object metadata, replacing the
unencrypted version.
- The salt and IKiv are also written to the sealed key object metadata.

Unsealing with a PIN looks like this:
- The supplied PIN and a salt are passed through Argon2i to create a
derived key (DK).
- The TPM unseals DEKenc if the PCR values match the PCR policy and the
upper 32-bits of DK match the authorization value of the sealed key
object.
- The lower 32-bits of DK are used along with IKiv to decrypt IKenc in
order to recover IK.
- DEKiv and IK are used to decrypt DEKenc to recover DEK.

This scheme retains the property that low-entropy PINs provide some
protection of data against most determined attackers, because it still
relies on the TPM asserting knowledge of the correct PIN before unsealing
the encrypted DEK, and this benefits from the TPM's dictionary attack
protection.

This scheme should be more suitable for incorporating a network unlock
feature in the future, where IK and the the TPM auth value can be
protected with the public key of a trusted device on the local network.