### PR TITLE
Add ActivateVolumeWithMultipleTPMSealedKeys

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -568,6 +568,10 @@ type ActivateVolumeOptions struct {
 // If the volume is successfully activated, either with a TPM sealed key or the fallback recovery key, this function returns true.
 // If it is not successfully activated, then this function returns false.
 func ActivateVolumeWithMultipleTPMSealedKeys(tpm *TPMConnection, volumeName, sourceDevicePath string, keyPaths []string, passphraseReader io.Reader, options *ActivateVolumeOptions) (bool, error) {
+	if len(keyPaths) == 0 {
+		return false, errors.New("no key files provided")
+	}
+
 	if options.PassphraseTries < 0 {
 		return false, errors.New("invalid PassphraseTries")
 	}

--- a/crypt.go
+++ b/crypt.go
@@ -392,7 +392,7 @@ type activateWithTPMKeyError struct {
 }
 
 func (e *activateWithTPMKeyError) Error() string {
-	return e.err.Error() + " (" + e.path + ")"
+	return fmt.Sprintf("%s: %v", e.path, e.err)
 }
 
 func (e *activateWithTPMKeyError) Unwrap() error {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -665,9 +665,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		success:           true,
 		errCodes:          []KeyErrorCode{KeyErrorTPMLockout, KeyErrorTPMLockout},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot unseal key: the TPM is in DA lockout mode " +
-			"\\(.*/keydata\\)\\), \\(cannot unseal key: the TPM is in DA lockout mode \\(.*/keydata\\)\\)\\] but activation with recovery " +
-			"key was successful"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\nbut activation with recovery key was successful"},
 	})
 }
 
@@ -698,9 +699,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		success:           true,
 		errCodes:          []KeyErrorCode{KeyErrorTPMProvisioning, KeyErrorTPMProvisioning},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot unseal key: the TPM is not correctly provisioned " +
-			"\\(.*/keydata\\)\\), \\(cannot unseal key: the TPM is not correctly provisioned \\(.*/keydata\\)\\)\\] but activation with recovery " +
-			"key was successful"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot unseal key: the TPM is not correctly provisioned" +
+			"\n- .*/keydata: cannot unseal key: the TPM is not correctly provisioned" +
+			"\nbut activation with recovery key was successful"},
 	})
 }
 
@@ -727,9 +729,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		success:           true,
 		errCodes:          []KeyErrorCode{KeyErrorInvalidFile, KeyErrorInvalidFile},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5 " +
-			"\\(.*/keydata\\)\\), \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5 \\(.*/keydata\\)\\)\\] but activation with recovery " +
-			"key was successful"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5" +
+			"\n- .*/keydata: cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5" +
+			"\nbut activation with recovery key was successful"},
 	})
 }
 
@@ -753,9 +756,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		keyFiles:   []string{s.keyFile, keyFile},
 		errCodes:   []KeyErrorCode{KeyErrorTPMLockout, KeyErrorTPMLockout},
 		errChecker: ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot unseal key: the TPM is in DA lockout mode " +
-			"\\(.*/keydata\\)\\), \\(cannot unseal key: the TPM is in DA lockout mode \\(.*/keydata\\)\\)\\] and activation with " +
-			"recovery key failed \\(no recovery key tries permitted\\)"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\nand activation with recovery key failed: no recovery key tries permitted"},
 	})
 }
 
@@ -782,9 +786,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		passphrases:       []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
 		errCodes:          []KeyErrorCode{KeyErrorTPMLockout, KeyErrorTPMLockout},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot unseal key: the TPM is in DA lockout mode " +
-			"\\(.*/keydata\\)\\), \\(cannot unseal key: the TPM is in DA lockout mode \\(.*/keydata\\)\\)\\] and activation with " +
-			"recovery key failed \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5\\)"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\nand activation with recovery key failed: " +
+			"cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5"},
 	})
 }
 
@@ -810,9 +816,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		success:           true,
 		errCodes:          []KeyErrorCode{KeyErrorPassphraseFail, KeyErrorPassphraseFail},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(no PIN tries permitted when a PIN is required " +
-			"\\(.*/keydata\\)\\), \\(no PIN tries permitted when a PIN is required \\(.*/keydata\\)\\)\\] but activation with recovery " +
-			"key was successful"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: no PIN tries permitted when a PIN is required" +
+			"\n- .*/keydata: no PIN tries permitted when a PIN is required" +
+			"\nbut activation with recovery key was successful"},
 	})
 }
 
