### PR TITLE
Add the ability to seal keys with shared authorization policies

### DIFF
--- a/seal.go
+++ b/seal.go
@@ -339,7 +339,7 @@ func SealKeyToTPMMultiple(tpm *TPMConnection, keys []*SealKeyRequest, params *Ke
 	}
 
 	succeeded = true
-	return
+	return authKey, nil
 }
 
 // SealKeyToTPM seals the supplied disk encryption key to the storage hierarchy of the TPM. The sealed key object and associated

--- a/seal.go
+++ b/seal.go
@@ -208,7 +208,7 @@ func SealKeyToTPMMultiple(tpm *TPMConnection, keys []*SealKeyRequest, params *Ke
 
 	succeeded := false
 
-	// Compuate metadata.
+	// Compute metadata.
 
 	var goAuthKey *ecdsa.PrivateKey
 	// Use the provided authorization key,

--- a/seal.go
+++ b/seal.go
@@ -132,15 +132,214 @@ type KeyCreationParams struct {
 	// If set a key from elliptic.P256 must be used,
 	// if not set one is generated.
 	AuthKey *ecdsa.PrivateKey
+}
 
-	// RelatedSealedKey permits the creation of a new sealed key that shares the same authorization
-	// policy and TPM resources as the specified key. If this is supplied, then RelatedAuthKey
-	// must be provided, and PCRProfile, PCRPolicyCounterHandle and AuthKey must not be provided.
-	RelatedSealedKey *SealedKeyObject
+// SealKeyRequest corresponds to a key that should be sealed by SealKeyToTPMMultiple
+// to a file at the specified path.
+type SealKeyRequest struct {
+	Key  []byte
+	Path string
+}
 
-	// RelatedAuthKey is the private part of the dynamic authorization policy key associated with
-	// RelatedSealedKey.
-	RelatedAuthKey TPMPolicyAuthKey
+// SealKeyToTPMMultiple seals the supplied disk encryption keys to the storage hierarchy of the TPM. The keys are specified by
+// the keys argument, which is a slice of associated key and corresponding file path. The sealed key objects and associated
+// metadata that is required during early boot in order to unseal the keys again and unlock the associated encrypted volumes
+// are written to files at the specifed paths.
+//
+// This function requires knowledge of the authorization value for the storage hierarchy, which must be provided by calling
+// TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the provided authorization value is incorrect,
+// a AuthFailError error will be returned.
+//
+// This function expects there to be no files at the specified paths. If the keys argument references a file that already exists, a
+// wrapped *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be
+// returned if any file cannot be created and opened for writing.
+//
+// This function will create a NV index at the handle specified by the PCRPolicyCounterHandle field of the params argument if it is
+// not tpm2.HandleNull. If the handle is already in use, a TPMResourceExistsError error will be returned. In this case, the caller
+// will need to either choose a different handle or undefine the existing one. If it is not tpm2.HandleNull, then it must be a valid
+// NV index handle (MSO == 0x01), and the choice of handle should take in to consideration the reserved indices from the "Registry of
+// reserved TPM 2.0 handles and localities" specification. It is recommended that the handle is in the block reserved for owner
+// objects (0x01800000 - 0x01bfffff).
+//
+// All keys will be created with the same authorization policy, and will be protected with a PCR policy computed from the
+// PCRProtectionProfile supplied via the PCRProfile field of the params argument.
+//
+// If any part of this function fails, no sealed keys will be created.
+//
+// On success, this function returns the private part of the key used for authorizing PCR policy updates with
+// UpdateKeyPCRProtectionPolicyMultiple. This key doesn't need to be stored anywhere, and certainly mustn't be stored outside of the
+// encrypted volume protected with this sealed key file. The key is stored encrypted inside this sealed key file and returned from
+// future calls to SealedKeyObject.UnsealFromTPM.
+//
+// The authorization key can also be chosen and provided by setting
+// AuthKey in the params argument.
+func SealKeyToTPMMultiple(tpm *TPMConnection, keys []*SealKeyRequest, params *KeyCreationParams) (authKey TPMPolicyAuthKey, err error) {
+	// params is mandatory.
+	if params == nil {
+		return nil, errors.New("no KeyCreationParams provided")
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("no keys provided")
+	}
+
+	// Perform some sanity checks on params.
+	if params.AuthKey != nil && params.AuthKey.Curve != elliptic.P256() {
+		return nil, errors.New("provided AuthKey must be from elliptic.P256, no other curve is supported")
+	}
+
+	// Use the HMAC session created when the connection was opened rather than creating a new one.
+	session := tpm.HmacSession()
+
+	// Obtain a context for the SRK now. If we're called immediately after ProvisionTPM without closing the TPMConnection, we use the
+	// context cached by ProvisionTPM, which corresponds to the object provisioned. If not, we just unconditionally provision a new
+	// SRK as this function requires knowledge of the owner hierarchy authorization anyway. This way, we know that the primary key we
+	// seal to is good and future calls to ProvisionTPM won't provision an object that cannot unseal the key we protect.
+	srk := tpm.provisionedSrk
+	if srk == nil {
+		var err error
+		srk, err = provisionPrimaryKey(tpm.TPMContext, tpm.OwnerHandleContext(), tcg.SRKTemplate, tcg.SRKHandle, session)
+		switch {
+		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
+			return nil, AuthFailError{tpm2.HandleOwner}
+		case err != nil:
+			return nil, xerrors.Errorf("cannot provision storage root key: %w", err)
+		}
+	}
+
+	succeeded := false
+
+	// Compuate metadata.
+
+	var goAuthKey *ecdsa.PrivateKey
+	// Use the provided authorization key,
+	// otherwise create an asymmetric key for signing
+	// authorization policy updates, and authorizing dynamic
+	// authorization policy revocations.
+	if params.AuthKey != nil {
+		goAuthKey = params.AuthKey
+	} else {
+		goAuthKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot generate key for signing dynamic authorization policies: %w", err)
+		}
+	}
+	authPublicKey := createTPMPublicAreaForECDSAKey(&goAuthKey.PublicKey)
+	authKeyName, err := authPublicKey.Name()
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute name of signing key for dynamic policy authorization: %w", err)
+	}
+	authKey = goAuthKey.D.Bytes()
+
+	// Create PCR policy counter, if requested.
+	var pcrPolicyCounterPub *tpm2.NVPublic
+	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		pcrPolicyCounterPub, err = createPcrPolicyCounter(tpm.TPMContext, params.PCRPolicyCounterHandle, authKeyName, session)
+		switch {
+		case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
+			return nil, TPMResourceExistsError{params.PCRPolicyCounterHandle}
+		case isAuthFailError(err, tpm2.CommandNVDefineSpace, 1):
+			return nil, AuthFailError{tpm2.HandleOwner}
+		case err != nil:
+			return nil, xerrors.Errorf("cannot create new dynamic authorization policy counter: %w", err)
+		}
+		defer func() {
+			if succeeded {
+				return
+			}
+			index, err := tpm2.CreateNVIndexResourceContextFromPublic(pcrPolicyCounterPub)
+			if err != nil {
+				return
+			}
+			tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, session)
+		}()
+	}
+
+	template := makeSealedKeyTemplate()
+
+	// Compute the static policy - this never changes for the lifetime of this key file
+	staticPolicyData, authPolicy, err := computeStaticPolicy(template.NameAlg, &staticPolicyComputeParams{
+		key:                 authPublicKey,
+		pcrPolicyCounterPub: pcrPolicyCounterPub})
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute static authorization policy: %w", err)
+	}
+
+	// Define the template for the sealed key object, using the computed policy digest
+	template.AuthPolicy = authPolicy
+
+	// Create a dynamic authorization policy
+	pcrProfile := params.PCRProfile
+	if pcrProfile == nil {
+		pcrProfile = &PCRProtectionProfile{}
+	}
+	dynamicPolicyData, err := computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, currentMetadataVersion, template.NameAlg,
+		authPublicKey.NameAlg, goAuthKey, pcrPolicyCounterPub, nil, pcrProfile, session)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
+	}
+
+	// Clean up files on failure.
+	defer func() {
+		if succeeded {
+			return
+		}
+		for _, key := range keys {
+			os.Remove(key.Path)
+		}
+	}()
+
+	// Seal each key.
+	for _, key := range keys {
+		// Create the destination file
+		f, err := os.OpenFile(key.Path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot create key data file %s: %w", key.Path, err)
+		}
+		// We'll close this at the end of this loop, but make sure it is closed if the function
+		// returns early
+		defer f.Close()
+
+		// Create the sensitive data
+		sealedData, err := mu.MarshalToBytes(sealedData{Key: key.Key, AuthPrivateKey: authKey})
+		if err != nil {
+			panic(fmt.Sprintf("cannot marshal sensitive data: %v", err))
+		}
+		sensitive := tpm2.SensitiveCreate{Data: sealedData}
+
+		// Now create the sealed key object. The command is integrity protected so if the object at the handle we expect the SRK to reside
+		// at has a different name (ie, if we're connected via a resource manager and somebody swapped the object with another one), this
+		// command will fail. We take advantage of parameter encryption here too.
+		priv, pub, _, _, _, err := tpm.Create(srk, &sensitive, template, nil, nil, session.IncludeAttrs(tpm2.AttrCommandEncrypt))
+		if err != nil {
+			return nil, xerrors.Errorf("cannot create sealed data object for key: %w", err)
+		}
+
+		// Marshal the entire object (sealed key object and auxiliary data) to disk
+		data := keyData{
+			version:           currentMetadataVersion,
+			keyPrivate:        priv,
+			keyPublic:         pub,
+			authModeHint:      AuthModeNone,
+			staticPolicyData:  staticPolicyData,
+			dynamicPolicyData: dynamicPolicyData}
+
+		if err := data.write(f); err != nil {
+			return nil, xerrors.Errorf("cannot write key data file: %w", err)
+		}
+
+		f.Close()
+	}
+
+	// Increment the PCR policy counter for the first time.
+	if pcrPolicyCounterPub != nil {
+		if err := incrementPcrPolicyCounter(tpm.TPMContext, currentMetadataVersion, pcrPolicyCounterPub, nil, goAuthKey, authPublicKey,
+			session); err != nil {
+			return nil, xerrors.Errorf("cannot increment PCR policy counter: %w", err)
+		}
+	}
+
+	succeeded = true
+	return
 }
 
 // SealKeyToTPM seals the supplied disk encryption key to the storage hierarchy of the TPM. The sealed key object and associated
