### PR TITLE
Update the KDF parameters for the primary key

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -945,7 +945,7 @@ func InitializeLUKS2Container(devicePath, label string, key []byte, options *Ini
 		// entropy of at least 32 bytes, and increased cost doesn't provide a security benefit because
 		// this key and these settings are already more secure than the recovery key. Increased cost
 		// here only slows down unlocking.
-		"--pbkdf", "argon2i", "--iter-time", "200",
+		"--pbkdf", "argon2i", "--iter-time", "100",
 		// set LUKS2 label
 		"--label", label,
 	}
@@ -1061,7 +1061,7 @@ func ChangeLUKS2KeyUsingRecoveryKey(devicePath string, recoveryKey RecoveryKey, 
 		// entropy of at least 32 bytes, and increased cost doesn't provide a security benefit because
 		// this key and these settings are already more secure than the recovery key. Increased cost
 		// here only slows down unlocking.
-		"--pbkdf", "argon2i", "--iter-time", "200",
+		"--pbkdf", "argon2i", "--iter-time", "100",
 		// always have the main key in slot 0 for now
 		"--key-slot", "0"}); err != nil {
 		return err

--- a/crypt.go
+++ b/crypt.go
@@ -914,7 +914,7 @@ func validateInitializeLUKS2Options(options *InitializeLUKS2ContainerOptions) er
 // be called on a partition that isn't mapped. The label for the new LUKS2 container is provided via the label argument.
 //
 // The initial key used for unlocking the container is provided via the key argument, and must be a cryptographically secure
-// 64-byte random number. The key should be stored encrypted by using SealKeyToTPM.
+// random number of at least 32-bytes. The key should be encrypted by using SealKeyToTPM.
 //
 // The container will be configured to encrypt data with AES-256 and XTS block cipher mode.
 //
@@ -923,8 +923,8 @@ func validateInitializeLUKS2Options(options *InitializeLUKS2ContainerOptions) er
 // WARNING: This function is destructive. Calling this on an existing LUKS container will make the data contained inside of it
 // irretrievable.
 func InitializeLUKS2Container(devicePath, label string, key []byte, options *InitializeLUKS2ContainerOptions) error {
-	if len(key) != 64 {
-		return fmt.Errorf("expected a key length of 512-bits (got %d)", len(key)*8)
+	if len(key) < 32 {
+		return fmt.Errorf("expected a key length of at least 256-bits (got %d)", len(key)*8)
 	}
 	if err := validateInitializeLUKS2Options(options); err != nil {
 		return err
@@ -941,10 +941,11 @@ func InitializeLUKS2Container(devicePath, label string, key []byte, options *Ini
 		"--key-file", "-",
 		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)
 		"--cipher", "aes-xts-plain64", "--key-size", "512",
-		// use argon2i as the KDF with minimum cost (lowest possible time and memory costs). This is done
-		// because the supplied input key has the same entropy (512-bits) as the derived key and therefore
-		// increased time or memory cost don't provide a security benefit (but does slow down unlocking).
-		"--pbkdf", "argon2i", "--pbkdf-force-iterations", "4", "--pbkdf-memory", "32",
+		// use argon2i as the KDF with reduced cost. This is done because the supplied input key has an
+		// entropy of at least 32 bytes, and increased cost doesn't provide a security benefit because
+		// this key and these settings are already more secure than the recovery key. Increased cost
+		// here only slows down unlocking.
+		"--pbkdf", "argon2i", "--iter-time", "200",
 		// set LUKS2 label
 		"--label", label,
 	}
@@ -1045,8 +1046,8 @@ func AddRecoveryKeyToLUKS2Container(devicePath string, key []byte, recoveryKey R
 // the new key. This is not a problem, because this function is intended to be called in the scenario that the default key cannot
 // be used to activate the LUKS2 container.
 func ChangeLUKS2KeyUsingRecoveryKey(devicePath string, recoveryKey RecoveryKey, key []byte) error {
-	if len(key) != 64 {
-		return fmt.Errorf("expected a key length of 512-bits (got %d)", len(key)*8)
+	if len(key) < 32 {
+		return fmt.Errorf("expected a key length of at least 256-bits (got %d)", len(key)*8)
 	}
 
 	cmd := exec.Command("cryptsetup", "luksKillSlot", "--key-file", "-", devicePath, "0")
@@ -1056,10 +1057,11 @@ func ChangeLUKS2KeyUsingRecoveryKey(devicePath string, recoveryKey RecoveryKey, 
 	}
 
 	if err := addKeyToLUKS2Container(devicePath, recoveryKey[:], key, []string{
-		// use argon2i as the KDF with minimum cost (lowest possible time and memory costs). This is done
-		// because the supplied input key has the same entropy (512-bits) as the derived key and therefore
-		// increased time or memory cost don't provide a security benefit (but does slow down unlocking).
-		"--pbkdf", "argon2i", "--pbkdf-force-iterations", "4", "--pbkdf-memory", "32",
+		// use argon2i as the KDF with reduced cost. This is done because the supplied input key has an
+		// entropy of at least 32 bytes, and increased cost doesn't provide a security benefit because
+		// this key and these settings are already more secure than the recovery key. Increased cost
+		// here only slows down unlocking.
+		"--pbkdf", "argon2i", "--iter-time", "200",
 		// always have the main key in slot 0 for now
 		"--key-slot", "0"}); err != nil {
 		return err

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1928,7 +1928,7 @@ func (s *cryptSuite) testInitializeLUKS2Container(c *C, data *testInitializeLUKS
 		"-q", "luksFormat", "--type", "luks2",
 		"--key-file", "-", "--cipher", "aes-xts-plain64",
 		"--key-size", "512",
-		"--pbkdf", "argon2i", "--iter-time", "200",
+		"--pbkdf", "argon2i", "--iter-time", "100",
 		"--label", data.label, data.devicePath,
 	}
 	if data.formatArgs != nil {
@@ -1983,7 +1983,7 @@ func (s *cryptSuite) TestInitializeLUKS2ContainerWithOptions(c *C) {
 			"-q", "luksFormat", "--type", "luks2",
 			"--key-file", "-", "--cipher", "aes-xts-plain64",
 			"--key-size", "512",
-			"--pbkdf", "argon2i", "--iter-time", "200",
+			"--pbkdf", "argon2i", "--iter-time", "100",
 			"--label", "test",
 			"--luks2-metadata-size", "2048k",
 			"--luks2-keyslots-size", "3072k",
@@ -2125,7 +2125,7 @@ func (s *cryptSuite) testChangeLUKS2KeyUsingRecoveryKey(c *C, data *testChangeLU
 	c.Assert(len(call), Equals, 12)
 	c.Check(call[0:3], DeepEquals, []string{"cryptsetup", "luksAddKey", "--key-file"})
 	c.Check(call[3], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-	c.Check(call[4:12], DeepEquals, []string{"--pbkdf", "argon2i", "--iter-time", "200", "--key-slot", "0", data.devicePath, "-"})
+	c.Check(call[4:12], DeepEquals, []string{"--pbkdf", "argon2i", "--iter-time", "100", "--key-slot", "0", data.devicePath, "-"})
 
 	c.Check(s.mockCryptsetup.Calls()[2], DeepEquals, []string{"cryptsetup", "config", "--priority", "prefer", "--key-slot", "0", data.devicePath})
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1928,9 +1928,8 @@ func (s *cryptSuite) testInitializeLUKS2Container(c *C, data *testInitializeLUKS
 		"-q", "luksFormat", "--type", "luks2",
 		"--key-file", "-", "--cipher", "aes-xts-plain64",
 		"--key-size", "512",
-		"--pbkdf", "argon2i", "--pbkdf-force-iterations", "4",
-		"--pbkdf-memory", "32", "--label",
-		data.label, data.devicePath,
+		"--pbkdf", "argon2i", "--iter-time", "200",
+		"--label", data.label, data.devicePath,
 	}
 	if data.formatArgs != nil {
 		formatArgs = data.formatArgs
@@ -1984,8 +1983,7 @@ func (s *cryptSuite) TestInitializeLUKS2ContainerWithOptions(c *C) {
 			"-q", "luksFormat", "--type", "luks2",
 			"--key-file", "-", "--cipher", "aes-xts-plain64",
 			"--key-size", "512",
-			"--pbkdf", "argon2i", "--pbkdf-force-iterations", "4",
-			"--pbkdf-memory", "32",
+			"--pbkdf", "argon2i", "--iter-time", "200",
 			"--label", "test",
 			"--luks2-metadata-size", "2048k",
 			"--luks2-keyslots-size", "3072k",
@@ -1995,7 +1993,7 @@ func (s *cryptSuite) TestInitializeLUKS2ContainerWithOptions(c *C) {
 }
 
 func (s *cryptSuite) TestInitializeLUKS2ContainerInvalidKeySize(c *C) {
-	c.Check(InitializeLUKS2Container("/dev/sda1", "data", s.tpmKey[0:32], nil), ErrorMatches, "expected a key length of 512-bits \\(got 256\\)")
+	c.Check(InitializeLUKS2Container("/dev/sda1", "data", s.tpmKey[0:16], nil), ErrorMatches, "expected a key length of at least 256-bits \\(got 128\\)")
 }
 
 func (s *cryptSuite) TestInitializeLUKS2ContainerMetadataKiBSize(c *C) {
@@ -2124,10 +2122,10 @@ func (s *cryptSuite) testChangeLUKS2KeyUsingRecoveryKey(c *C, data *testChangeLU
 	c.Check(s.mockCryptsetup.Calls()[0], DeepEquals, []string{"cryptsetup", "luksKillSlot", "--key-file", "-", data.devicePath, "0"})
 
 	call := s.mockCryptsetup.Calls()[1]
-	c.Assert(len(call), Equals, 14)
+	c.Assert(len(call), Equals, 12)
 	c.Check(call[0:3], DeepEquals, []string{"cryptsetup", "luksAddKey", "--key-file"})
 	c.Check(call[3], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-	c.Check(call[4:14], DeepEquals, []string{"--pbkdf", "argon2i", "--pbkdf-force-iterations", "4", "--pbkdf-memory", "32", "--key-slot", "0", data.devicePath, "-"})
+	c.Check(call[4:12], DeepEquals, []string{"--pbkdf", "argon2i", "--iter-time", "200", "--key-slot", "0", data.devicePath, "-"})
 
 	c.Check(s.mockCryptsetup.Calls()[2], DeepEquals, []string{"cryptsetup", "config", "--priority", "prefer", "--key-slot", "0", data.devicePath})
 


### PR DESCRIPTION
This updates the KDF parameters for the primary key to not
hardcode minimum values for iterations and memory cost, and instead
specify a benchmark time of 200ms.