### PR TITLE
Reimplement the support for LockAccessToSealedKeys to reduce fragility

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	lockNVHandle     tpm2.Handle = 0x01801100 // Global NV handle for locking access to sealed key objects
-	lockNVDataHandle tpm2.Handle = 0x01801101 // NV index containing policy data for lockNVHandle
+	lockNVHandle1 tpm2.Handle = 0x01801100 // First global NV handle for locking access to sealed key objects
+	lockNVHandle2 tpm2.Handle = 0x01801101 // Second global NV handle for locking access to sealed key objects
 
 	// SHA-256 is mandatory to exist on every PC-Client TPM
 	// XXX: Maybe dynamically select algorithms based on what's available on the device?

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -235,48 +235,41 @@ func (ctb *cryptTestBase) checkRecoveryKeyKeyringEntry(c *C, reason RecoveryKeyU
 	c.Check(buf, DeepEquals, ctb.recoveryKey)
 }
 
-type cryptTPMTestBase struct {
+type cryptTPMSimulatorSuite struct {
+	testutil.TPMSimulatorTestBase
 	cryptTestBase
 
 	keyFile string
 }
 
-func (ctb *cryptTPMTestBase) setUpTestBase(c *C, ttb *testutil.TPMTestBase) {
-	ctb.cryptTestBase.setUpTestBase(c, &ttb.BaseTest)
+var _ = Suite(&cryptTPMSimulatorSuite{})
 
-	c.Assert(ProvisionTPM(ttb.TPM, ProvisionModeFull, nil), IsNil)
+func (s *cryptTPMSimulatorSuite) SetUpSuite(c *C) {
+	s.cryptTestBase.setUpSuiteBase(c)
+}
+
+func (s *cryptTPMSimulatorSuite) SetUpTest(c *C) {
+	s.TPMSimulatorTestBase.SetUpTest(c)
+	s.cryptTestBase.setUpTestBase(c, &s.BaseTest)
+
+	c.Assert(ProvisionTPM(s.TPM, ProvisionModeFull, nil), IsNil)
+	s.ResetTPMSimulator(c)
 
 	dir := c.MkDir()
-	ctb.keyFile = dir + "/keydata"
+	s.keyFile = dir + "/keydata"
 
 	pcrPolicyCounterHandle := tpm2.Handle(0x0181fff0)
-	c.Assert(SealKeyToTPM(ttb.TPM, ctb.tpmKey, ctb.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: pcrPolicyCounterHandle}), IsNil)
-	pinIndex, err := ttb.TPM.CreateResourceContextFromTPM(pcrPolicyCounterHandle)
+	c.Assert(SealKeyToTPM(s.TPM, s.tpmKey, s.keyFile, "", &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: pcrPolicyCounterHandle}), IsNil)
+	pinIndex, err := s.TPM.CreateResourceContextFromTPM(pcrPolicyCounterHandle)
 	c.Assert(err, IsNil)
-	ttb.AddCleanupNVSpace(c, ttb.TPM.OwnerHandleContext(), pinIndex)
+	s.AddCleanupNVSpace(c, s.TPM.OwnerHandleContext(), pinIndex)
 
-	c.Assert(ioutil.WriteFile(ctb.expectedTpmKeyFile, ctb.tpmKey, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(s.expectedTpmKeyFile, s.tpmKey, 0644), IsNil)
 
 	// Some tests may increment the DA lockout counter
-	ttb.AddCleanup(func() {
-		c.Check(ttb.TPM.DictionaryAttackLockReset(ttb.TPM.LockoutHandleContext(), nil), IsNil)
+	s.AddCleanup(func() {
+		c.Check(s.TPM.DictionaryAttackLockReset(s.TPM.LockoutHandleContext(), nil), IsNil)
 	})
-}
-
-type cryptTPMSuite struct {
-	testutil.TPMTestBase
-	cryptTPMTestBase
-}
-
-var _ = Suite(&cryptTPMSuite{})
-
-func (s *cryptTPMSuite) SetUpSuite(c *C) {
-	s.cryptTPMTestBase.setUpSuiteBase(c)
-}
-
-func (s *cryptTPMSuite) SetUpTest(c *C) {
-	s.TPMTestBase.SetUpTest(c)
-	s.cryptTPMTestBase.setUpTestBase(c, &s.TPMTestBase)
 }
 
 type testActivateVolumeWithTPMSealedKeyNo2FAData struct {
@@ -287,7 +280,7 @@ type testActivateVolumeWithTPMSealedKeyNo2FAData struct {
 	activateOptions  []string
 }
 
-func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyNo2FA(c *C, data *testActivateVolumeWithTPMSealedKeyNo2FAData) {
+func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyNo2FA(c *C, data *testActivateVolumeWithTPMSealedKeyNo2FAData) {
 	options := ActivateWithTPMSealedKeyOptions{PINTries: data.pinTries, RecoveryKeyTries: data.recoveryKeyTries, ActivateOptions: data.activateOptions}
 	success, err := ActivateVolumeWithTPMSealedKey(s.TPM, data.volumeName, data.sourceDevicePath, s.keyFile, nil, &options)
 	c.Check(success, Equals, true)
@@ -302,14 +295,14 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyNo2FA(c *C, data *test
 	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, strings.Join(append(data.activateOptions, "tries=1"), ","))
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA1(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyNo2FA1(c *C) {
 	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
 		volumeName:       "data",
 		sourceDevicePath: "/dev/sda1",
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA2(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyNo2FA2(c *C) {
 	// Test with a non-zero PINTries when a PIN isn't set.
 	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
 		volumeName:       "data",
@@ -318,7 +311,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA2(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA3(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyNo2FA3(c *C) {
 	// Test with a non-zero RecoveryKeyTries.
 	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
 		volumeName:       "data",
@@ -327,7 +320,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA3(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA4(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyNo2FA4(c *C) {
 	// Test with extra options for systemd-cryptsetup.
 	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
 		volumeName:       "data",
@@ -336,7 +329,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA4(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA5(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyNo2FA5(c *C) {
 	// Test with a different volume name / device path.
 	s.testActivateVolumeWithTPMSealedKeyNo2FA(c, &testActivateVolumeWithTPMSealedKeyNo2FAData{
 		volumeName:       "foo",
@@ -344,7 +337,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA5(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyNo2FA6(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyNo2FA6(c *C) {
 	// Test that ActivateVolumeWithTPMSealedKey creates a SRK when it can, rather than fallback back to the recovery key.
 	srk, err := s.TPM.CreateResourceContextFromTPM(tcg.SRKHandle)
 	c.Assert(err, IsNil)
@@ -362,7 +355,7 @@ type testActivateVolumeWithTPMSealedKeyAndPINData struct {
 	pinTries int
 }
 
-func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPIN(c *C, data *testActivateVolumeWithTPMSealedKeyAndPINData) {
+func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyAndPIN(c *C, data *testActivateVolumeWithTPMSealedKeyAndPINData) {
 	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.pins, "\n")+"\n"), 0644), IsNil)
 
 	options := ActivateWithTPMSealedKeyOptions{PINTries: data.pinTries}
@@ -384,7 +377,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPIN(c *C, data *tes
 	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
 	// Test with a single PIN attempt.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -394,7 +387,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPIN2(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPIN2(c *C) {
 	// Test with 2 PIN attempts.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -410,7 +403,7 @@ type testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData struct {
 	pinTries        int
 }
 
-func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c *C, data *testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData) {
+func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c *C, data *testActivateVolumeWithTPMSealedKeyAndPINUsingPINReaderData) {
 	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.pins, "\n")+"\n"), 0644), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(s.dir, "pinfile"), []byte(data.pinFileContents), 0644), IsNil)
 
@@ -437,7 +430,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyAndPINUsingPINReader(c
 	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(c *C) {
 	// Test with the correct PIN provided via the io.Reader.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -448,7 +441,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader2(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader2(c *C) {
 	// Test with the correct PIN provided via the io.Reader when the file doesn't end in a newline.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -459,7 +452,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader2(
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader3(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader3(c *C) {
 	// Test falling back to asking for a PIN if the wrong PIN is provided via the io.Reader.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -471,7 +464,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader3(
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader4(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader4(c *C) {
 	// Test falling back to asking for a PIN without using a try if the io.Reader has no contents.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -494,7 +487,7 @@ type testActivateVolumeWithTPMSealedKeyErrorHandlingData struct {
 	errCheckerArgs    []interface{}
 }
 
-func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, data *testActivateVolumeWithTPMSealedKeyErrorHandlingData) {
+func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, data *testActivateVolumeWithTPMSealedKeyErrorHandlingData) {
 	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.passphrases, "\n")+"\n"), 0644), IsNil)
 
 	options := ActivateWithTPMSealedKeyOptions{PINTries: data.pinTries, RecoveryKeyTries: data.recoveryKeyTries, ActivateOptions: data.activateOptions}
@@ -527,7 +520,7 @@ func (s *cryptTPMSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, da
 	s.checkRecoveryKeyKeyringEntry(c, data.recoveryReason)
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
 	// Test with an invalid value for PINTries.
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
 		pinTries:       -1,
@@ -536,7 +529,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling2(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling2(c *C) {
 	// Test with an invalid value for RecoveryKeyTries.
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
 		recoveryKeyTries: -1,
@@ -545,7 +538,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling2(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling3(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling3(c *C) {
 	// Test that adding "tries=" to ActivateOptions fails.
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
 		activateOptions: []string{"tries=2"},
@@ -554,7 +547,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling3(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
 	// Test that recovery fallback works with the TPM in DA lockout mode.
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	defer func() {
@@ -573,7 +566,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling4(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
 	// Test that recovery fallback works when there is no SRK and a new one can't be created.
 	srk, err := s.TPM.CreateResourceContextFromTPM(tcg.SRKHandle)
 	c.Assert(err, IsNil)
@@ -598,7 +591,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling5(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
 	// Test that recovery fallback works when the unsealed key is incorrect.
 	incorrectKey := make([]byte, 32)
 	rand.Read(incorrectKey)
@@ -616,7 +609,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling6(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling7(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling7(c *C) {
 	// Test that activation fails if RecoveryKeyTries is zero.
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	defer func() {
@@ -631,7 +624,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling7(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
 	// Test that activation fails if the wrong recovery key is provided.
 	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	defer func() {
@@ -649,7 +642,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling8(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 	// Test that recovery fallback works if the wrong PIN is supplied.
 	testPIN := "1234"
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", testPIN), IsNil)
@@ -669,7 +662,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling9(c *C) {
 	})
 }
 
-func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling10(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling10(c *C) {
 	// Test that recovery fallback works if a PIN is set but no PIN attempts are permitted.
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
@@ -684,53 +677,7 @@ func (s *cryptTPMSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling10(c *C) 
 	})
 }
 
-type cryptTPMSimulatorSuite struct {
-	testutil.TPMSimulatorTestBase
-	cryptTPMTestBase
-}
-
-var _ = Suite(&cryptTPMSimulatorSuite{})
-
-func (s *cryptTPMSimulatorSuite) SetUpSuite(c *C) {
-	s.cryptTPMTestBase.setUpSuiteBase(c)
-}
-
-func (s *cryptTPMSimulatorSuite) SetUpTest(c *C) {
-	s.TPMSimulatorTestBase.SetUpTest(c)
-	s.ResetTPMSimulator(c)
-	s.cryptTPMTestBase.setUpTestBase(c, &s.TPMTestBase)
-}
-
-func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, data *testActivateVolumeWithTPMSealedKeyErrorHandlingData) {
-	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(strings.Join(data.passphrases, "\n")+"\n"), 0644), IsNil)
-
-	options := ActivateWithTPMSealedKeyOptions{PINTries: data.pinTries, RecoveryKeyTries: data.recoveryKeyTries, ActivateOptions: data.activateOptions}
-	success, err := ActivateVolumeWithTPMSealedKey(s.TPM, "data", "/dev/sda1", s.keyFile, nil, &options)
-	c.Check(err, data.errChecker, data.errCheckerArgs...)
-	c.Check(success, Equals, data.success)
-
-	c.Check(len(s.mockSdAskPassword.Calls()), Equals, len(data.passphrases))
-	for _, call := range s.mockSdAskPassword.Calls() {
-		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
-			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the recovery key for disk /dev/sda1:"})
-	}
-	c.Check(len(s.mockSdCryptsetup.Calls()), Equals, data.sdCryptsetupCalls)
-	for _, call := range s.mockSdCryptsetup.Calls() {
-		c.Assert(len(call), Equals, 6)
-		c.Check(call[0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", "data", "/dev/sda1"})
-		c.Check(call[4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-		c.Check(call[5], Equals, strings.Join(append(data.activateOptions, "tries=1"), ","))
-	}
-
-	if !data.success {
-		return
-	}
-
-	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyKeyringEntry(c, data.recoveryReason)
-}
-
-func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling1(c *C) {
+func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling11(c *C) {
 	// Test that recovery fallback works when the sealed key authorization policy is wrong.
 	_, err := s.TPM.PCREvent(s.TPM.PCRHandleContext(7), []byte("foo"), nil)
 	c.Assert(err, IsNil)

--- a/export_test.go
+++ b/export_test.go
@@ -42,7 +42,7 @@ const (
 var (
 	ComputeDbUpdate                          = computeDbUpdate
 	ComputeDynamicPolicy                     = computeDynamicPolicy
-	ComputeLockNVIndexPublicAreas            = computeLockNVIndexPublicAreas
+	ComputeLockNVIndexTemplates              = computeLockNVIndexTemplates
 	CreatePcrPolicyCounter                   = createPcrPolicyCounter
 	ComputePcrPolicyCounterAuthPolicies      = computePcrPolicyCounterAuthPolicies
 	ComputePcrPolicyRefFromCounterContext    = computePcrPolicyRefFromCounterContext

--- a/export_test.go
+++ b/export_test.go
@@ -33,8 +33,8 @@ import (
 // Export constants for testing
 const (
 	CurrentMetadataVersion                = currentMetadataVersion
-	LockNVDataHandle                      = lockNVDataHandle
-	LockNVHandle                          = lockNVHandle
+	LockNVHandle1                         = lockNVHandle1
+	LockNVHandle2                         = lockNVHandle2
 	SigDbUpdateQuirkModeNone              = sigDbUpdateQuirkModeNone
 	SigDbUpdateQuirkModeDedupIgnoresOwner = sigDbUpdateQuirkModeDedupIgnoresOwner
 )
@@ -56,17 +56,17 @@ var (
 	DecodeWinCertificate                     = decodeWinCertificate
 	EFICertTypePkcs7Guid                     = efiCertTypePkcs7Guid
 	EFICertX509Guid                          = efiCertX509Guid
-	EnsureLockNVIndex                        = ensureLockNVIndex
+	EnsureLockNVIndices                      = ensureLockNVIndices
 	ExecutePolicySession                     = executePolicySession
 	IdentifyInitialOSLaunchVerificationEvent = identifyInitialOSLaunchVerificationEvent
 	IncrementPcrPolicyCounter                = incrementPcrPolicyCounter
 	IsDynamicPolicyDataError                 = isDynamicPolicyDataError
 	IsStaticPolicyDataError                  = isStaticPolicyDataError
-	LockNVIndexAttrs                         = lockNVIndexAttrs
+	LockNVIndex1Attrs                        = lockNVIndex1Attrs
 	PerformPinChange                         = performPinChange
-	ReadAndValidateLockNVIndexPublic         = readAndValidateLockNVIndexPublic
 	ReadPcrPolicyCounter                     = readPcrPolicyCounter
 	ReadShimVendorCert                       = readShimVendorCert
+	ValidateLockNVIndices                    = validateLockNVIndices
 	WinCertTypePKCSSignedData                = winCertTypePKCSSignedData
 	WinCertTypeEfiGuid                       = winCertTypeEfiGuid
 )
@@ -237,8 +237,8 @@ func NewDynamicPolicyComputeParams(key *ecdsa.PrivateKey, signAlg tpm2.HashAlgor
 		policyCount:       policyCount}
 }
 
-func NewStaticPolicyComputeParams(key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, lockIndexName tpm2.Name) *staticPolicyComputeParams {
-	return &staticPolicyComputeParams{key: key, pcrPolicyCounterPub: pcrPolicyCounterPub, lockIndexName: lockIndexName}
+func NewStaticPolicyComputeParams(key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, legacyLockIndexName tpm2.Name) *staticPolicyComputeParams {
+	return &staticPolicyComputeParams{key: key, pcrPolicyCounterPub: pcrPolicyCounterPub, legacyLockIndexName: legacyLockIndexName}
 }
 
 func (p *PCRProtectionProfile) ComputePCRDigests(tpm *tpm2.TPMContext, alg tpm2.HashAlgorithmId) (tpm2.PCRSelectionList, tpm2.DigestList, error) {

--- a/export_test.go
+++ b/export_test.go
@@ -42,6 +42,7 @@ const (
 var (
 	ComputeDbUpdate                          = computeDbUpdate
 	ComputeDynamicPolicy                     = computeDynamicPolicy
+	ComputeLockNVIndexPublicAreas            = computeLockNVIndexPublicAreas
 	CreatePcrPolicyCounter                   = createPcrPolicyCounter
 	ComputePcrPolicyCounterAuthPolicies      = computePcrPolicyCounterAuthPolicies
 	ComputePcrPolicyRefFromCounterContext    = computePcrPolicyRefFromCounterContext

--- a/internal/compattest/v0_test.go
+++ b/internal/compattest/v0_test.go
@@ -21,7 +21,12 @@ package compattest
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/binary"
 	"fmt"
+	"math/big"
+	"math/rand"
 
 	"github.com/canonical/go-tpm2"
 	"github.com/snapcore/secboot"
@@ -40,12 +45,160 @@ func (s *compatTestV0Suite) SetUpSuite(c *C) {
 
 var _ = Suite(&compatTestV0Suite{})
 
+func (s *compatTestV0Suite) TestSealKeyToTPM(c *C) {
+	// Verify that we can seal a new key on a TPM provisioned with a legacy style lock NV index
+	key := make([]byte, 64)
+	rand.Read(key)
+	profile := secboot.NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7)
+	c.Check(secboot.SealKeyToTPM(s.TPM, key, c.MkDir()+"/key", "", &secboot.KeyCreationParams{PCRProfile: profile, PCRPolicyCounterHandle: 0x01810001}), IsNil)
+	// TODO: Validate the key file when we have an API for this
+}
+
+func (s *compatTestV0Suite) testSealKeyToTPMWithLockIndexProvisionError(c *C) {
+	key := make([]byte, 64)
+	rand.Read(key)
+	profile := secboot.NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7)
+	c.Check(secboot.SealKeyToTPM(s.TPM, key, c.MkDir()+"/key", "", &secboot.KeyCreationParams{PCRProfile: profile, PCRPolicyCounterHandle: 0x01810001}), ErrorMatches, "the TPM is not correctly provisioned")
+}
+
+func (s *compatTestV0Suite) TestSealKeyToTPMWithLockIndexProvisionError1(c *C) {
+	// Verify that undefining the lock data NV index is detected as a provisioning error
+	index, err := s.TPM.CreateResourceContextFromTPM(0x01801101)
+	c.Assert(err, IsNil)
+	c.Assert(s.TPM.NVUndefineSpace(s.TPM.OwnerHandleContext(), index, nil), IsNil)
+	s.testSealKeyToTPMWithLockIndexProvisionError(c)
+}
+
+func (s *compatTestV0Suite) TestSealKeyToTPMWithLockIndexProvisionError2(c *C) {
+	// Verify that a legacy lock data NV index containing a time in the future is detected as a provisioning error
+	index, err := s.TPM.CreateResourceContextFromTPM(0x01801101)
+	c.Assert(err, IsNil)
+	pub, _, err := s.TPM.NVReadPublic(index)
+	c.Assert(err, IsNil)
+	data, err := s.TPM.NVRead(index, index, pub.Size, 0, nil)
+	c.Assert(err, IsNil)
+
+	var version uint8
+	var keyName tpm2.Name
+	var clock uint64
+	_, err = tpm2.UnmarshalFromBytes(data, &version, &keyName, &clock)
+	c.Assert(err, IsNil)
+
+	time, err := s.TPM.ReadClock()
+	c.Assert(err, IsNil)
+
+	data, err = tpm2.MarshalToBytes(version, keyName, time.ClockInfo.Clock+3600000)
+	c.Assert(err, IsNil)
+	c.Assert(s.TPM.NVUndefineSpace(s.TPM.OwnerHandleContext(), index, nil), IsNil)
+	pub = &tpm2.NVPublic{
+		Index:   0x01801101,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
+		Size:    uint16(len(data))}
+	index, err = s.TPM.NVDefineSpace(s.TPM.OwnerHandleContext(), nil, pub, nil)
+	c.Assert(err, IsNil)
+	c.Assert(s.TPM.NVWrite(index, index, data, 0, nil), IsNil)
+
+	s.testSealKeyToTPMWithLockIndexProvisionError(c)
+}
+
+func fillBytes(x *big.Int, buf []byte) []byte {
+	for i := range buf {
+		buf[i] = 0
+	}
+	b := x.Bytes()
+	copy(buf[len(buf)-len(b):], b)
+	return buf
+}
+
+func (s *compatTestV0Suite) TestSealKeyToTPMWithLockIndexProvisionError3(c *C) {
+	// Verify that a legacy lock index that has a policy that allows it to be recreated at this point in time and doesn't match the
+	// corresponding data index is detected as a provisioning error.
+	key, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
+	c.Assert(err, IsNil)
+	keyPub := tpm2.Public{
+		Type:    tpm2.ObjectTypeECC,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.AttrSensitiveDataOrigin | tpm2.AttrUserWithAuth | tpm2.AttrSign,
+		Params: tpm2.PublicParamsU{
+			Data: &tpm2.ECCParams{
+				Symmetric: tpm2.SymDefObject{Algorithm: tpm2.SymObjectAlgorithmNull},
+				Scheme: tpm2.ECCScheme{
+					Scheme:  tpm2.ECCSchemeECDSA,
+					Details: tpm2.AsymSchemeU{Data: &tpm2.SigSchemeECDSA{HashAlg: tpm2.HashAlgorithmSHA256}}},
+				CurveID: tpm2.ECCCurveNIST_P256,
+				KDF:     tpm2.KDFScheme{Scheme: tpm2.KDFAlgorithmNull}}},
+		Unique: tpm2.PublicIDU{
+			Data: &tpm2.ECCPoint{
+				X: fillBytes(key.X, make([]byte, key.Params().BitSize/8)),
+				Y: fillBytes(key.Y, make([]byte, key.Params().BitSize/8))}}}
+	keyName, err := keyPub.Name()
+	c.Assert(err, IsNil)
+
+	time, err := s.TPM.ReadClock()
+	c.Assert(err, IsNil)
+	time.ClockInfo.Clock += 5000
+	clockBytes := make(tpm2.Operand, binary.Size(time.ClockInfo.Clock))
+	binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock+3600000000)
+
+	trial, _ := tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	trial.PolicyCommandCode(tpm2.CommandNVWrite)
+	trial.PolicyCounterTimer(clockBytes, 8, tpm2.OpUnsignedLT)
+	trial.PolicySigned(keyName, nil)
+
+	pub := tpm2.NVPublic{
+		Index:      0x01801100,
+		NameAlg:    tpm2.HashAlgorithmSHA256,
+		Attrs:      tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVReadStClear),
+		AuthPolicy: trial.GetDigest(),
+		Size:       0}
+
+	index, err := s.TPM.CreateResourceContextFromTPM(0x01801100)
+	c.Assert(err, IsNil)
+	c.Assert(s.TPM.NVUndefineSpace(s.TPM.OwnerHandleContext(), index, nil), IsNil)
+	index, err = s.TPM.NVDefineSpace(s.TPM.OwnerHandleContext(), nil, &pub, nil)
+	c.Assert(err, IsNil)
+	policySession, err := s.TPM.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)
+	c.Assert(err, IsNil)
+	defer s.TPM.FlushContext(policySession)
+
+	h := tpm2.HashAlgorithmSHA256.NewHash()
+	h.Write(policySession.NonceTPM())
+	binary.Write(h, binary.BigEndian, int32(0))
+	sigR, sigS, err := ecdsa.Sign(testutil.RandReader, key, h.Sum(nil))
+	c.Assert(err, IsNil)
+	signature := tpm2.Signature{
+		SigAlg: tpm2.SigSchemeAlgECDSA,
+		Signature: tpm2.SignatureU{
+			Data: &tpm2.SignatureECDSA{
+				Hash:       tpm2.HashAlgorithmSHA256,
+				SignatureR: sigR.Bytes(),
+				SignatureS: sigS.Bytes()}}}
+
+	keyLoaded, err := s.TPM.LoadExternal(nil, &keyPub, tpm2.HandleEndorsement)
+	c.Assert(err, IsNil)
+	defer s.TPM.FlushContext(keyLoaded)
+	c.Assert(s.TPM.PolicyCommandCode(policySession, tpm2.CommandNVWrite), IsNil)
+	c.Assert(s.TPM.PolicyCounterTimer(policySession, clockBytes, 8, tpm2.OpUnsignedLT), IsNil)
+	_, _, err = s.TPM.PolicySigned(keyLoaded, policySession, true, nil, nil, 0, &signature)
+	c.Assert(err, IsNil)
+	c.Assert(s.TPM.NVWrite(index, index, nil, 0, policySession), IsNil)
+
+	s.testSealKeyToTPMWithLockIndexProvisionError(c)
+}
+
 func (s *compatTestV0Suite) TestUnseal1(c *C) {
 	s.testUnseal(c, s.absPath("pcrSequence.1"))
 }
 
 func (s *compatTestV0Suite) TestUnseal2(c *C) {
 	s.testUnseal(c, s.absPath("pcrSequence.2"))
+}
+
+func (s *compatTestV0Suite) TestUnsealAfterReprovision(c *C) {
+	// Test that reprovisioning doesn't touch the legacy lock NV index if it is valid
+	c.Assert(secboot.ProvisionTPM(s.TPM, secboot.ProvisionModeWithoutLockout, nil), IsNil)
+	s.testUnseal(c, s.absPath("pcrSequence.1"))
 }
 
 func (s *compatTestV0Suite) TestUnsealWithPIN1(c *C) {
@@ -82,6 +235,16 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAndUnseal(c *C) {
 	fmt.Fprintf(&b, "12 11 %x\n", testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
 	s.testUpdateKeyPCRProtectionPolicyAndUnseal(c, profile, &b)
+}
+
+func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAfterLock(c *C) {
+	c.Assert(secboot.LockAccessToSealedKeys(s.TPM), IsNil)
+
+	profile := secboot.NewPCRProtectionProfile()
+	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
+	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
+
+	s.testUpdateKeyPCRProtectionPolicy(c, profile)
 }
 
 func (s *compatTestV0Suite) TestUnsealAfterLock(c *C) {

--- a/pin_test.go
+++ b/pin_test.go
@@ -90,7 +90,7 @@ func TestPerformPinChange(t *testing.T) {
 }
 
 type pinSuite struct {
-	testutil.TPMTestBase
+	testutil.TPMSimulatorTestBase
 	key                    []byte
 	pcrPolicyCounterHandle tpm2.Handle
 	keyFile                string
@@ -105,8 +105,9 @@ func (s *pinSuite) SetUpSuite(c *C) {
 }
 
 func (s *pinSuite) SetUpTest(c *C) {
-	s.TPMTestBase.SetUpTest(c)
+	s.TPMSimulatorTestBase.SetUpTest(c)
 	c.Assert(ProvisionTPM(s.TPM, ProvisionModeFull, nil), IsNil)
+	s.ResetTPMSimulator(c)
 
 	dir := c.MkDir()
 	s.keyFile = dir + "/keydata"

--- a/policy.go
+++ b/policy.go
@@ -510,7 +510,7 @@ func computeLockNVIndexNames() (tpm2.Name, tpm2.Name, error) {
 // Authorization policies for sealed keys must assert the presence of both of these NV indices using the names of the initialized
 // indices without the read lock enabled. Enabling the read lock on index 1 by calling LockAccessToSealedKeys will disable access to
 // these keys.
-// 
+//
 // It isn't possible to recreate these indices in their unlocked state. Although they can be recovered if they are undefined
 // accidentally, they will not return to their unlocked state until the next TPM reset or restart.
 //

--- a/policy.go
+++ b/policy.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/binary"
@@ -35,14 +34,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const (
-	lockNVIndexVersion   uint8 = 0    // Policy data version for lockNVHandle, to support backwards compatible changes
-	lockNVIndexGraceTime       = 5000 // Time window in milliseconds in which lockNVHandle can be initialized after creation
-)
-
 var (
-	// lockNVIndexAttrs are the attributes for the global lock NV index.
-	lockNVIndexAttrs = tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVReadStClear)
+	// lockNVIndex1Attrs are the attributes for the first global lock NV index.
+	lockNVIndex1Attrs = tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVReadStClear)
 )
 
 // dynamicPolicyComputeParams provides the parameters to computeDynamicPolicy.
@@ -108,7 +102,7 @@ func makeDynamicPolicyDataRaw_v0(data *dynamicPolicyData) *dynamicPolicyDataRaw_
 type staticPolicyComputeParams struct {
 	key                 *tpm2.Public   // Public part of key used to authorize a dynamic authorization policy
 	pcrPolicyCounterPub *tpm2.NVPublic // Public area of the NV counter used for revoking PCR policies
-	lockIndexName       tpm2.Name      // Name of the global NV index for locking access to sealed key objects
+	legacyLockIndexName tpm2.Name      // Name of the legacy global NV index for locking access to sealed key objects
 }
 
 // staticPolicyData is an output of computeStaticPolicy and provides metadata for executing a policy session.
@@ -399,218 +393,252 @@ func createPcrPolicyCounter(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKeyN
 	return public, nil
 }
 
-// ensureLockNVIndex creates a NV index at lockNVHandle if one doesn't exist already. This is used for locking access to any sealed
-// key objects we create until the next TPM restart or reset. The same handle is used for all keys, regardless of individual key
-// policy.
-//
-// Locking works by enabling the read lock bit for the NV index. As this changes the name of the index until the next TPM reset or
-// restart, it makes any authorization policy that depends on it un-satisfiable. We do this rather than extending an extra value to a
-// PCR, as it decouples the PCR policy from the locking feature and allows for the option of having more flexible, owner-customizable
-// and maybe device-specific PCR policies in the future.
-//
-// To prevent someone with knowledge of the owner authorization (which is empty unless someone has taken ownership of the TPM) from
-// clearing the read lock bit by just undefining and redifining a new NV index with the same properties, we need a way to prevent
-// someone from being able to create an identical index. One option for this would be to use a NV counter, which has the property
-// that they can only increment and are initialized with a value larger than the largest count value seen on the TPM. Whilst it
-// would be possible to recreate a counter with the same name, it wouldn't be possible to recreate one with the same value. Keys
-// sealed by this package can then execute an assertion that the counter is equal to a certain value. One problem with this is that
-// the current value needs to be known at key sealing time (as it forms part of the authorization policy), and the read lock bit will
-// prevent the count value from being read from the TPM. Also, the number of counters available is extremely limited, and we already
-// use one per sealed key.
-//
-// Another approach is to use an ordinary NV index that can't be recreated with the same name. To do this, we require the NV index
-// to have been written to and only allow writes with a signed authorization policy. Once initialized, the signing key is discarded.
-// This works because the name of the signing key is included in the authorization policy digest for the NV index, and the
-// authorization policy digest and attributes are included in the name of the NV index. Without the private part of the signing key,
-// it is impossible to create a new NV index with the same name, and so, if this NV index is undefined then it becomes impossible to
-// satisfy the authorization policy for any sealed key objects we've created already.
-//
-// The issue here though is that the globally defined NV index is created at provisioning time, and it may be possible to seal a new
-// key to the TPM at any point in the future without provisioning a new global NV index here. In the time between provisioning and
-// sealing a key to the TPM, an adversary may have created a new NV index with a policy that only allows writes with a signed
-// authorization, initialized it, but then retained the private part of the key. This allows them to undefine and redefine a new NV
-// index with the same name in the future in order to remove the read lock bit. To mitigate this, we include another assertion in
-// the authorization policy that only allows writes during a small time window (sufficient to initialize the index after it is
-// created), and disallows writes once the TPM's clock has advanced past that window. As the parameters of this assertion are
-// included in the authorization policy digest, it becomes impossible even for someone with the private part of the key to create
-// and initialize a NV index with the same name once the TPM's clock has advanced past that point, without performing a clear of the
-// TPM. Clearing the TPM changes the SPS anyway, and makes it impossible to recover any keys previously sealed.
-//
-// The signing key name and the time window during which the index can be initialized are recorded in another NV index so that it is
-// possible to use those to determine whether the lock NV index has an authorization policy that can never be satisfied, in order to
-// verify that the index can not be recreated and is therefore safe to use.
-func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error {
-	if existing, err := tpm.CreateResourceContextFromTPM(lockNVHandle); err == nil {
-		if _, err := readAndValidateLockNVIndexPublic(tpm, existing, session); err == nil {
-			return nil
-		}
-	}
-
-	// Create signing key.
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+// computeLockNVIndexPublicAreas computes the public areas used to define the NV indices used for locking access to sealed keys. It
+// returns 3 public areas - the first one is for a bootstrap index, which is required to initialize the first index. See the
+// description of ensureLockNVIndices to see the sequence for initializing these indices.
+func computeLockNVIndexPublicAreas() (bootstrap *tpm2.NVPublic, index1 *tpm2.NVPublic, index2 *tpm2.NVPublic, err error) {
+	bootstrap = &tpm2.NVPublic{
+		Index:   lockNVHandle2,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
+		Size:    0}
+	bootstrap.Attrs |= tpm2.AttrNVWritten
+	bootstrapName, err := bootstrap.Name()
 	if err != nil {
-		return xerrors.Errorf("cannot create signing key for initializing NV index: %w", err)
+		return nil, nil, nil, xerrors.Errorf("cannot compute name of bootstrap index: %w", err)
 	}
+	bootstrap.Attrs &^= tpm2.AttrNVWritten
 
-	keyPublic := createPublicAreaForECDSAKey(&key.PublicKey)
-	keyName, err := keyPublic.Name()
-	if err != nil {
-		return xerrors.Errorf("cannot compute name of signing key for initializing NV index: %w", err)
-	}
+	trial, _ := tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	trial.PolicySecret(bootstrapName, nil)
 
-	// Read the TPM clock (no session here because some Infineon devices don't allow them, despite being permitted in the spec
-	// and reference implementation)
-	time, err := tpm.ReadClock()
-	if err != nil {
-		return xerrors.Errorf("cannot read current time: %w", err)
-	}
-	// Give us a small window in which to initialize the index, beyond which the index cannot be written to without a change in TPM owner.
-	time.ClockInfo.Clock += lockNVIndexGraceTime
-	clockBytes := make(tpm2.Operand, binary.Size(time.ClockInfo.Clock))
-	binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock)
-
-	nameAlg := tpm2.HashAlgorithmSHA256
-
-	// Compute the authorization policy.
-	trial, _ := tpm2.ComputeAuthPolicy(nameAlg)
-	trial.PolicyCommandCode(tpm2.CommandNVWrite)
-	trial.PolicyCounterTimer(clockBytes, 8, tpm2.OpUnsignedLT)
-	trial.PolicySigned(keyName, nil)
-
-	// Create the index.
-	public := &tpm2.NVPublic{
-		Index:      lockNVHandle,
-		NameAlg:    nameAlg,
-		Attrs:      lockNVIndexAttrs,
+	index1 = &tpm2.NVPublic{
+		Index:      lockNVHandle1,
+		NameAlg:    tpm2.HashAlgorithmSHA256,
+		Attrs:      lockNVIndex1Attrs,
 		AuthPolicy: trial.GetDigest(),
 		Size:       0}
-	index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, public, session)
+	index1.Attrs |= tpm2.AttrNVReadLocked | tpm2.AttrNVWritten
+	index1LockedName, err := index1.Name()
 	if err != nil {
-		var e *tpm2.TPMError
-		if tpm2.AsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace, &e) {
-			return &tpmErrorWithHandle{err: e, handle: public.Index}
+		return nil, nil, nil, xerrors.Errorf("cannot compute name of index 1: %w", err)
+	}
+	index1.Attrs &^= tpm2.AttrNVReadLocked | tpm2.AttrNVWritten
+
+	trial, _ = tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	trial.PolicySecret(index1LockedName, nil)
+
+	index2 = &tpm2.NVPublic{
+		Index:      lockNVHandle2,
+		NameAlg:    tpm2.HashAlgorithmSHA256,
+		Attrs:      tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
+		AuthPolicy: trial.GetDigest(),
+		Size:       0}
+
+	return
+}
+
+// computeLockNVIndexNames computes the names of the 2 NV indices at well-known locations that are used for locking access to
+// sealed keys. These names are not unique, and the presence of indices with these names should be asserted in any authorization
+// policy that wants to benefit from locking.
+func computeLockNVIndexNames() (tpm2.Name, tpm2.Name, error) {
+	_, index1, index2, err := computeLockNVIndexPublicAreas()
+	if err != nil {
+		return nil, nil, xerrors.Errorf("cannot compute public areas for indices: %w", err)
+	}
+
+	index1.Attrs |= tpm2.AttrNVWritten
+	index2.Attrs |= tpm2.AttrNVWritten
+
+	index1Name, err := index1.Name()
+	if err != nil {
+		return nil, nil, xerrors.Errorf("cannot compute name of index 1: %w", err)
+	}
+	index2Name, err := index2.Name()
+	if err != nil {
+		return nil, nil, xerrors.Errorf("cannot compute name of index 2: %w", err)
+	}
+
+	return index1Name, index2Name, nil
+}
+
+// ensureLockNVIndices creates a pair of NV indices at well known handles for locking access to sealed keys with
+// LockAccessToSealedKeys if they don't exist already, and the TPM doesn't contain a valid legacy lock NV index.
+//
+// These indices are used for locking access to any sealed key objects we create until the next TPM restart or reset. The same
+// handles are used for all keys, regardless of individual key policy.
+//
+// The traditional way of achieving this is by extending another value to a PCR that is included in the PCR selection for a
+// sealed key's authorization policy after the key has been unsealed, which makes its authorization policy non-satisfiable until
+// the next reset or restart. The issue with this is that it makes the feature dependent on the PCR profile.
+//
+// The implementation here uses a pair of NV indices at well known handles and takes advantage of a couple of properties of NV
+// index read locks:
+// - Once enabled, they can only be disabled by a TPM reset or restart.
+// - Enabling a read lock sets the index's TPMA_NV_READLOCKED attribute which changes its name.
+// Sealed keys created by this package have an authorization policy that asserts that these NV indices exists at their well known
+// handles. Calling LockAccessToSealedKeys enables the read lock for one of them, which changes its name and makes this assertion
+// fail.
+//
+// The problem with this approach though is that the TPM owner (ie, anyone who knows the authorization value for the storage hierarchy,
+// which is empty by default) can undefine and redefine a NV index in order to clear the read lock attribute, thus re-enabling access
+// to sealed keys. One approach to prevent this from happening relies on the fact that writing to a NV index for the first time sets
+// the TPMA_NV_WRITTEN attribute which also changes its name. If the index is defined with the TPMA_NV_POLICY_WRITE attribute and an
+// authorization policy that can only be satisfied by an assertion signed with an ephemeral key (using TPM2_PolicySigned), and sealed
+// keys have authorization policies that can only be satisfied by the presence of the initialized index, then it is not possible for
+// an adversary without the private part of the ephemeral key to undefine and redefine an identical NV index in order to remove the
+// TPMA_NV_READLOCKED attribute and reenable access to sealed keys. This was the approach previously taken by secboot, but this had
+// its own problem - if the NV index is accidentally undefined, then this would make all sealed keys permanently unrecoverable.
+// Ideally, provisioning the TPM without clearing it should be able to remedy any accidental changes and restore access to valid
+// sealed keys in all cases except where the storage primary seed has been changed (ie, the TPM has been cleared).
+//
+// The current approach used for protecting the NV index used by LockAccessToSealedKeys makes use of 2 NV indices and has the property
+// that the NV indices have names that are common to all devices and can always be recreated, but they have authorization policies
+// that enforce a creation sequence that means that they can only be created in the locked state. The way this works is as follows:
+// - A bootstrap index is created at handle 2 with TPMA_NV_AUTHREAD and TPMA_NV_AUTHWRITE attributes and an empty authorization
+//   policy.
+// - An empty write is performed to initialize the bootstrap index.
+// - An index is created at handle 1 with TPMA_NV_AUTHREAD, TPMA_NV_POLICY_WRITE and TPMA_NV_READ_STCLEAR attributes, and an
+//   authorization policy that can only be satisfied by the presence of the initialized bootstrap index.
+// - An empty write is performed to initialize index 1 using a policy session.
+// - The bootstrap index is undefined and another index is created at handle 2 with TPMA_NV_AUTHREAD and TPMA_NV_POLICY_WRITE
+//   attributes, and an authorization policy that can only be satisfied by the presence of the initialized index at handle 1 with
+//   its read lock enabled.
+// - The read lock for the index at handle 1 is enabled.
+// - An empty write is performed to initialize index 2 using a policy session.
+//
+// Authorization policies for sealed keys must assert the presence of both of these NV indices using the names of the initialized
+// indices without the read lock enabled. Enabling the read lock on index 1 by calling LockAccessToSealedKeys will disable access to
+// these keys.
+// 
+// It isn't possible to recreate these indices in their unlocked state. Although they can be recovered if they are undefined
+// accidentally, they will not return to their unlocked state until the next TPM reset or restart.
+//
+// An adversary can't undefine and redefine either index in order to reenable access to sealed keys. Eg, say an adversary performs the
+// following actions:
+// - They undefine and redefine index 1. The new index isn't read locked, but sealed keys can't be unsealed until the new index has
+//   been written to. But it has an authorization policy that requires index 2 to be undefined and replaced with the bootstrap index.
+// - They undefine index 2 and create the boostrap index in its place.
+// - They perform an empty write to index 1 to initialize it. Index 1 now has the expected name, but sealed keys still can't be
+//   accessed because index 2 no longer exists.
+// - They undefine the bootstrap index again and redefine index 2. However, sealed keys still can't be unsealed until the new index
+//   has been written to. But it has an authorization policy that requires the read lock to be enabled on index 1.
+// - They enable the read lock on index 1.
+// - They perform an empty write to index 2 to initialize it. Index 2 now has the expected name, but sealed keys still can't be
+//   accessed because index 1 is read locked. This can ony be undone by performing a TPM reset or restart.
+//
+// If this device has been provisioned with the legacy index, or has valid new-style indices, then this function does nothing.
+func ensureLockNVIndices(tpm *tpm2.TPMContext, session tpm2.SessionContext) error {
+	if _, err := validateLockNVIndices(tpm, session); err == nil {
+		// Nothing to do
+		return nil
+	}
+
+	bootstrapPub, index1Pub, index2Pub, err := computeLockNVIndexPublicAreas()
+	if err != nil {
+		return xerrors.Errorf("cannot compute public areas for indices: %w", err)
+	}
+
+	for _, h := range []tpm2.Handle{index1Pub.Index, index2Pub.Index} {
+		index, err := tpm.CreateResourceContextFromTPM(h)
+		switch {
+		case err != nil && !tpm2.IsResourceUnavailableError(err, h):
+			// Unexpected error
+			return xerrors.Errorf("cannot create context to determine if index is already defined: %w", err)
+		case tpm2.IsResourceUnavailableError(err, h):
+			// No existing index defined
+		default:
+			// Undefine the current index
+			if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, session); err != nil {
+				return xerrors.Errorf("cannot undefine existing index: %w", err)
+			}
 		}
-		return xerrors.Errorf("cannot create NV index: %w", err)
 	}
 
 	succeeded := false
+
+	bootstrap, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, bootstrapPub, session)
+	if err != nil {
+		return xerrors.Errorf("cannot create bootstrap index: %w", err)
+	}
+	defer func() {
+		if succeeded || bootstrap.Handle() == tpm2.HandleUnassigned {
+			return
+		}
+		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), bootstrap, session)
+	}()
+
+	if err := tpm.NVWrite(bootstrap, bootstrap, nil, 0, session); err != nil {
+		return xerrors.Errorf("cannot initialize bootstrap index: %w", err)
+	}
+
+	index1, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, index1Pub, session)
+	if err != nil {
+		return xerrors.Errorf("cannot create index 1: %w", err)
+	}
 	defer func() {
 		if succeeded {
 			return
 		}
-		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, session)
+		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index1, session)
 	}()
 
-	// Begin a session to initialize the index.
-	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, nameAlg)
+	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, index1Pub.NameAlg)
 	if err != nil {
-		return xerrors.Errorf("cannot begin policy session to initialize NV index: %w", err)
+		return xerrors.Errorf("cannot begin policy session to initialize indices: %w", err)
 	}
 	defer tpm.FlushContext(policySession)
 
-	// Compute a digest for signing with our key
-	signDigest := tpm2.HashAlgorithmNull
-	keyScheme := keyPublic.Params.AsymDetail().Scheme
-	if keyScheme.Scheme != tpm2.AsymSchemeNull {
-		signDigest = keyScheme.Details.Any().HashAlg
+	if _, _, err := tpm.PolicySecret(bootstrap, policySession, nil, nil, 0, session); err != nil {
+		return xerrors.Errorf("cannot execute assertion to initialize index 1: %w", err)
 	}
-	if signDigest == tpm2.HashAlgorithmNull {
-		signDigest = tpm2.HashAlgorithmSHA256
-	}
-	h := signDigest.NewHash()
-	h.Write(policySession.NonceTPM())
-	binary.Write(h, binary.BigEndian, int32(0))
 
-	// Sign the digest
-	sigR, sigS, err := ecdsa.Sign(rand.Reader, key, h.Sum(nil))
+	if err := tpm.NVWrite(index1, index1, nil, 0, policySession.IncludeAttrs(tpm2.AttrContinueSession), session.IncludeAttrs(tpm2.AttrAudit)); err != nil {
+		return xerrors.Errorf("cannot initialize index 1: %w", err)
+	}
+	if err := tpm.NVReadLock(index1, index1, session); err != nil {
+		return xerrors.Errorf("cannot enable read lock for index 1: %w", err)
+	}
+
+	if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), bootstrap, session); err != nil {
+		return xerrors.Errorf("cannot undefine bootstrap index: %w", err)
+	}
+
+	index2, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, index2Pub, session)
 	if err != nil {
-		return xerrors.Errorf("cannot provide signature for initializing NV index: %w", err)
+		return xerrors.Errorf("cannot create index 2: %w", err)
 	}
-
-	// Load the public part of the key in to the TPM. There's no integrity protection for this command as if it's altered in
-	// transit then either the signature verification fails or the policy digest will not match the one associated with the NV
-	// index.
-	keyLoaded, err := tpm.LoadExternal(nil, keyPublic, tpm2.HandleEndorsement)
-	if err != nil {
-		return xerrors.Errorf("cannot load public part of key used to initialize NV index to the TPM: %w", err)
-	}
-	defer tpm.FlushContext(keyLoaded)
-
-	signature := tpm2.Signature{
-		SigAlg: tpm2.SigSchemeAlgECDSA,
-		Signature: tpm2.SignatureU{
-			Data: &tpm2.SignatureECDSA{
-				Hash:       signDigest,
-				SignatureR: sigR.Bytes(),
-				SignatureS: sigS.Bytes()}}}
-
-	// Execute the policy assertions
-	if err := tpm.PolicyCommandCode(policySession, tpm2.CommandNVWrite); err != nil {
-		return xerrors.Errorf("cannot execute assertion to initialize NV index: %w", err)
-	}
-	if err := tpm.PolicyCounterTimer(policySession, clockBytes, 8, tpm2.OpUnsignedLT); err != nil {
-		return xerrors.Errorf("cannot execute assertion to initialize NV index: %w", err)
-	}
-	if _, _, err := tpm.PolicySigned(keyLoaded, policySession, true, nil, nil, 0, &signature); err != nil {
-		return xerrors.Errorf("cannot execute assertion to initialize NV index: %w", err)
-	}
-
-	// Initialize the index
-	if err := tpm.NVWrite(index, index, nil, 0, policySession, session.IncludeAttrs(tpm2.AttrAudit)); err != nil {
-		return xerrors.Errorf("cannot initialize NV index: %w", err)
-	}
-
-	// Marshal key name and cut-off time for writing to the NV index so that they can be used for verification in the future.
-	data, err := tpm2.MarshalToBytes(lockNVIndexVersion, keyName, time.ClockInfo.Clock)
-	if err != nil {
-		panic(fmt.Sprintf("cannot marshal contents for policy data NV index: %v", err))
-	}
-
-	// Create the data index.
-	dataPublic := tpm2.NVPublic{
-		Index:   lockNVDataHandle,
-		NameAlg: tpm2.HashAlgorithmSHA256,
-		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
-		Size:    uint16(len(data))}
-	dataIndex, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &dataPublic, session)
-	if err != nil {
-		var e *tpm2.TPMError
-		if tpm2.AsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace, &e) {
-			return &tpmErrorWithHandle{err: e, handle: dataPublic.Index}
-		}
-		return xerrors.Errorf("cannot create policy data NV index: %w", err)
-	}
-
 	defer func() {
 		if succeeded {
 			return
 		}
-		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), dataIndex, session)
+		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index2, session)
 	}()
 
-	// Initialize the index
-	if err := tpm.NVWrite(dataIndex, dataIndex, data, 0, session); err != nil {
-		return xerrors.Errorf("cannot initialize policy data NV index: %w", err)
+	if _, _, err := tpm.PolicySecret(index1, policySession, nil, nil, 0, session); err != nil {
+		return xerrors.Errorf("cannot execute assertion to initialize index 2: %w", err)
 	}
-	if err := tpm.NVWriteLock(dataIndex, dataIndex, session); err != nil {
-		return xerrors.Errorf("cannot write lock policy data NV index: %w", err)
+
+	if err := tpm.NVWrite(index2, index2, nil, 0, policySession, session.IncludeAttrs(tpm2.AttrAudit)); err != nil {
+		return xerrors.Errorf("cannot initialize index 2: %w", err)
 	}
 
 	succeeded = true
+
 	return nil
 }
 
-// readAndValidateLockNVIndexPublic validates that the NV index at the global lock handle is safe to protect a new key against, and
-// then returns the public area if it is. The name of the public area can then be used in an authorization policy.
-func readAndValidateLockNVIndexPublic(tpm *tpm2.TPMContext, index tpm2.ResourceContext, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
-	// Obtain the data recorded alongside the lock NV index for validating that it has a valid authorization policy.
-	dataIndex, err := tpm.CreateResourceContextFromTPM(lockNVDataHandle)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot obtain context for policy data NV index: %w", err)
+// validateLegacyLockNVIndex validates that the supplied NV index is a valid legacy lock index and is safe to protect a new key against,
+// and then returns the validated public area if it is. The name of the public area can then be used in an authorization policy.
+func validateLegacyLockNVIndex(tpm *tpm2.TPMContext, index, dataIndex tpm2.ResourceContext, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
+	var s tpm2.SessionContext
+	if session != nil {
+		s = session.IncludeAttrs(tpm2.AttrAudit)
 	}
+
 	dataPub, _, err := tpm.NVReadPublic(dataIndex)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot read public area of policy data NV index: %w", err)
+		return nil, xerrors.Errorf("cannot read public area of policy data index: %w", err)
 	}
 	data, err := tpm.NVRead(dataIndex, dataIndex, dataPub.Size, 0, nil)
 	if err != nil {
@@ -626,7 +654,7 @@ func readAndValidateLockNVIndexPublic(tpm *tpm2.TPMContext, index tpm2.ResourceC
 	}
 
 	// Allow for future changes to the public attributes or auth policy configuration.
-	if version != lockNVIndexVersion {
+	if version != 0 {
 		return nil, errors.New("unrecognized version for policy data")
 	}
 
@@ -638,41 +666,100 @@ func readAndValidateLockNVIndexPublic(tpm *tpm2.TPMContext, index tpm2.ResourceC
 	}
 
 	// Make sure the window beyond which this index can be written has passed or about to pass.
-	if time.ClockInfo.Clock+lockNVIndexGraceTime < clock {
+	if time.ClockInfo.Clock+5000 < clock {
 		return nil, errors.New("unexpected clock value in policy data")
 	}
 
 	// Read the public area of the lock NV index.
-	pub, _, err := tpm.NVReadPublic(index, session.IncludeAttrs(tpm2.AttrAudit))
+	pub, _, err := tpm.NVReadPublic(index, s)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot read public area of NV index: %w", err)
+		return nil, xerrors.Errorf("cannot read public area of index: %w", err)
 	}
 
 	pub.Attrs &^= tpm2.AttrNVReadLocked
 	// Validate its attributes
-	if pub.Attrs != lockNVIndexAttrs|tpm2.AttrNVWritten {
-		return nil, errors.New("unexpected NV index attributes")
+	if pub.Attrs != lockNVIndex1Attrs|tpm2.AttrNVWritten {
+		return nil, errors.New("unexpected index attributes")
 	}
 
 	clockBytes := make([]byte, binary.Size(clock))
 	binary.BigEndian.PutUint64(clockBytes, clock)
 
-	// Compute the expected authorization policy from the contents of the data index, and make sure this matches the public area.
+	// Compute the expected authorization policy from the contents of the data index, and make sure that this matches the public area.
 	// This verifies that the lock NV index has a valid authorization policy.
 	trial, err := tpm2.ComputeAuthPolicy(pub.NameAlg)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot compute expected policy for NV index: %w", err)
+		return nil, xerrors.Errorf("cannot compute expected policy for index: %w", err)
 	}
 	trial.PolicyCommandCode(tpm2.CommandNVWrite)
 	trial.PolicyCounterTimer(clockBytes, 8, tpm2.OpUnsignedLT)
 	trial.PolicySigned(keyName, nil)
 
 	if !bytes.Equal(trial.GetDigest(), pub.AuthPolicy) {
-		return nil, errors.New("incorrect policy for NV index")
+		return nil, errors.New("incorrect policy for index")
 	}
 
-	// This is a valid global lock NV index that cannot be recreated!
+	// pub corresponds to a valid legacy global lock NV index that cannot be recreated!
 	return pub, nil
+}
+
+// validateCurrentLockNVIndices validates that the supplied NV indices correspond to valid new-style lock NV indices.
+func validateCurrentLockNVIndices(tpm *tpm2.TPMContext, index1, index2 tpm2.ResourceContext, session tpm2.SessionContext) error {
+	var s tpm2.SessionContext
+	if session != nil {
+		s = session.IncludeAttrs(tpm2.AttrAudit)
+	}
+
+	index1Pub, _, err := tpm.NVReadPublic(index1, s)
+	if err != nil {
+		return xerrors.Errorf("cannot read public area of index 1: %w", err)
+	}
+	index1Pub.Attrs &^= tpm2.AttrNVReadLocked
+	index1Name, err := index1Pub.Name()
+	if err != nil {
+		return xerrors.Errorf("cannot compute name of index 1: %w", err)
+	}
+
+	index1ExpectedName, index2ExpectedName, err := computeLockNVIndexNames()
+	if err != nil {
+		return xerrors.Errorf("cannot compute expected names: %w", err)
+	}
+
+	if !bytes.Equal(index1Name, index1ExpectedName) || !bytes.Equal(index2.Name(), index2ExpectedName) {
+		return errors.New("found indices with unexpected names")
+	}
+
+	return nil
+}
+
+// validateLockNVIndices checks that the NV indices at the global handles used for locking access to sealed keys are valid lock
+// indices, and returns an error if they aren't. If the indices correspond to the legacy mechanism, the public area of the lock index
+// is returned, else no public area is returned.
+func validateLockNVIndices(tpm *tpm2.TPMContext, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
+	var s tpm2.SessionContext
+	if session != nil {
+		s = session.IncludeAttrs(tpm2.AttrAudit)
+	}
+	index1, err := tpm.CreateResourceContextFromTPM(lockNVHandle1, s)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create context for index 1: %w", err)
+	}
+	index2, err := tpm.CreateResourceContextFromTPM(lockNVHandle2, s)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create context for index 2: %w", err)
+	}
+
+	err1 := validateCurrentLockNVIndices(tpm, index1, index2, session)
+	if err1 == nil {
+		return nil, nil
+	}
+
+	legacyPub, err2 := validateLegacyLockNVIndex(tpm, index1, index2, session)
+	if err2 != nil {
+		return nil, fmt.Errorf("cannot detect new indices (%v) or legacy index (%v)", err1, err2)
+	}
+
+	return legacyPub, nil
 }
 
 // ensureSufficientORDigests turns a single digest in to a pair of identical digests. This is because TPM2_PolicyOR assertions
@@ -742,7 +829,16 @@ func computeStaticPolicy(alg tpm2.HashAlgorithmId, input *staticPolicyComputePar
 	trial, _ := tpm2.ComputeAuthPolicy(alg)
 	trial.PolicyAuthorize(computePcrPolicyRefFromCounterName(pcrPolicyCounterName), keyName)
 	trial.PolicyAuthValue()
-	trial.PolicyNV(input.lockIndexName, nil, 0, tpm2.OpEq)
+	if len(input.legacyLockIndexName) > 0 {
+		trial.PolicyNV(input.legacyLockIndexName, nil, 0, tpm2.OpEq)
+	} else {
+		lockIndex1Name, lockIndex2Name, err := computeLockNVIndexNames()
+		if err != nil {
+			return nil, nil, xerrors.Errorf("cannot compute names of lock NV indices: %w", err)
+		}
+		trial.PolicyNV(lockIndex1Name, nil, 0, tpm2.OpEq)
+		trial.PolicyNV(lockIndex2Name, nil, 0, tpm2.OpEq)
+	}
 
 	return &staticPolicyData{
 		authPublicKey:          input.key,
@@ -1109,12 +1205,20 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 		}
 	}
 
-	lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
-	if err != nil {
-		return xerrors.Errorf("cannot obtain context for lock NV index: %w", err)
+	lockNVHandles := []tpm2.Handle{lockNVHandle1}
+	if legacyPub, err := validateLockNVIndices(tpm, hmacSession); legacyPub == nil && err == nil {
+		// The TPM is provisioned with new style lock NV indices.
+		lockNVHandles = append(lockNVHandles, lockNVHandle2)
 	}
-	if err := tpm.PolicyNV(lockIndex, lockIndex, policySession, nil, 0, tpm2.OpEq, hmacSession); err != nil {
-		return xerrors.Errorf("policy lock check failed: %w", err)
+
+	for _, h := range lockNVHandles {
+		index, err := tpm.CreateResourceContextFromTPM(h)
+		if err != nil {
+			return xerrors.Errorf("cannot obtain context for lock NV index: %w", err)
+		}
+		if err := tpm.PolicyNV(index, index, policySession, nil, 0, tpm2.OpEq, nil); err != nil {
+			return xerrors.Errorf("policy lock check failed: %w", err)
+		}
 	}
 
 	return nil
@@ -1129,15 +1233,15 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 func LockAccessToSealedKeys(tpm *TPMConnection) error {
 	session := tpm.HmacSession()
 
-	handles, err := tpm.GetCapabilityHandles(lockNVHandle, 1, session.IncludeAttrs(tpm2.AttrAudit))
+	handles, err := tpm.GetCapabilityHandles(lockNVHandle1, 1, session.IncludeAttrs(tpm2.AttrAudit))
 	if err != nil {
 		return xerrors.Errorf("cannot obtain handles from TPM: %w", err)
 	}
-	if len(handles) == 0 || handles[0] != lockNVHandle {
+	if len(handles) == 0 || handles[0] != lockNVHandle1 {
 		// Not provisioned, so no keys created by this package can be unsealed by this TPM
 		return nil
 	}
-	lock, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
+	lock, err := tpm.CreateResourceContextFromTPM(lockNVHandle1)
 	if err != nil {
 		return xerrors.Errorf("cannot obtain context for lock NV index: %w", err)
 	}
@@ -1145,7 +1249,7 @@ func LockAccessToSealedKeys(tpm *TPMConnection) error {
 	if err != nil {
 		return xerrors.Errorf("cannot read public area of lock NV index: %w", err)
 	}
-	if lockPublic.Attrs != lockNVIndexAttrs|tpm2.AttrNVWritten {
+	if lockPublic.Attrs != lockNVIndex1Attrs|tpm2.AttrNVWritten {
 		// Definitely not an index created by us, so no keys created by this package can be unsealed by this TPM.
 		return nil
 	}

--- a/policy.go
+++ b/policy.go
@@ -488,6 +488,17 @@ func computeLockNVIndexNames() (tpm2.Name, tpm2.Name, error) {
 // sealed key's authorization policy after the key has been unsealed, which makes its authorization policy non-satisfiable until
 // the next reset or restart. The issue with this is that it makes the feature dependent on the PCR profile.
 //
+// This feature is not designed to protect the key that you need to unseal to boot the current OS, but to protect keys that you
+// don't need and may not even be aware of in order to boot the current OS - eg, say you boot from external media on a device that
+// has an internal encrypted drive, or you insert and boot from an additional internal drive on a device that already has an
+// encrypted install. The feature is designed to protect the contents of an encrypted drive belonging to someone else from being
+// accessed by an adversary that just boots the same OS from another drive on a device, but where the OS provided by the adversary
+// is configured to permit some form of shell access with their own credentials.
+//
+// In order to do this, it needs to work universally and it needs to work without being dependent on accessing key data for the
+// keys it is meant to protect. Given that there could keys with slightly different PCR profiles, it's not really possible to make
+// the feature work universally and without being dependent on accessing key data if it relies on PCRs.
+//
 // The implementation here uses a pair of NV indices at well known handles and takes advantage of a couple of properties of NV
 // index read locks:
 // - Once enabled, they can only be disabled by a TPM reset or restart.

--- a/policy_test.go
+++ b/policy_test.go
@@ -339,7 +339,6 @@ func TestEnsureLockNVIndicesSecurity(t *testing.T) {
 	if err := tpm.NVWrite(index2, index2, nil, 0, session); err == nil {
 		t.Errorf("NVWrite should have failed")
 	}
-	// Policy should still fail after initializing index 1
 	testPolicy(false)
 
 	// Enable the read lock on index 1

--- a/policy_test.go
+++ b/policy_test.go
@@ -201,7 +201,7 @@ func TestEnsureLockNVIndicesSecurity(t *testing.T) {
 	}
 
 	// Get the NV index public templates
-	bootstrapPub, index1Pub, index2Pub, err := ComputeLockNVIndexPublicAreas()
+	bootstrapPub, index1Pub, index2Pub, err := ComputeLockNVIndexTemplates()
 	if err != nil {
 		t.Fatalf("ComputeLockNVIndexPublicAreas failed: %v", err)
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -251,28 +251,36 @@ AwEHoUQDQgAEkxoOhf6oe3ZE91Kl97qMH/WndK1B0gD7nuqXzPnwtxBBWhTF6pbw
 		desc                string
 		alg                 tpm2.HashAlgorithmId
 		pcrPolicyCounterPub *tpm2.NVPublic
+		legacyLockIndexName tpm2.Name
 		policy              tpm2.Digest
 	}{
 		{
 			desc:                "SHA256",
 			alg:                 tpm2.HashAlgorithmSHA256,
 			pcrPolicyCounterPub: pcrPolicyCounterPub,
-			policy:              decodeHexStringT(t, "c5254ead173361569199cee1479ff329d1b4f0d329c794d7c362e0ed6aa43dbe"),
+			policy:              decodeHexStringT(t, "7ee3989de946cacba5d30e91507ac44d5dfc304a1c31bd1fc62fedab93f22d73"),
 		},
 		{
 			desc:                "SHA1",
 			alg:                 tpm2.HashAlgorithmSHA1,
 			pcrPolicyCounterPub: pcrPolicyCounterPub,
-			policy:              decodeHexStringT(t, "e502a0d62dfc7a61ccf1b3e7814729532761171a"),
+			policy:              decodeHexStringT(t, "132a4592464c20eaab89e752cd2322ed685776ed"),
 		},
 		{
 			desc:   "NoPolicyCounter",
 			alg:    tpm2.HashAlgorithmSHA256,
-			policy: decodeHexStringT(t, "594b23bea81ac48f593fdb179e35f74a23ca002d97415fc1a95b424b59fcdf28"),
+			policy: decodeHexStringT(t, "6733425c4b14ce4363bdfe7f65c91f64ee857a5524a2c4ba4fd2706e4454352b"),
+		},
+		{
+			desc:                "WithLegacyLockNVIndex",
+			alg:                 tpm2.HashAlgorithmSHA256,
+			pcrPolicyCounterPub: pcrPolicyCounterPub,
+			legacyLockIndexName: legacyLockName,
+			policy:              decodeHexStringT(t, "c5254ead173361569199cee1479ff329d1b4f0d329c794d7c362e0ed6aa43dbe"),
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
-			dataout, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(publicKey, data.pcrPolicyCounterPub, legacyLockName))
+			dataout, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(publicKey, data.pcrPolicyCounterPub, data.legacyLockIndexName))
 			if err != nil {
 				t.Fatalf("ComputeStaticPolicy failed: %v", err)
 			}

--- a/policy_test.go
+++ b/policy_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
-	"encoding/binary"
 	"encoding/pem"
 	"math/big"
 	"sort"
@@ -35,69 +34,6 @@ import (
 	. "github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/testutil"
 )
-
-func validateLockNVIndex(t *testing.T, tpm *tpm2.TPMContext) {
-	index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-	if err != nil {
-		t.Fatalf("Cannot create context for lock NV index: %v", err)
-	}
-
-	// Validate the properties of the index
-	pub, _, err := tpm.NVReadPublic(index)
-	if err != nil {
-		t.Fatalf("NVReadPublic failed: %v", err)
-	}
-
-	if pub.NameAlg != tpm2.HashAlgorithmSHA256 {
-		t.Errorf("Lock NV index has the wrong name algorithm")
-	}
-	if pub.Attrs.Type() != tpm2.NVTypeOrdinary {
-		t.Errorf("Lock NV index has the wrong type")
-	}
-	if pub.Attrs.AttrsOnly() != tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVNoDA|tpm2.AttrNVReadStClear|tpm2.AttrNVWritten {
-		t.Errorf("Lock NV index has the wrong attributes")
-	}
-	if pub.Size != uint16(0) {
-		t.Errorf("Lock NV index has the wrong size")
-	}
-
-	dataIndex, err := tpm.CreateResourceContextFromTPM(LockNVDataHandle)
-	if err != nil {
-		t.Fatalf("Cannot create context for lock policy data NV index: %v", err)
-	}
-
-	dataPub, _, err := tpm.NVReadPublic(dataIndex)
-	if err != nil {
-		t.Fatalf("NVReadPublic failed: %v", err)
-	}
-	data, err := tpm.NVRead(dataIndex, dataIndex, dataPub.Size, 0, nil)
-	if err != nil {
-		t.Fatalf("NVRead failed: %v", err)
-	}
-
-	var version uint8
-	var keyName tpm2.Name
-	var clock uint64
-	if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
-		t.Fatalf("UnmarshalFromBytes failed: %v", err)
-	}
-
-	if version != 0 {
-		t.Errorf("Unexpected version for lock NV index policy")
-	}
-
-	clockBytes := make([]byte, binary.Size(clock))
-	binary.BigEndian.PutUint64(clockBytes, clock)
-
-	trial, _ := tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-	trial.PolicyCommandCode(tpm2.CommandNVWrite)
-	trial.PolicyCounterTimer(clockBytes, 8, tpm2.OpUnsignedLT)
-	trial.PolicySigned(keyName, nil)
-
-	if !bytes.Equal(trial.GetDigest(), pub.AuthPolicy) {
-		t.Errorf("Lock NV index has the wrong authorization policy")
-	}
-}
 
 func TestIncrementPcrPolicyCounter(t *testing.T) {
 	tpm := openTPMForTesting(t)
@@ -187,317 +123,96 @@ func TestReadPcrPolicyCounter(t *testing.T) {
 }
 
 func undefineLockNVIndices(t *testing.T, tpm *TPMConnection) {
-	if index, err := tpm.CreateResourceContextFromTPM(LockNVHandle); err == nil {
-		undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-	}
-	if index, err := tpm.CreateResourceContextFromTPM(LockNVDataHandle); err == nil {
-		undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+	for _, h := range []tpm2.Handle{LockNVHandle1, LockNVHandle2} {
+		if index, err := tpm.CreateResourceContextFromTPM(h); err == nil {
+			undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+		}
 	}
 }
 
-func TestEnsureLockNVIndex(t *testing.T) {
-	tpm := openTPMForTesting(t)
-	defer closeTPM(t, tpm)
-
-	undefineLockNVIndices(t, tpm)
-	if err := EnsureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
-		t.Errorf("EnsureLockNVIndex failed: %v", err)
-	}
+func TestEnsureLockNVIndices(t *testing.T) {
+	tpm, _ := openTPMSimulatorForTesting(t)
 	defer func() {
-		index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-		if err != nil {
-			t.Errorf("CreateResourceContextFromTPM failed: %v", err)
-		}
-		undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-		index, err = tpm.CreateResourceContextFromTPM(LockNVDataHandle)
-		if err != nil {
-			t.Errorf("CreateResourceContextFromTPM failed: %v", err)
-		}
-		undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+		clearTPMWithPlatformAuth(t, tpm)
+		closeTPM(t, tpm)
 	}()
 
-	validateLockNVIndex(t, tpm.TPMContext)
-
-	index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-	if err != nil {
-		t.Fatalf("No lock NV index created")
-	}
-	origName := index.Name()
-
-	if err := EnsureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
-		t.Errorf("EnsureLockNVIndex failed: %v", err)
+	run := func(t *testing.T) {
+		if err := EnsureLockNVIndices(tpm.TPMContext, tpm.HmacSession()); err != nil {
+			t.Errorf("EnsureLockNVIndices failed: %v", err)
+		}
+		if _, err := ValidateLockNVIndices(tpm.TPMContext, tpm.HmacSession()); err != nil {
+			t.Errorf("ValidateLockNVIndices failed: %v", err)
+		}
 	}
 
-	index, err = tpm.CreateResourceContextFromTPM(LockNVHandle)
-	if err != nil {
-		t.Fatalf("No lock NV index created")
-	}
-	if !bytes.Equal(index.Name(), origName) {
-		t.Errorf("lock NV index shouldn't have been recreated")
-	}
-}
-
-func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
-	tpm := openTPMForTesting(t)
-	defer closeTPM(t, tpm)
-
-	prepare := func(t *testing.T) (tpm2.ResourceContext, tpm2.ResourceContext) {
-		undefineLockNVIndices(t, tpm)
-		if err := EnsureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
-			t.Errorf("EnsureLockNVIndex failed: %v", err)
-		}
-		index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-		if err != nil {
-			t.Fatalf("No lock NV index created")
-		}
-		dataIndex, err := tpm.CreateResourceContextFromTPM(LockNVDataHandle)
-		if err != nil {
-			t.Fatalf("No lock NV data index created")
-		}
-		return index, dataIndex
-	}
-
-	t.Run("Good", func(t *testing.T) {
-		index, dataIndex := prepare(t)
-		defer func() {
-			undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-			undefineNVSpace(t, tpm, dataIndex, tpm.OwnerHandleContext())
-		}()
-		pub, err := ReadAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
-		if err != nil {
-			t.Fatalf("ReadAndValidateLockNVIndexPublic failed: %v", err)
-		}
-		if pub.Index != LockNVHandle {
-			t.Errorf("Returned public area has wrong handle")
-		}
-		if pub.Attrs != LockNVIndexAttrs|tpm2.AttrNVWritten {
-			t.Errorf("incorrect lock NV index attributes")
-		}
-	})
-
-	t.Run("ReadLocked", func(t *testing.T) {
-		index, dataIndex := prepare(t)
-		defer func() {
-			undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-			undefineNVSpace(t, tpm, dataIndex, tpm.OwnerHandleContext())
-		}()
-		if err := tpm.NVReadLock(index, index, nil); err != nil {
-			t.Fatalf("NVReadLock failed: %v", err)
-		}
-		pub, err := ReadAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
-		if err != nil {
-			t.Fatalf("ReadAndValidateLockNVIndexPublic failed: %v", err)
-		}
-		if pub.Index != LockNVHandle {
-			t.Errorf("Returned public area has wrong handle")
-		}
-		if pub.Attrs != LockNVIndexAttrs|tpm2.AttrNVWritten {
-			t.Errorf("incorrect lock NV index attributes")
-		}
-	})
-
-	t.Run("NoPolicyDataIndex", func(t *testing.T) {
-		index, dataIndex := prepare(t)
-		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), dataIndex, nil); err != nil {
-			t.Fatalf("NVUndefineSpace failed: %v", err)
-		}
-		pub, err := ReadAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
-		if pub != nil {
-			t.Errorf("ReadAndValidateLockNVIndexPublic should have returned no public area")
-		}
-		if !tpm2.IsResourceUnavailableError(err, LockNVDataHandle) {
-			t.Errorf("Unexpected error type")
-		}
-	})
-
-	t.Run("IncorrectClockValue", func(t *testing.T) {
-		index, dataIndex := prepare(t)
-		dataIndexUndefined := false
-		defer func() {
-			undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-			if dataIndexUndefined {
-				return
-			}
-			undefineNVSpace(t, tpm, dataIndex, tpm.OwnerHandleContext())
-		}()
-
-		// Test with a policy data index that indicates a time in the future.
-
-		dataPub, _, err := tpm.NVReadPublic(dataIndex)
-		if err != nil {
-			t.Fatalf("NVReadPublic failed: %v", err)
-		}
-		data, err := tpm.NVRead(dataIndex, dataIndex, dataPub.Size, 0, nil)
-		if err != nil {
-			t.Fatalf("NVRead failed: %v", err)
-		}
-		var version uint8
-		var keyName tpm2.Name
-		var clock uint64
-		if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
-			t.Fatalf("UnmarshalFromBytes failed: %v", err)
-		}
-
-		time, err := tpm.ReadClock()
-		if err != nil {
-			t.Fatalf("ReadClock failed: %v", err)
-		}
-
-		data, err = tpm2.MarshalToBytes(version, keyName, time.ClockInfo.Clock+3600000)
-		if err != nil {
-			t.Errorf("MarshalToBytes failed: %v", err)
-		}
-
-		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), dataIndex, nil); err != nil {
-			t.Fatalf("NVUndefineSpace failed: %v", err)
-		}
-		dataIndexUndefined = true
-
-		public := tpm2.NVPublic{
-			Index:   LockNVDataHandle,
-			NameAlg: tpm2.HashAlgorithmSHA256,
-			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
-			Size:    uint16(len(data))}
-		dataIndex, err = tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &public, nil)
-		if err != nil {
-			t.Fatalf("NVDefineSpace failed: %v", err)
-		}
-		defer undefineNVSpace(t, tpm, dataIndex, tpm.OwnerHandleContext())
-
-		if err := tpm.NVWrite(dataIndex, dataIndex, data, 0, nil); err != nil {
-			t.Errorf("NVWrite failed: %v", err)
-		}
-		pub, err := ReadAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
-		if err == nil {
-			t.Fatalf("ReadAndValidateLockNVIndexPublic should have failed")
-		}
-		if pub != nil {
-			t.Errorf("ReadAndValidateLockNVIndexPublic should have returned no public area")
-		}
-		if err.Error() != "unexpected clock value in policy data" {
-			t.Errorf("Unexpected error: %v", err)
-		}
-	})
-
-	t.Run("IncorrectPolicy", func(t *testing.T) {
+	t.Run("Fresh", func(t *testing.T) {
 		clearTPMWithPlatformAuth(t, tpm)
+		run(t)
+	})
 
-		// Test with a bogus lock NV index that allows writes far in to the future, making it possible
-		// to recreate it to remove the read lock bit.
-
-		key, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
-		if err != nil {
-			t.Fatalf("GenerateKey failed: %v", err)
+	t.Run("Refresh", func(t *testing.T) {
+		if err := EnsureLockNVIndices(tpm.TPMContext, tpm.HmacSession()); err != nil {
+			t.Fatalf("EnsureLockNVIndices failed: %v", err)
 		}
+		run(t)
+	})
 
-		keyPublic := CreatePublicAreaForECDSAKey(&key.PublicKey)
-		keyName, err := keyPublic.Name()
-		if err != nil {
-			t.Errorf("Cannot compute key name: %v", err)
-		}
-
-		time, err := tpm.ReadClock()
-		if err != nil {
-			t.Fatalf("ReadClock failed: %v", err)
-		}
-		time.ClockInfo.Clock += 5000
-		clockBytes := make(tpm2.Operand, binary.Size(time.ClockInfo.Clock))
-		binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock+3600000000)
-
-		trial, _ := tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
-		trial.PolicyCommandCode(tpm2.CommandNVWrite)
-		trial.PolicyCounterTimer(clockBytes, 8, tpm2.OpUnsignedLT)
-		trial.PolicySigned(keyName, nil)
-
-		public := tpm2.NVPublic{
-			Index:      LockNVHandle,
-			NameAlg:    tpm2.HashAlgorithmSHA256,
-			Attrs:      LockNVIndexAttrs,
-			AuthPolicy: trial.GetDigest(),
-			Size:       0}
-		index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &public, nil)
-		if err != nil {
-			t.Fatalf("NVDefineSpace failed: %v", err)
-		}
-		defer undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
-
-		policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)
-		if err != nil {
-			t.Fatalf("StartAuthSession failed: %v", err)
-		}
-		defer tpm.FlushContext(policySession)
-
-		h := tpm2.HashAlgorithmSHA256.NewHash()
-		h.Write(policySession.NonceTPM())
-		binary.Write(h, binary.BigEndian, int32(0))
-
-		sigR, sigS, err := ecdsa.Sign(testutil.RandReader, key, h.Sum(nil))
-		if err != nil {
-			t.Errorf("SignPSS failed: %v", err)
-		}
-
-		keyLoaded, err := tpm.LoadExternal(nil, keyPublic, tpm2.HandleEndorsement)
-		if err != nil {
-			t.Fatalf("LoadExternal failed: %v", err)
-		}
-		defer tpm.FlushContext(keyLoaded)
-
-		signature := tpm2.Signature{
-			SigAlg: tpm2.SigSchemeAlgECDSA,
-			Signature: tpm2.SignatureU{
-				Data: &tpm2.SignatureECDSA{
-					Hash:       tpm2.HashAlgorithmSHA256,
-					SignatureR: sigR.Bytes(),
-					SignatureS: sigS.Bytes()}}}
-
-		if err := tpm.PolicyCommandCode(policySession, tpm2.CommandNVWrite); err != nil {
-			t.Errorf("Assertion failed: %v", err)
-		}
-		if err := tpm.PolicyCounterTimer(policySession, clockBytes, 8, tpm2.OpUnsignedLT); err != nil {
-			t.Errorf("Assertion failed: %v", err)
-		}
-		if _, _, err := tpm.PolicySigned(keyLoaded, policySession, true, nil, nil, 0, &signature); err != nil {
-			t.Errorf("Assertion failed: %v", err)
-		}
-
-		if err := tpm.NVWrite(index, index, nil, 0, policySession); err != nil {
-			t.Errorf("NVWrite failed: %v", err)
-		}
-
-		data, err := tpm2.MarshalToBytes(uint8(0), keyName, time.ClockInfo.Clock)
-		if err != nil {
-			t.Fatalf("MarshalToBytes failed: %v", err)
-		}
-
-		// Create the data index.
-		dataPublic := tpm2.NVPublic{
-			Index:   LockNVDataHandle,
+	t.Run("DeleteExisting", func(t *testing.T) {
+		clearTPMWithPlatformAuth(t, tpm)
+		pub := tpm2.NVPublic{
+			Index:   LockNVHandle1,
 			NameAlg: tpm2.HashAlgorithmSHA256,
-			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
-			Size:    uint16(len(data))}
-		dataIndex, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &dataPublic, nil)
-		if err != nil {
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthRead | tpm2.AttrNVAuthWrite),
+			Size:    8}
+		if _, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &pub, nil); err != nil {
 			t.Fatalf("NVDefineSpace failed: %v", err)
 		}
-		defer undefineNVSpace(t, tpm, dataIndex, tpm.OwnerHandleContext())
-
-		if err := tpm.NVWrite(dataIndex, dataIndex, data, 0, nil); err != nil {
-			t.Errorf("NVWrite failed: %v", err)
-		}
-
-		pub, err := ReadAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
-		if err == nil {
-			t.Fatalf("ReadAndValidateLockNVIndexPublic should have failed")
-		}
-		if pub != nil {
-			t.Errorf("ReadAndValidateLockNVIndexPublic should have returned no public area")
-		}
-		if err.Error() != "incorrect policy for NV index" {
-			t.Errorf("Unexpected error: %v", err)
-		}
+		run(t)
 	})
 }
+
+//func TestEnsureLockNVIndex(t *testing.T) {
+//	tpm := openTPMForTesting(t)
+//	defer closeTPM(t, tpm)
+//
+//	undefineLockNVIndices(t, tpm)
+//	if err := EnsureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+//		t.Errorf("EnsureLockNVIndex failed: %v", err)
+//	}
+//	defer func() {
+//		index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
+//		if err != nil {
+//			t.Errorf("CreateResourceContextFromTPM failed: %v", err)
+//		}
+//		undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+//		index, err = tpm.CreateResourceContextFromTPM(LockNVDataHandle)
+//		if err != nil {
+//			t.Errorf("CreateResourceContextFromTPM failed: %v", err)
+//		}
+//		undefineNVSpace(t, tpm, index, tpm.OwnerHandleContext())
+//	}()
+//
+//	validateLockNVIndex(t, tpm.TPMContext)
+//
+//	index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
+//	if err != nil {
+//		t.Fatalf("No lock NV index created")
+//	}
+//	origName := index.Name()
+//
+//	if err := EnsureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+//		t.Errorf("EnsureLockNVIndex failed: %v", err)
+//	}
+//
+//	index, err = tpm.CreateResourceContextFromTPM(LockNVHandle)
+//	if err != nil {
+//		t.Fatalf("No lock NV index created")
+//	}
+//	if !bytes.Equal(index.Name(), origName) {
+//		t.Errorf("lock NV index shouldn't have been recreated")
+//	}
+//}
 
 func TestComputeStaticPolicy(t *testing.T) {
 	block, _ := pem.Decode([]byte(`
@@ -524,13 +239,13 @@ AwEHoUQDQgAEkxoOhf6oe3ZE91Kl97qMH/WndK1B0gD7nuqXzPnwtxBBWhTF6pbw
 		AuthPolicy: trial.GetDigest(),
 		Size:       8}
 
-	lockIndexPub := tpm2.NVPublic{
-		Index:      LockNVHandle,
+	legacyLockIndexPub := tpm2.NVPublic{
+		Index:      LockNVHandle1,
 		NameAlg:    tpm2.HashAlgorithmSHA256,
 		Attrs:      tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVReadStClear | tpm2.AttrNVWritten),
 		AuthPolicy: make(tpm2.Digest, tpm2.HashAlgorithmSHA256.Size()),
 		Size:       0}
-	lockName, _ := lockIndexPub.Name()
+	legacyLockName, _ := legacyLockIndexPub.Name()
 
 	for _, data := range []struct {
 		desc                string
@@ -557,7 +272,7 @@ AwEHoUQDQgAEkxoOhf6oe3ZE91Kl97qMH/WndK1B0gD7nuqXzPnwtxBBWhTF6pbw
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
-			dataout, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(publicKey, data.pcrPolicyCounterPub, lockName))
+			dataout, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(publicKey, data.pcrPolicyCounterPub, legacyLockName))
 			if err != nil {
 				t.Fatalf("ComputeStaticPolicy failed: %v", err)
 			}
@@ -1155,10 +870,10 @@ func TestExecutePolicy(t *testing.T) {
 	tpm, tcti := openTPMSimulatorForTesting(t)
 	defer func() { closeTPM(t, tpm) }()
 
-	undefineLockNVIndices(t, tpm)
-	if err := EnsureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
-		t.Errorf("ensureLockNVIndex failed: %v", err)
+	if err := EnsureLockNVIndices(tpm.TPMContext, tpm.HmacSession()); err != nil {
+		t.Errorf("ensureLockNVIndices failed: %v", err)
 	}
+	tpm, tcti = resetTPMSimulator(t, tpm, tcti)
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	if err != nil {
@@ -1201,17 +916,12 @@ func TestExecutePolicy(t *testing.T) {
 	run := func(t *testing.T, data *testData, prepare func(*StaticPolicyData, *DynamicPolicyData)) (tpm2.Digest, tpm2.Digest, error) {
 		tpm, tcti = resetTPMSimulator(t, tpm, tcti)
 
-		lockIndex, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-		if err != nil {
-			t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
-		}
-
 		var policyCounterName tpm2.Name
 		if data.policyCounterPub != nil {
 			policyCounterName, _ = data.policyCounterPub.Name()
 		}
 
-		staticPolicyData, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(CreatePublicAreaForECDSAKey(&key.PublicKey), data.policyCounterPub, lockIndex.Name()))
+		staticPolicyData, policy, err := ComputeStaticPolicy(data.alg, NewStaticPolicyComputeParams(CreatePublicAreaForECDSAKey(&key.PublicKey), data.policyCounterPub, nil))
 		if err != nil {
 			t.Fatalf("ComputeStaticPolicy failed: %v", err)
 		}
@@ -1797,7 +1507,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, func(*StaticPolicyData, *DynamicPolicyData) {
-			lockIndex, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
+			lockIndex, err := tpm.CreateResourceContextFromTPM(LockNVHandle1)
 			if err != nil {
 				t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 			}
@@ -2401,20 +2111,12 @@ func TestExecutePolicy(t *testing.T) {
 
 func TestLockAccessToSealedKeys(t *testing.T) {
 	tpm, tcti := openTPMSimulatorForTesting(t)
-	defer func() {
-		tpm, _ = resetTPMSimulator(t, tpm, tcti)
-		closeTPM(t, tpm)
-	}()
+	defer func() { closeTPM(t, tpm) }()
 
-	undefineLockNVIndices(t, tpm)
-	if err := EnsureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+	if err := EnsureLockNVIndices(tpm.TPMContext, tpm.HmacSession()); err != nil {
 		t.Errorf("EnsureLockNVIndex failed: %v", err)
 	}
-
-	lockIndex, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-	if err != nil {
-		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
-	}
+	tpm, tcti = resetTPMSimulator(t, tpm, tcti)
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	if err != nil {
@@ -2436,7 +2138,7 @@ func TestLockAccessToSealedKeys(t *testing.T) {
 	}
 	defer func() { undefineNVSpace(t, tpm, policyCounter, tpm.OwnerHandleContext()) }()
 
-	staticPolicyData, policy, err := ComputeStaticPolicy(tpm2.HashAlgorithmSHA256, NewStaticPolicyComputeParams(keyPublic, policyCounterPub, lockIndex.Name()))
+	staticPolicyData, policy, err := ComputeStaticPolicy(tpm2.HashAlgorithmSHA256, NewStaticPolicyComputeParams(keyPublic, policyCounterPub, nil))
 	if err != nil {
 		t.Fatalf("ComputeStaticPolicy failed: %v", err)
 	}
@@ -2528,7 +2230,7 @@ func TestLockAccessToSealedKeysUnprovisioned(t *testing.T) {
 		// Test with a NV index defined that has the wrong attributes.
 		undefineLockNVIndices(t, tpm)
 		public := tpm2.NVPublic{
-			Index:   LockNVHandle,
+			Index:   LockNVHandle1,
 			NameAlg: tpm2.HashAlgorithmSHA256,
 			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVOwnerWrite | tpm2.AttrNVOwnerRead),
 			Size:    8}
@@ -2544,7 +2246,7 @@ func TestLockAccessToSealedKeysUnprovisioned(t *testing.T) {
 		// Test with a NV index defined with the expected attributes, but with a non-empty authorization value.
 		undefineLockNVIndices(t, tpm)
 		public := tpm2.NVPublic{
-			Index:   LockNVHandle,
+			Index:   LockNVHandle1,
 			NameAlg: tpm2.HashAlgorithmSHA256,
 			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVReadStClear),
 			Size:    0}

--- a/provisioning.go
+++ b/provisioning.go
@@ -336,18 +336,9 @@ func ProvisionStatus(tpm *TPMConnection) (ProvisionStatusAttributes, error) {
 		out |= AttrLockoutAuthSet
 	}
 
-	//lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle, session)
-	//switch {
-	//case err != nil && !tpm2.IsResourceUnavailableError(err, lockNVHandle):
-	//	// Unexpected error
-	//	return 0, err
-	//case tpm2.IsResourceUnavailableError(err, lockNVHandle):
-	//	// Nothing to do
-	//default:
-	//	if _, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session); err == nil {
-	//		out |= AttrValidLockNVIndex
-	//	}
-	//}
+	if _, err := validateLockNVIndices(tpm.TPMContext, tpm.HmacSession()); err == nil {
+		out |= AttrValidLockNVIndex
+	}
 
 	return out, nil
 }

--- a/seal.go
+++ b/seal.go
@@ -180,22 +180,17 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 		}
 	}
 
-	// Validate that the lock NV index is valid and obtain its name
-	lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
-	switch {
-	case tpm2.IsResourceUnavailableError(err, lockNVHandle):
-		return ErrTPMProvisioning
-	case err != nil:
-		return xerrors.Errorf("cannot create context for lock NV index: %w", err)
-	}
-
-	lockIndexPub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session)
+	// Validate that the TPM has either new-style lock NV indices or legacy-style lock NV index.
+	legacyLockIndexPub, err := validateLockNVIndices(tpm.TPMContext, session)
 	if err != nil {
 		return ErrTPMProvisioning
 	}
-	lockIndexName, err := lockIndexPub.Name()
-	if err != nil {
-		return xerrors.Errorf("cannot compute name of global lock NV index: %w", err)
+	var legacyLockIndexName tpm2.Name
+	if legacyLockIndexPub != nil {
+		legacyLockIndexName, err = legacyLockIndexPub.Name()
+		if err != nil {
+			return xerrors.Errorf("cannot compute name of legacy global lock NV index: %w", err)
+		}
 	}
 
 	succeeded := false
@@ -270,7 +265,7 @@ func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath, policyUpdatePath stri
 	staticPolicyData, authPolicy, err := computeStaticPolicy(template.NameAlg, &staticPolicyComputeParams{
 		key:                 authPublicKey,
 		pcrPolicyCounterPub: pcrPolicyCounterPub,
-		lockIndexName:       lockIndexName})
+		legacyLockIndexName: legacyLockIndexName})
 	if err != nil {
 		return xerrors.Errorf("cannot compute static authorization policy: %w", err)
 	}

--- a/seal_test.go
+++ b/seal_test.go
@@ -203,7 +203,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 	})
 
 	t.Run("Provisioning/1", func(t *testing.T) {
-		index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
+		index, err := tpm.CreateResourceContextFromTPM(LockNVHandle1)
 		if err != nil {
 			t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 		}
@@ -211,13 +211,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Errorf("NVUndefineSpace failed: %v", err)
 		}
 		defer func() {
-			index, err := tpm.CreateResourceContextFromTPM(LockNVDataHandle)
-			if err != nil {
-				t.Errorf("CreateResourceContextFromTPM failed: %v", err)
-			}
-			if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, nil); err != nil {
-				t.Errorf("NVUndefineSpace failed: %v", err)
-			}
+			undefineLockNVIndices(t, tpm)
 			if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}
@@ -228,7 +222,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 	})
 
 	t.Run("Provisioning/2", func(t *testing.T) {
-		index, err := tpm.CreateResourceContextFromTPM(LockNVDataHandle)
+		index, err := tpm.CreateResourceContextFromTPM(LockNVHandle2)
 		if err != nil {
 			t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 		}
@@ -236,13 +230,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 			t.Errorf("NVUndefineSpace failed: %v", err)
 		}
 		defer func() {
-			index, err := tpm.CreateResourceContextFromTPM(LockNVHandle)
-			if err != nil {
-				t.Errorf("CreateResourceContextFromTPM failed: %v", err)
-			}
-			if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, nil); err != nil {
-				t.Errorf("NVUndefineSpace failed: %v", err)
-			}
+			undefineLockNVIndices(t, tpm)
 			if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 				t.Errorf("Failed to re-provision TPM after test: %v", err)
 			}

--- a/unseal.go
+++ b/unseal.go
@@ -132,7 +132,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string) ([]byte,
 			return nil, InvalidKeyFileError{err.Error()}
 		case isAuthFailError(err, tpm2.CommandPolicySecret, 1):
 			return nil, ErrPINFail
-		case tpm2.IsResourceUnavailableError(err, lockNVHandle):
+		case tpm2.IsResourceUnavailableError(err, lockNVHandle1) || tpm2.IsResourceUnavailableError(err, lockNVHandle2):
 			return nil, ErrTPMProvisioning
 		case tpm2.IsTPMError(err, tpm2.ErrorNVLocked, tpm2.CommandPolicyNV):
 			return nil, ErrSealedKeyAccessLocked


### PR DESCRIPTION
Access to sealed keys can be denied until the next TPM reset or restart
by calling LockAccessToSealedKeys. The traditional way of achieving this
is by extending another value to a PCR that is included in the PCR
selection for a sealed key's authorization policy after the key has been
unsealed, which makes its authorization policy non-satisfiable until the
next reset or restart. The issue with this is that it makes the feature
dependent on the PCR profile.

The current implementation of LockAccessToSealedKeys uses a NV index at a
well known handle and takes advantage of a couple of properties of NV
index read locks:
- Once enabled, they can only be disabled by a TPM reset or restart.
- Enabling a read lock sets the index's TPMA_NV_READLOCKED attribute which
changes its name.

Sealed keys created by this package have an authorization policy that
asserts that this NV index exists at its well known handle. Calling
LockAccessToSealedKeys enables the read lock for this index, which changes
its name and makes this assertion fail.

The problem with this approach though is that the TPM owner (ie, anyone
who knows the authorization value for the storage hierarchy, which is
empty by default) can undefine and redefine a NV index in order to clear
the read lock attribute, thus re-enabling access to sealed keys. One
approach to prevent this from happening relies on the fact that writing to
a NV index for the first time sets the TPMA_NV_WRITTEN attribute which
also changes its name. If the index is defined with the
TPMA_NV_POLICY_WRITE attribute and an authorization policy that can only
be satisfied by an assertion signed with an ephemeral key (using
TPM2_PolicySigned), and sealed keys have authorization policies that can
only be satisfied by the presence of the initialized index, then it is not
possible for an adversary without the private part of the ephemeral key to
undefine and redefine an identical NV index in order to remove the
TPMA_NV_READLOCKED attribute and reenable access to sealed keys. This is
the approach currently taken by secboot, but this has its own problem - if
the NV index is accidentally undefined, then this would make all sealed
keys permanently unrecoverable. Ideally, provisioning the TPM without
clearing it should be able to remedy any accidental changes and restore
access to valid sealed keys in all cases except where the storage primary
seed has been changed (ie, the TPM has been cleared).

This changes the approach used for protecting the NV index used by
LockAccessToSealedKeys. The new approach makes use of 2 NV indices and has
the property that the NV indices have names that are common to all devices
and can always be recreated, but they have authorization policies that
enforce a creation sequence that means that they can only be created in
the locked state. The way this works is as follows:
- A bootstrap index is created at handle 2 with TPMA_NV_AUTHREAD and
TPMA_NV_AUTHWRITE attributes and an empty authorization policy.
- An empty write is performed to initialize the bootstrap index.
- An index is created at handle 1 with TPMA_NV_AUTHREAD,
TPMA_NV_POLICY_WRITE and TPMA_NV_READ_STCLEAR attributes, and an
authorization policy that can only be satisfied by the presence of the
initialized bootstrap index.
- An empty write is performed to initialize index 1 using a policy session.
- The bootstrap index is undefined and another index is created at handle
2 with TPMA_NV_AUTHREAD and TPMA_NV_POLICY_WRITE attributes, and an
authorization policy that can only be satisfied by the presence of the
initialized index at handle 1 with its read lock enabled.
- The read lock for the index at handle 1 is enabled.
- An empty write is performed to initialize index 2 using a policy session.

Authorization policies for sealed keys must assert the presence of both of
these NV indices using the names of the initialized indices without the
read lock enabled. Enabling the read lock on index 1 will disable access
to these keys.

It isn't possible to recreate these indices in their unlocked state.
Although they can be recovered if they are undefined accidentally, they
will not return to their unlocked state until the next TPM reset or
restart.

An adversary can't undefine and redefine either index in order to
reenable access to sealed keys. Eg, say an adversary performs the
following actions:
- They undefine and redefine index 1. The new index isn't read locked, but
sealed keys can't be unsealed until the new index has been written to. But
it has an authorization policy that requires index 2 to be undefined and
replaced with the bootstrap index.
- They undefine index 2 and create the boostrap index in its place.
- They perform an empty write to index 1 to initialize it. Index 1 now has
the expected name, but sealed keys still can't be accessed because index 2
no longer exists.
- They undefine the bootstrap index again and redefine index 2. However,
sealed keys still can't be unsealed until the new index has been written
to. But it has an authorization policy that requires the read lock to be
enabled on index 1.
- They enable the read lock on index 1.
- They perform an empty write to index 2 to initialize it. Index 2 now has
the expected name, but sealed keys still can't be accessed because index 1
is read locked. This can ony be undone by performing a TPM reset or
restart.