@@ -176,211 +375,7 @@ type KeyCreationParams struct {
 // The authorization key can also be chosen and provided by setting
 // AuthKey in the params argument.
 func SealKeyToTPM(tpm *TPMConnection, key []byte, keyPath string, params *KeyCreationParams) (authKey TPMPolicyAuthKey, err error) {
-	// params is mandatory.
-	if params == nil {
-		return nil, errors.New("no KeyCreationParams provided")
-	}
-
-	// Perform some sanity checks on params.
-	switch {
-	case params.RelatedSealedKey != nil:
-		if params.PCRProfile != nil {
-			return nil, errors.New("cannot provide PCRProfile when sealing a related key")
-		}
-		if params.PCRPolicyCounterHandle != tpm2.HandleNull {
-			return nil, errors.New("cannot provide PCRPolicyCounterHandle when sealing a related key")
-		}
-		if params.AuthKey != nil {
-			return nil, errors.New("cannot provide AuthKey when sealing a related key")
-		}
-	default:
-		if params.AuthKey != nil && params.AuthKey.Curve != elliptic.P256() {
-			return nil, errors.New("provided AuthKey must be from elliptic.P256, no other curve is supported")
-		}
-	}
-
-	// Use the HMAC session created when the connection was opened rather than creating a new one.
-	session := tpm.HmacSession()
-
-	// Obtain a context for the SRK now. If we're called immediately after ProvisionTPM without closing the TPMConnection, we use the
-	// context cached by ProvisionTPM, which corresponds to the object provisioned. If not, we just unconditionally provision a new
-	// SRK as this function requires knowledge of the owner hierarchy authorization anyway. This way, we know that the primary key we
-	// seal to is good and future calls to ProvisionTPM won't provision an object that cannot unseal the key we protect.
-	srk := tpm.provisionedSrk
-	if srk == nil {
-		var err error
-		srk, err = provisionPrimaryKey(tpm.TPMContext, tpm.OwnerHandleContext(), tcg.SRKTemplate, tcg.SRKHandle, session)
-		switch {
-		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
-			return nil, AuthFailError{tpm2.HandleOwner}
-		case err != nil:
-			return nil, xerrors.Errorf("cannot provision storage root key: %w", err)
-		}
-	}
-
-	succeeded := false
-
-	// Create destination files
-	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create key data file: %w", err)
-	}
-	defer func() {
-		keyFile.Close()
-		if succeeded {
-			return
-		}
-		os.Remove(keyPath)
-	}()
-
-	// Obtain or create metadata.
-	var metadataVersion uint32
-	var template *tpm2.Public
-	var staticPolicyData *staticPolicyData
-	var dynamicPolicyData *dynamicPolicyData
-
-	if params.RelatedSealedKey != nil {
-		// We are creating a new key that is related to an existing key. Validate that the existing key is correct
-		// and then copy its metadata.
-
-		goAuthKey, err := createECDSAPrivateKeyFromTPM(params.RelatedSealedKey.data.staticPolicyData.authPublicKey, tpm2.ECCParameter(params.RelatedAuthKey))
-		if err != nil {
-			return nil, InvalidKeyFileError{fmt.Sprintf("cannot create auth key: %w", err)}
-		}
-		if _, err := params.RelatedSealedKey.data.validate(tpm.TPMContext, goAuthKey, session); err != nil {
-			if isKeyFileError(err) {
-				return nil, InvalidKeyFileError{err.Error()}
-			}
-			return nil, xerrors.Errorf("cannot validate related key: %w", err)
-		}
-		authKey = params.RelatedAuthKey
-		metadataVersion = params.RelatedSealedKey.data.version
-		if metadataVersion < 1 {
-			// Keys have independent auth mode which isn't possible for v0 keys because they will
-			// share a NV index for the PIN
-			return nil, errors.New("cannot seal related key with metadata version < 1")
-		}
-		template = &tpm2.Public{
-			Type:       params.RelatedSealedKey.data.keyPublic.Type,
-			NameAlg:    params.RelatedSealedKey.data.keyPublic.NameAlg,
-			Attrs:      params.RelatedSealedKey.data.keyPublic.Attrs,
-			AuthPolicy: params.RelatedSealedKey.data.keyPublic.AuthPolicy,
-			Params:     params.RelatedSealedKey.data.keyPublic.Params}
-		staticPolicyData = params.RelatedSealedKey.data.staticPolicyData
-		dynamicPolicyData = params.RelatedSealedKey.data.dynamicPolicyData
-	} else {
-		// We are creating a new key that is not based on an existing key. Compute new policy metadata and
-		// create required resources.
-
-		var goAuthKey *ecdsa.PrivateKey
-		// Use the provided authorization key,
-		// otherwise create an asymmetric key for signing
-		// authorization policy updates, and authorizing dynamic
-		// authorization policy revocations.
-		if params.AuthKey != nil {
-			goAuthKey = params.AuthKey
-		} else {
-			goAuthKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-			if err != nil {
-				return nil, xerrors.Errorf("cannot generate key for signing dynamic authorization policies: %w", err)
-			}
-		}
-		authPublicKey := createTPMPublicAreaForECDSAKey(&goAuthKey.PublicKey)
-		authKeyName, err := authPublicKey.Name()
-		if err != nil {
-			return nil, xerrors.Errorf("cannot compute name of signing key for dynamic policy authorization: %w", err)
-		}
-		authKey = goAuthKey.D.Bytes()
-
-		// Create PCR policy counter, if requested.
-		var pcrPolicyCounterPub *tpm2.NVPublic
-		if params.PCRPolicyCounterHandle != tpm2.HandleNull {
-			pcrPolicyCounterPub, err = createPcrPolicyCounter(tpm.TPMContext, params.PCRPolicyCounterHandle, authKeyName, session)
-			switch {
-			case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
-				return nil, TPMResourceExistsError{params.PCRPolicyCounterHandle}
-			case isAuthFailError(err, tpm2.CommandNVDefineSpace, 1):
-				return nil, AuthFailError{tpm2.HandleOwner}
-			case err != nil:
-				return nil, xerrors.Errorf("cannot create new dynamic authorization policy counter: %w", err)
-			}
-			defer func() {
-				if succeeded {
-					return
-				}
-				index, err := tpm2.CreateNVIndexResourceContextFromPublic(pcrPolicyCounterPub)
-				if err != nil {
-					return
-				}
-				tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, session)
-			}()
-		}
-
-		metadataVersion = currentMetadataVersion
-		template = makeSealedKeyTemplate()
-
-		// Compute the static policy - this never changes for the lifetime of this key file
-		var authPolicy tpm2.Digest
-		staticPolicyData, authPolicy, err = computeStaticPolicy(template.NameAlg, &staticPolicyComputeParams{
-			key:                 authPublicKey,
-			pcrPolicyCounterPub: pcrPolicyCounterPub})
-		if err != nil {
-			return nil, xerrors.Errorf("cannot compute static authorization policy: %w", err)
-		}
-
-		// Define the template for the sealed key object, using the computed policy digest
-		template.AuthPolicy = authPolicy
-
-		// Create a dynamic authorization policy
-		pcrProfile := params.PCRProfile
-		if pcrProfile == nil {
-			pcrProfile = &PCRProtectionProfile{}
-		}
-		dynamicPolicyData, err = computeSealedKeyDynamicAuthPolicy(tpm.TPMContext, currentMetadataVersion, template.NameAlg,
-			authPublicKey.NameAlg, goAuthKey, pcrPolicyCounterPub, nil, pcrProfile, session)
-		if err != nil {
-			return nil, xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
-		}
-
-		// Increment the PCR policy counter for the first time.
-		if pcrPolicyCounterPub != nil {
-			if err := incrementPcrPolicyCounter(tpm.TPMContext, currentMetadataVersion, pcrPolicyCounterPub, nil, goAuthKey, authPublicKey,
-				session); err != nil {
-				return nil, xerrors.Errorf("cannot increment PCR policy counter: %w", err)
-			}
-		}
-	}
-
-	// Create the sensitive data
-	sealedData, err := mu.MarshalToBytes(sealedData{Key: key, AuthPrivateKey: authKey})
-	if err != nil {
-		panic(fmt.Sprintf("cannot marshal sensitive data: %v", err))
-	}
-	sensitive := tpm2.SensitiveCreate{Data: sealedData}
-
-	// Now create the sealed key object. The command is integrity protected so if the object at the handle we expect the SRK to reside
-	// at has a different name (ie, if we're connected via a resource manager and somebody swapped the object with another one), this
-	// command will fail. We take advantage of parameter encryption here too.
-	priv, pub, _, _, _, err := tpm.Create(srk, &sensitive, template, nil, nil, session.IncludeAttrs(tpm2.AttrCommandEncrypt))
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create sealed data object for key: %w", err)
-	}
-
-	// Marshal the entire object (sealed key object and auxiliary data) to disk
-	data := keyData{
-		version:           currentMetadataVersion,
-		keyPrivate:        priv,
-		keyPublic:         pub,
-		authModeHint:      AuthModeNone,
-		staticPolicyData:  staticPolicyData,
-		dynamicPolicyData: dynamicPolicyData}
-
-	if err := data.write(keyFile); err != nil {
-		return nil, xerrors.Errorf("cannot write key data file: %w", err)
-	}
-
-	succeeded = true
-	return
+	return SealKeyToTPMMultiple(tpm, []*SealKeyRequest{{Key: key, Path: keyPath}}, params)
 }
 
 func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keyPath string, authData interface{}, pcrProfile *PCRProtectionProfile, session tpm2.SessionContext) error {

--- a/secboot_test.go
+++ b/secboot_test.go
@@ -127,6 +127,9 @@ func undefineKeyNVSpace(t *testing.T, tpm *TPMConnection, path string) {
 		return
 	}
 	rc, err := tpm.CreateResourceContextFromTPM(h)
+	if tpm2.IsResourceUnavailableError(err, h) {
+		return
+	}
 	if err != nil {
 		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
 	}

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -98,63 +98,42 @@ func TestUnsealRelated(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key1 := make([]byte, 64)
-	rand.Read(key1)
-	key2 := make([]byte, 64)
-	rand.Read(key2)
-
 	tmpDir, err := ioutil.TempDir("", "_TestUnsealRelated_")
 	if err != nil {
 		t.Fatalf("Creating temporary directory failed: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	keyFile1 := tmpDir + "/keydata1"
+	keys := []*SealKeyRequest{
+		{Key: make([]byte, 64), Path: filepath.Join(tmpDir, "keydata1")},
+		{Key: make([]byte, 64), Path: filepath.Join(tmpDir, "keydata2")}}
+	for _, k := range keys {
+		rand.Read(k.Key)
+	}
 
-	authKey, err := SealKeyToTPM(tpm, key1, keyFile1, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x0181fff0})
+	authKey, err := SealKeyToTPMMultiple(tpm, keys, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x0181fff0})
 	if err != nil {
-		t.Fatalf("SealKeyToTPM failed: %v", err)
+		t.Fatalf("SealKeyToTPMMultiple failed: %v", err)
 	}
-	defer undefineKeyNVSpace(t, tpm, keyFile1)
+	defer undefineKeyNVSpace(t, tpm, keys[0].Path)
 
-	k1, err := ReadSealedKeyObject(keyFile1)
-	if err != nil {
-		t.Fatalf("ReadSealedKeyObject failed: %v", err)
-	}
+	for _, key := range keys {
+		k, err := ReadSealedKeyObject(key.Path)
+		if err != nil {
+			t.Fatalf("ReadSealedKeyObject failed: %v", err)
+		}
 
-	keyFile2 := tmpDir + "/keydata2"
+		keyUnsealed, authKeyUnsealed, err := k.UnsealFromTPM(tpm, "")
+		if err != nil {
+			t.Fatalf("UnsealFromTPM failed: %v", err)
+		}
 
-	if _, err = SealKeyToTPM(tpm, key2, keyFile2, &KeyCreationParams{PCRPolicyCounterHandle: tpm2.HandleNull, RelatedSealedKey: k1, RelatedAuthKey: authKey}); err != nil {
-		t.Fatalf("SealKeyToTPM failed: %v", err)
-	}
-
-	k2, err := ReadSealedKeyObject(keyFile2)
-	if err != nil {
-		t.Fatalf("ReadSealedKeyObject failed: %v", err)
-	}
-
-	keyUnsealed, authKeyUnsealed, err := k1.UnsealFromTPM(tpm, "")
-	if err != nil {
-		t.Fatalf("UnsealFromTPM failed: %v", err)
-	}
-
-	if !bytes.Equal(key1, keyUnsealed) {
-		t.Errorf("TPM returned the wrong key")
-	}
-	if !bytes.Equal(authKey, authKeyUnsealed) {
-		t.Errorf("TPM returned the wrong auth key")
-	}
-
-	keyUnsealed, authKeyUnsealed, err = k2.UnsealFromTPM(tpm, "")
-	if err != nil {
-		t.Fatalf("UnsealFromTPM failed: %v", err)
-	}
-
-	if !bytes.Equal(key2, keyUnsealed) {
-		t.Errorf("TPM returned the wrong key")
-	}
-	if !bytes.Equal(authKey, authKeyUnsealed) {
-		t.Errorf("TPM returned the wrong auth key")
+		if !bytes.Equal(keyUnsealed, key.Key) {
+			t.Errorf("TPM returned the wrong key")
+		}
+		if !bytes.Equal(authKeyUnsealed, authKey) {
+			t.Errorf("TPM returned the wrong auth key")
+		}
 	}
 }
 


### PR DESCRIPTION
This introduces the ability to create keys that are related and share
authorization policies, by adding a new RelatedSealedKey field to
KeyCreationParams. If this is initialized to an existing key, then
SealKeyToTPM will seal a new key with an identical authorization
policy after performing validation on the original key data, as
opposed to computing a new authorization policy. Keys that share a
policy also share a PCR policy counter, if one is defined.

This also requires the private part of the signing key for authorizing
policy updates in the form returned by SealKeyToTPM and UnsealFromTPM
(so that it can be included in the new sealed key object), which is
provided by another new field in KeyCreationParams (RelatedAuthKey).

I'm not sure of the naming yet - "related" is probably the best thing
I can think of at the moment.