@@ -838,11 +845,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		success:           true,
 		errCodes:          []KeyErrorCode{KeyErrorInvalidFile, KeyErrorInvalidFile},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot unseal key: invalid key data file: cannot " +
-			"complete authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data " +
-			"\\(.*/keydata\\)\\), \\(cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
-			"complete OR assertions: current session digest not found in policy data \\(.*/keydata\\)\\)\\] but activation with recovery " +
-			"key was successful"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
+			"complete OR assertions: current session digest not found in policy data" +
+			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
+			"complete OR assertions: current session digest not found in policy data" +
+			"\nbut activation with recovery key was successful"},
 	})
 }
 
@@ -870,10 +878,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		success:           true,
 		errCodes:          []KeyErrorCode{KeyErrorPassphraseFail, KeyErrorInvalidFile},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot unseal key: the provided PIN is incorrect " +
-			"\\(.*/keydata\\)\\), \\(cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
-			"complete OR assertions: current session digest not found in policy data \\(.*/keydata\\)\\)\\] but activation with recovery " +
-			"key was successful"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot unseal key: the provided PIN is incorrect" +
+			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
+			"complete OR assertions: current session digest not found in policy data" +
+			"\nbut activation with recovery key was successful"},
 	})
 }
 
@@ -904,9 +913,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		success:           true,
 		errCodes:          []KeyErrorCode{KeyErrorTPMLockout, KeyErrorTPMLockout},
 		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed keys \\[\\(cannot unseal key: the TPM is in DA lockout mode " +
-			"\\(.*/keydata\\)\\), \\(cannot unseal key: the TPM is in DA lockout mode \\(.*/keydata\\)\\)\\] but activation with recovery " +
-			"key was successful"},
+		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\nbut activation with recovery key was successful"},
 	})
 }
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -359,7 +359,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys1(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -378,7 +378,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys2(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -397,7 +397,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys3(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	authPrivateKey, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -416,7 +416,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys4(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -436,7 +436,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys5(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -460,7 +460,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys6(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	pcrProfile := NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7).ExtendPCR(tpm2.HashAlgorithmSHA256, 7, make([]byte, 32))
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: tpm2.HandleNull})
@@ -481,7 +481,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys7(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -501,7 +501,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys8(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -525,7 +525,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys9(c 
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	authPrivateKey, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -549,7 +549,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys10(c
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -573,7 +573,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys11(c
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	pcrProfile := NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7).ExtendPCR(tpm2.HashAlgorithmSHA256, 7, make([]byte, 32))
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: tpm2.HandleNull})
@@ -647,7 +647,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -667,7 +667,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
-			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata2: cannot unseal key: the TPM is in DA lockout mode" +
 			"\nbut activation with recovery key was successful"},
 	})
 }
@@ -678,7 +678,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -701,7 +701,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is not correctly provisioned" +
-			"\n- .*/keydata: cannot unseal key: the TPM is not correctly provisioned" +
+			"\n- .*/keydata2: cannot unseal key: the TPM is not correctly provisioned" +
 			"\nbut activation with recovery key was successful"},
 	})
 }
@@ -716,7 +716,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	c.Assert(os.RemoveAll(filepath.Join(s.mockKeyslotsDir, "1")), IsNil)
 	s.addMockKeyslot(c, incorrectKey)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -731,7 +731,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5" +
-			"\n- .*/keydata: cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5" +
+			"\n- .*/keydata2: cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5" +
 			"\nbut activation with recovery key was successful"},
 	})
 }
@@ -742,7 +742,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -758,7 +758,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker: ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
-			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata2: cannot unseal key: the TPM is in DA lockout mode" +
 			"\nand activation with recovery key failed: no recovery key tries permitted"},
 	})
 }
@@ -769,7 +769,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -788,7 +788,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
-			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata2: cannot unseal key: the TPM is in DA lockout mode" +
 			"\nand activation with recovery key failed: " +
 			"cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5"},
 	})
@@ -801,7 +801,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -818,7 +818,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: no PIN tries permitted when a PIN is required" +
-			"\n- .*/keydata: no PIN tries permitted when a PIN is required" +
+			"\n- .*/keydata2: no PIN tries permitted when a PIN is required" +
 			"\nbut activation with recovery key was successful"},
 	})
 }
@@ -829,7 +829,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -848,7 +848,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
 			"complete OR assertions: current session digest not found in policy data" +
-			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
+			"\n- .*/keydata2: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
 			"complete OR assertions: current session digest not found in policy data" +
 			"\nbut activation with recovery key was successful"},
 	})
@@ -861,7 +861,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	pcrProfile := NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7).ExtendPCR(tpm2.HashAlgorithmSHA256, 7, make([]byte, 32))
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: tpm2.HandleNull})
@@ -880,7 +880,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the provided PIN is incorrect" +
-			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
+			"\n- .*/keydata2: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
 			"complete OR assertions: current session digest not found in policy data" +
 			"\nbut activation with recovery key was successful"},
 	})
@@ -892,7 +892,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	rand.Read(key)
 	s.addMockKeyslot(c, key)
 
-	keyFile := filepath.Join(c.MkDir(), "keydata")
+	keyFile := filepath.Join(c.MkDir(), "keydata2")
 
 	_, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, IsNil)
@@ -915,7 +915,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 		errChecker:        ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
-			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
+			"\n- .*/keydata2: cannot unseal key: the TPM is in DA lockout mode" +
 			"\nbut activation with recovery key was successful"},
 	})
 }

--- a/errors.go
+++ b/errors.go
@@ -161,18 +161,14 @@ type ActivateWithMultipleTPMSealedKeysError struct {
 
 func (e *ActivateWithMultipleTPMSealedKeysError) Error() string {
 	var s bytes.Buffer
-	fmt.Fprintf(&s, "cannot activate with TPM sealed keys [")
-	for i, err := range e.TPMErrs {
-		if i > 0 {
-			fmt.Fprintf(&s, ", ")
-		}
-		fmt.Fprintf(&s, "(%v)", err)
+	fmt.Fprintf(&s, "cannot activate with TPM sealed keys:")
+	for _, err := range e.TPMErrs {
+		fmt.Fprintf(&s, "\n- %v", err)
 	}
-	fmt.Fprintf(&s, "] ")
 	if e.RecoveryKeyUsageErr != nil {
-		fmt.Fprintf(&s, "and activation with recovery key failed (%v)", e.RecoveryKeyUsageErr)
+		fmt.Fprintf(&s, "\nand activation with recovery key failed: %v", e.RecoveryKeyUsageErr)
 	} else {
-		fmt.Fprintf(&s, "but activation with recovery key was successful")
+		fmt.Fprintf(&s, "\nbut activation with recovery key was successful")
 	}
 	return s.String()
 }

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,7 @@
 package secboot
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -145,4 +146,33 @@ func (e *ActivateWithTPMSealedKeyError) Error() string {
 		return fmt.Sprintf("cannot activate with TPM sealed key (%v) and activation with recovery key failed (%v)", e.TPMErr, e.RecoveryKeyUsageErr)
 	}
 	return fmt.Sprintf("cannot activate with TPM sealed key (%v) but activation with recovery key was successful", e.TPMErr)
+}
+
+// ActivateWithMultipleTPMSealedKeysError is returned from ActivateVolumeWithMultipleTPMSealedKeys if activation with the
+// TPM protected keys failed.
+type ActivateWithMultipleTPMSealedKeysError struct {
+	// TPMErrs details the errors that occurred during activation with the TPM sealed keys.
+	TPMErrs []error
+
+	// RecoveryKeyUsageErr details the error that occurred during activation with the fallback recovery key, if activation
+	// with the recovery key was also unsuccessful.
+	RecoveryKeyUsageErr error
+}
+
+func (e *ActivateWithMultipleTPMSealedKeysError) Error() string {
+	var s bytes.Buffer
+	fmt.Fprintf(&s, "cannot activate with TPM sealed keys [")
+	for i, err := range e.TPMErrs {
+		if i > 0 {
+			fmt.Fprintf(&s, ", ")
+		}
+		fmt.Fprintf(&s, "(%v)", err)
+	}
+	fmt.Fprintf(&s, "] ")
+	if e.RecoveryKeyUsageErr != nil {
+		fmt.Fprintf(&s, "and activation with recovery key failed (%v)", e.RecoveryKeyUsageErr)
+	} else {
+		fmt.Fprintf(&s, "but activation with recovery key was successful")
+	}
+	return s.String()
 }


### PR DESCRIPTION
This adds the ability to activate a volume with multiple TPM sealed key objects. The existing API is not just a wrapper around the new API.

I'm not sure what to do about returning errors from this function - I've added a new ActivateWithMultipleTPMSealedKeysError which has the ability to access each of the individual errors, but I'm not sure that it's actually worth surfacing all of this information.

I've renamed RecoveryKeyUsageReason to KeyErrorCode, as its usage is now more associated with why a key failed rather than why the recovery key was used. Where multiple keys are supplied and they all fail, they each have their own error code.