### PR TITLE
Add platform agnostic keydata

### DIFF
--- a/internal/testutil/checkers.go
+++ b/internal/testutil/checkers.go
@@ -39,8 +39,8 @@ func (checker *hasKeyChecker) Check(params []interface{}, names []string) (resul
 	}
 
 	k := reflect.ValueOf(params[1])
-	if k.Kind() != reflect.String {
-		return false, names[1] + " is not a string"
+	if k.Type() != m.Type().Key() {
+		return false, names[1] + " has an unexpected type"
 	}
 
 	keys := m.MapKeys()
@@ -63,7 +63,7 @@ var IsTrue Checker = &isTrueChecker{
 func (checker *isTrueChecker) Check(params []interface{}, names []string) (result bool, error string) {
 	value := reflect.ValueOf(params[0])
 	if value.Kind() != reflect.Bool {
-		return false, names[0] + "is not a bool"
+		return false, names[0] + " is not a bool"
 	}
 	return value.Bool(), ""
 }

--- a/internal/testutil/checkers.go
+++ b/internal/testutil/checkers.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"reflect"
+
+	. "gopkg.in/check.v1"
+)
+
+type hasKeyChecker struct {
+	*CheckerInfo
+}
+
+var HasKey = &hasKeyChecker{
+	&CheckerInfo{Name: "HasKey", Params: []string{"map", "key"}}}
+
+func (checker *hasKeyChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	m := reflect.ValueOf(params[0])
+	if m.Kind() != reflect.Map {
+		return false, names[0] + " is not a map"
+	}
+
+	k := reflect.ValueOf(params[1])
+	if k.Kind() != reflect.String {
+		return false, names[1] + " is not a string"
+	}
+
+	keys := m.MapKeys()
+	for _, key := range keys {
+		if key.Interface() == k.Interface() {
+			return true, ""
+		}
+	}
+
+	return false, ""
+}
+
+type isTrueChecker struct {
+	*CheckerInfo
+}
+
+var IsTrue Checker = &isTrueChecker{
+	&CheckerInfo{Name: "IsTrue", Params: []string{"value"}}}
+
+func (checker *isTrueChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	value := reflect.ValueOf(params[0])
+	if value.Kind() != reflect.Bool {
+		return false, names[0] + "is not a bool"
+	}
+	return value.Bool(), ""
+}

--- a/internal/testutil/checkers_test.go
+++ b/internal/testutil/checkers_test.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	"reflect"
+
+	. "github.com/snapcore/secboot/internal/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+func testInfo(c *C, checker Checker, name string, paramNames []string) {
+	info := checker.Info()
+	if info.Name != name {
+		c.Fatalf("Got name %s, expected %s", info.Name, name)
+	}
+	if !reflect.DeepEqual(info.Params, paramNames) {
+		c.Fatalf("Got param names %#v, expected %#v", info.Params, paramNames)
+	}
+}
+
+func testCheck(c *C, checker Checker, result bool, error string, params ...interface{}) ([]interface{}, []string) {
+	info := checker.Info()
+	if len(params) != len(info.Params) {
+		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))
+	}
+	names := append([]string{}, info.Params...)
+	resultActual, errorActual := checker.Check(params, names)
+	if resultActual != result || errorActual != error {
+		c.Fatalf("%s.Check(%#v) returned (%#v, %#v) rather than (%#v, %#v)",
+			info.Name, params, resultActual, errorActual, result, error)
+	}
+	return params, names
+}
+
+type checkersSuite struct{}
+
+var _ = Suite(&checkersSuite{})
+
+func (s *checkersSuite) TestHasKey(c *C) {
+	testInfo(c, HasKey, "HasKey", []string{"map", "key"})
+	testCheck(c, HasKey, true, "", map[string]int{"foo": 1, "bar": 2}, "foo")
+	testCheck(c, HasKey, false, "", map[string]int{"foo": 1, "bar": 2}, "baz")
+	testCheck(c, HasKey, true, "", map[int]int{5: 1, 8: 3}, 8)
+	testCheck(c, HasKey, false, "", map[int]int{5: 1, 8: 3}, 3)
+	testCheck(c, HasKey, false, "map is not a map", "foo", "foo")
+	testCheck(c, HasKey, false, "key has an unexpected type", map[int]int{}, "foo")
+}
+
+func (s *checkersSuite) TestIsTrue(c *C) {
+	testInfo(c, IsTrue, "IsTrue", []string{"value"})
+	testCheck(c, IsTrue, true, "", true)
+	testCheck(c, IsTrue, false, "", false)
+	testCheck(c, IsTrue, false, "value is not a bool", 1)
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }

--- a/keydata.go
+++ b/keydata.go
@@ -331,14 +331,14 @@ func (d *KeyData) ID() *KeyID {
 // AuthMode indicates the authentication mechanisms enabled for this key data.
 func (d *KeyData) AuthMode() (out AuthMode) {
 	if len(d.data.EncryptedPayload) > 0 {
-		return
+		return AuthModeNone
 	}
 
 	if d.data.PassphraseProtectedPayload != nil {
 		out |= AuthModePassphrase
 	}
 
-	return
+	return out
 }
 
 // RecoverKeys recovers the disk unlock key and auxiliary key associated with this

--- a/keydata.go
+++ b/keydata.go
@@ -19,6 +19,115 @@
 
 package secboot
 
+import (
+	"bytes"
+	"crypto"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/canonical/go-sp800.90a-drbg"
+
+	"golang.org/x/xerrors"
+)
+
+// ErrNoPlatformHandlerRegistered is returned from any of the KeyData.RecoverKeys*
+// functions if the keys cannot be successfully recovered because there is no
+// appropriate platform handler registered.
+var ErrNoPlatformHandlerRegistered = errors.New("cannot recover key because there isn't a platform handler registered for it")
+
+// InvalidKeyDataError is returned from any of the KeyData.RecoverKeys* functions
+// if the keys cannot be successfully recovered because the key data is invalid in
+// some way.
+type InvalidKeyDataError struct {
+	err error
+}
+
+func (e *InvalidKeyDataError) Error() string {
+	return fmt.Sprintf("invalid key data: %v", e.err)
+}
+
+func (e *InvalidKeyDataError) Unwrap() error {
+	return e.err
+}
+
+// PlatformUninitializedError is returned from any of the KeyData.RecoverKeys* functions
+// if the keys cannot be successfully recovered because the platform's secure device has
+// not been initialized properly.
+type PlatformUninitializedError struct {
+	err error
+}
+
+func (e *PlatformUninitializedError) Error() string {
+	return fmt.Sprintf("the platform's secure device is not properly initialized: %v", e.err)
+}
+
+func (e *PlatformUninitializedError) Unwrap() error {
+	return e.err
+}
+
+// PlatformDeviceUnavailableError is returned from any of the KeyData.RecoverKeys*
+// functions if the keys cannot be recovered because the platform's secure device is
+// currently unavailable.
+type PlatformDeviceUnavailableError struct {
+	err error
+}
+
+func (e *PlatformDeviceUnavailableError) Error() string {
+	return fmt.Sprintf("the platform's secure device is unavailable: %v", e.err)
+}
+
+func (e *PlatformDeviceUnavailableError) Unwrap() error {
+	return e.err
+}
+
+// DiskUnlockKey is the key used to unlock a LUKS volume.
+type DiskUnlockKey []byte
+
+// AuxiliaryKey is an additional key used to modify properties of a KeyData
+// object without having to create a new object.
+type AuxiliaryKey []byte
+
+// KeyPayload is the payload that should be encrypted by a platform's secure device.
+type KeyPayload []byte
+
+// Unmarshal obtains the keys from this payload.
+func (c KeyPayload) Unmarshal() (key DiskUnlockKey, auxKey AuxiliaryKey, err error) {
+	r := bytes.NewReader(c)
+
+	var sz uint16
+	if err := binary.Read(r, binary.BigEndian, &sz); err != nil {
+		return nil, nil, err
+	}
+
+	if sz > 0 {
+		key = make(DiskUnlockKey, sz)
+		if _, err := r.Read(key); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if err := binary.Read(r, binary.BigEndian, &sz); err != nil {
+		return nil, nil, err
+	}
+
+	if sz > 0 {
+		auxKey = make(AuxiliaryKey, sz)
+		if _, err := r.Read(auxKey); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if r.Len() > 0 {
+		return nil, nil, errors.New("excess bytes")
+	}
+
+	return
+}
+
 // AuthMode corresponds to a set of authentication mechanisms.
 type AuthMode uint32
 
@@ -26,3 +135,389 @@ const (
 	AuthModeNone       AuthMode = 0
 	AuthModePassphrase AuthMode = 1 << iota
 )
+
+// KeyCreationData is the data required to create a new KeyData object.
+// It should be produced by a platform implementation.
+type KeyCreationData struct {
+	PlatformKeyData
+	PlatformName string // Name of the platform that produced this data
+
+	// AuxiliaryKey is a key used to authorize changes to the key data.
+	// It must match the key protected inside PlatformKeyData.EncryptedPayload.
+	AuxiliaryKey AuxiliaryKey
+
+	// SnapModelAuthHash is the digest algorithm used for HMACs of Snap
+	// device models, and also the digest algorithm used to produce the
+	// key digest.
+	SnapModelAuthHash crypto.Hash
+}
+
+// KeyID is the unique ID for a KeyData object. It is used to facilitate the
+// sharing of state between the early boot environment and OS runtime.
+type KeyID struct {
+	Loader   string // "file" or "luks2"
+	Path     string
+	Name     string
+	Revision uint64
+}
+
+func (x *KeyID) Equals(y *KeyID) bool {
+	return *x == *y
+}
+
+func (id *KeyID) String() string {
+	s := id.Loader + ":" + id.Path
+	if id.Name != "" {
+		s += ":" + id.Name
+	}
+	s += "@" + strconv.FormatUint(id.Revision, 10)
+	return s
+}
+
+// KeyDataWriter is an interface used by KeyData to write the data to
+// persistent storage in an atomic way.
+type KeyDataWriter interface {
+	io.Writer
+	Cancel() error
+	Commit() error
+}
+
+// KeyDataReader is an interface used to read and decode a KeyData
+// from persistent storage.
+type KeyDataReader interface {
+	io.Reader
+	ID() *KeyID
+}
+
+type hashAlg struct {
+	crypto.Hash
+}
+
+func (a hashAlg) MarshalJSON() ([]byte, error) {
+	var s string
+
+	switch a.Hash {
+	case crypto.SHA1:
+		s = "sha1"
+	case crypto.SHA224:
+		s = "sha224"
+	case crypto.SHA256:
+		s = "sha256"
+	case crypto.SHA384:
+		s = "sha384"
+	case crypto.SHA512:
+		s = "sha512"
+	default:
+		return nil, errors.New("invalid hash algorithm")
+	}
+
+	return json.Marshal(s)
+}
+
+func (a *hashAlg) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	switch s {
+	case "sha1":
+		a.Hash = crypto.SHA1
+	case "sha224":
+		a.Hash = crypto.SHA224
+	case "sha256":
+		a.Hash = crypto.SHA256
+	case "sha384":
+		a.Hash = crypto.SHA384
+	case "sha512":
+		a.Hash = crypto.SHA512
+	default:
+		a.Hash = crypto.Hash(0)
+	}
+
+	return nil
+}
+
+type snapModelHMAC []byte
+
+type snapModelHMACList []snapModelHMAC
+
+func (l snapModelHMACList) contains(h snapModelHMAC) bool {
+	for _, v := range l {
+		if bytes.Equal(v, h) {
+			return true
+		}
+	}
+	return false
+}
+
+type authorizedSnapModels struct {
+	Alg       hashAlg           `json:"alg"`
+	KeyDigest []byte            `json:"key_digest"`
+	Hmacs     snapModelHMACList `json:"hmacs"`
+}
+
+type kdfData struct {
+	Type   string `json:"type"`
+	Salt   []byte `json:"salt"`
+	Time   int    `json:"time"`
+	Memory int    `json:"memory"`
+	CPUs   int    `json:"cpus"`
+}
+
+type passphraseData struct {
+	KDF              kdfData `json:"kdf"`
+	EncryptedPayload []byte  `json:"encrypted_payload"`
+}
+
+type keyData struct {
+	PlatformName   string          `json:"platform_name"`
+	PlatformHandle json.RawMessage `json:"platform_handle"`
+
+	EncryptedPayload           []byte          `json:"encrypted_payload,omitempty"`
+	PassphraseProtectedPayload *passphraseData `json:"passphrase_protected_payload,omitempty"`
+
+	AuthorizedSnapModels authorizedSnapModels `json:"authorized_snap_models"`
+}
+
+func processPlatformKeyRecoveryError(err error) error {
+	var pe *PlatformKeyRecoveryError
+	if xerrors.As(err, &pe) {
+		switch pe.Type {
+		case PlatformKeyRecoveryErrorInvalidData:
+			return &InvalidKeyDataError{pe.Err}
+		case PlatformKeyRecoveryErrorUninitialized:
+			return &PlatformUninitializedError{pe.Err}
+		case PlatformKeyRecoveryErrorUnavailable:
+			return &PlatformDeviceUnavailableError{pe.Err}
+		}
+	}
+
+	return xerrors.Errorf("cannot recover keys because of an unexpected error: %w", err)
+}
+
+// KeyData represents a disk unlock key and auxiliary key protected by a platform's
+// secure device.
+type KeyData struct {
+	id   *KeyID
+	data keyData
+}
+
+func (d *KeyData) snapModelAuthKey(auxKey AuxiliaryKey) ([]byte, error) {
+	rng, err := drbg.NewCTRWithExternalEntropy(32, auxKey, nil, []byte("SNAP-MODEL-HMAC"), nil)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot instantiate DRBG: %w", err)
+	}
+
+	alg := d.data.AuthorizedSnapModels.Alg
+	if alg.Hash == crypto.Hash(0) {
+		return nil, errors.New("invalid digest algorithm")
+	}
+
+	hmacKey := make([]byte, alg.Size())
+	if _, err := rng.Read(hmacKey); err != nil {
+		return nil, xerrors.Errorf("cannot derive key: %w", err)
+	}
+
+	return hmacKey, nil
+}
+
+// ID returns the unique ID for this key data.
+func (d *KeyData) ID() *KeyID {
+	return d.id
+}
+
+// AuthMode indicates the authentication mechanisms enabled for this key data.
+func (d *KeyData) AuthMode() (out AuthMode) {
+	if len(d.data.EncryptedPayload) > 0 {
+		return
+	}
+
+	if d.data.PassphraseProtectedPayload != nil {
+		out |= AuthModePassphrase
+	}
+
+	return
+}
+
+// RecoverKeys recovers the disk unlock key and auxiliary key associated with this
+// key data from the platform's secure device, for key data that doesn't have any
+// additional authentication modes enabled (AuthMode returns AuthModeNone).
+//
+// If AuthMode returns anything other than AuthModeNone, then this will return an error.
+//
+// If no platform handler has been registered for this key data, an
+// ErrNoPlatformHandlerRegistered error will be returned.
+//
+// If the keys cannot be recovered because the key data is invalid, a *InvalidKeyDataError
+// error will be returned.
+//
+// If the keys cannot be recovered because the platform's secure device is not
+// properly initialized, a *PlatformUninitializedError error will be returned.
+//
+// If the keys cannot be recovered because the platform's secure device is not
+// available, a *PlatformDeviceUnavailableError error will be returned.
+func (d *KeyData) RecoverKeys() (DiskUnlockKey, AuxiliaryKey, error) {
+	if d.AuthMode() != AuthModeNone {
+		return nil, nil, errors.New("cannot recover key without authorization")
+	}
+
+	handler := handlers[d.data.PlatformName]
+	if handler == nil {
+		return nil, nil, ErrNoPlatformHandlerRegistered
+	}
+
+	c, err := handler.RecoverKeys(&PlatformKeyData{
+		Handle:           d.data.PlatformHandle,
+		EncryptedPayload: d.data.EncryptedPayload})
+	if err != nil {
+		return nil, nil, processPlatformKeyRecoveryError(err)
+	}
+
+	key, auxKey, err := c.Unmarshal()
+	if err != nil {
+		return nil, nil, &InvalidKeyDataError{xerrors.Errorf("cannot unmarshal cleartext key payload: %w", err)}
+	}
+
+	return key, auxKey, nil
+}
+
+//func (d *KeyData) RecoverKeysWithPassphrase(passphrase string) (DiskUnlockKey, AuxiliaryKey, error) {
+//}
+
+// IsSnapModelAuthorized indicates whether the supplied Snap device model is trusted to
+// access the data on the encrypted volume protected by this key data.
+//
+// The supplied auxKey is obtained using one of the RecoverKeys* functions.
+func (d *KeyData) IsSnapModelAuthorized(auxKey AuxiliaryKey, model SnapModel) (bool, error) {
+	hmacKey, err := d.snapModelAuthKey(auxKey)
+	if err != nil {
+		return false, xerrors.Errorf("cannot obtain auth key: %w", err)
+	}
+
+	alg := d.data.AuthorizedSnapModels.Alg
+	if alg.Hash == crypto.Hash(0) {
+		return false, errors.New("invalid digest algorithm")
+	}
+
+	h, err := computeSnapModelHMAC(alg.Hash, hmacKey, model)
+	if err != nil {
+		return false, xerrors.Errorf("cannot compute HMAC of model: %w", err)
+	}
+
+	return d.data.AuthorizedSnapModels.Hmacs.contains(h), nil
+}
+
+// SetAuthorizedSnapModels marks the supplied Snap device models as trusted to access
+// the data on the encrypted volume protected by this key data. This function replaces all
+// previously trusted models.
+//
+// This makes changes to the key data, which will need to persisted afterwards using
+// WriteAtomic.
+//
+// The supplied auxKey is obtained using one of the RecoverKeys* functions. If the
+// supplied auxKey is incorrect, then an error will be returned.
+func (d *KeyData) SetAuthorizedSnapModels(auxKey AuxiliaryKey, models ...SnapModel) error {
+	hmacKey, err := d.snapModelAuthKey(auxKey)
+	if err != nil {
+		return xerrors.Errorf("cannot obtain auth key: %w", err)
+	}
+
+	alg := d.data.AuthorizedSnapModels.Alg
+	if alg.Hash == crypto.Hash(0) {
+		return errors.New("invalid digest algorithm")
+	}
+
+	h := alg.New()
+	h.Write(hmacKey)
+	if !bytes.Equal(h.Sum(nil), d.data.AuthorizedSnapModels.KeyDigest) {
+		return errors.New("incorrect key supplied")
+	}
+
+	var modelHMACs snapModelHMACList
+
+	for _, model := range models {
+		h, err := computeSnapModelHMAC(alg.Hash, hmacKey, model)
+		if err != nil {
+			return xerrors.Errorf("cannot compute HMAC of model: %w", err)
+		}
+
+		modelHMACs = append(modelHMACs, h)
+	}
+
+	d.data.AuthorizedSnapModels.Hmacs = modelHMACs
+	return nil
+}
+
+//func (d *KeyData) ChangePasshprase(old, new string) error {
+//}
+
+// WriteAtomic saves this key data to the supplied KeyDataWriter.
+func (d *KeyData) WriteAtomic(w KeyDataWriter) error {
+	defer w.Cancel()
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(d.data); err != nil {
+		return xerrors.Errorf("cannot encode keydata: %w", err)
+	}
+
+	if err := w.Commit(); err != nil {
+		return xerrors.Errorf("cannot commit keydata: %w", err)
+	}
+
+	return nil
+}
+
+// ReadKeyData reads the key data from the supplied KeyDataReader, returning a
+// new KeyData object.
+func ReadKeyData(r KeyDataReader) (*KeyData, error) {
+	id := *r.ID()
+	d := &KeyData{id: &id}
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&d.data); err != nil {
+		return nil, xerrors.Errorf("cannot decode key data: %w", err)
+	}
+
+	return d, nil
+}
+
+// NewKeyData creates a new KeyData object using the supplied KeyCreationData, which
+// should be created by a platform-specific package, containing a payload encrypted by
+// the platform's secure device and the associated handle required for subsequent
+// recovery of the keys.
+func NewKeyData(creationData *KeyCreationData) (*KeyData, error) {
+	if !json.Valid(creationData.Handle) {
+		return nil, errors.New("handle is not valid JSON")
+	}
+
+	rng, err := drbg.NewCTRWithExternalEntropy(32, creationData.AuxiliaryKey, nil, []byte("SNAP-MODEL-HMAC"), nil)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot instantiate DRBG: %w", err)
+	}
+
+	h := creationData.SnapModelAuthHash.New()
+	if _, err := io.CopyN(h, rng, int64(creationData.SnapModelAuthHash.Size())); err != nil {
+		return nil, xerrors.Errorf("cannot create hash of snap model auth key: %w", err)
+	}
+
+	return &KeyData{
+		id: &KeyID{},
+		data: keyData{
+			PlatformName:     creationData.PlatformName,
+			PlatformHandle:   json.RawMessage(creationData.Handle),
+			EncryptedPayload: creationData.EncryptedPayload,
+			AuthorizedSnapModels: authorizedSnapModels{
+				Alg:       hashAlg{creationData.SnapModelAuthHash},
+				KeyDigest: h.Sum(nil)}}}, nil
+}
+
+// MarshalKeys serializes the supplied disk unlock key and auxiliary key in
+// to a format that is ready to be encrypted by a platform's secure device.
+func MarshalKeys(key DiskUnlockKey, auxKey AuxiliaryKey) KeyPayload {
+	w := new(bytes.Buffer)
+	binary.Write(w, binary.BigEndian, uint16(len(key)))
+	w.Write(key)
+	binary.Write(w, binary.BigEndian, uint16(len(auxKey)))
+	w.Write(auxKey)
+	return w.Bytes()
+}

--- a/keydata.go
+++ b/keydata.go
@@ -122,7 +122,7 @@ func (c KeyPayload) Unmarshal() (key DiskUnlockKey, auxKey AuxiliaryKey, err err
 	}
 
 	if r.Len() > 0 {
-		return nil, nil, errors.New("excess bytes")
+		return nil, nil, fmt.Errorf("%v excess byte(s)", r.Len())
 	}
 
 	return
@@ -209,7 +209,7 @@ func (a hashAlg) MarshalJSON() ([]byte, error) {
 	case crypto.SHA512:
 		s = "sha512"
 	default:
-		return nil, errors.New("invalid hash algorithm")
+		return nil, fmt.Errorf("unknown has algorithm: %v", a.Hash)
 	}
 
 	return json.Marshal(s)

--- a/keydata_file.go
+++ b/keydata_file.go
@@ -20,69 +20,78 @@
 package secboot
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
-	"path/filepath"
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
 
-	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 )
 
-// FileKeyDataReader corresponds to an open file from which key data can be read.
-type FileKeyDataReader struct {
-	*os.File
+type fileKeyData struct {
+	Name string          `json:"name"`
+	Data json.RawMessage `json:"data"`
+}
 
-	dev  uint64
+// FileKeyDataReader provides a mechanism to read a KeyData from a file.
+type FileKeyDataReader struct {
 	name string
+	*bytes.Reader
 }
 
 // ID is the unique ID of the key data contained within this file.
-func (r *FileKeyDataReader) ID() *KeyID {
-	return &KeyID{Loader: "file", Device: r.dev, Name: r.name}
+func (r *FileKeyDataReader) ID() KeyID {
+	return KeyID{Name: r.name}
 }
 
-// OpenKeyDataFile is used to open a file containing key data at the specified path.
-// The file must be closed when it is no longer needed.
-func OpenKeyDataFile(path string) (*FileKeyDataReader, error) {
+// NewFileKeyDataReader is used to read a file containing key data at the specified path.
+func NewFileKeyDataReader(path string) (*FileKeyDataReader, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot open file: %w", err)
 	}
+	defer f.Close()
 
-	var st unix.Stat_t
-	if err := unix.Fstat(int(f.Fd()), &st); err != nil {
-		return nil, xerrors.Errorf("cannot obtain file info: %w", err)
+	var d *fileKeyData
+	dec := json.NewDecoder(f)
+	if err := dec.Decode(&d); err != nil {
+		return nil, xerrors.Errorf("cannot decode file key data: %w", err)
 	}
 
-	mountDir := filepath.Dir(path)
-	for ; mountDir != "/"; mountDir = filepath.Dir(mountDir) {
-		var dirSt unix.Stat_t
-		if err := unix.Stat(mountDir, &dirSt); err != nil {
-			return nil, xerrors.Errorf("cannot determine mount point: %w", err)
-		}
-
-		if dirSt.Dev != st.Dev {
-			break
-		}
-	}
-
-	name, err := filepath.Rel(mountDir, path)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot determine name: %w", err)
-	}
-
-	return &FileKeyDataReader{f, st.Dev, name}, nil
+	return &FileKeyDataReader{d.Name, bytes.NewReader(d.Data)}, nil
 }
 
-// NewKeyDataFileWriter creates a new osutil.AtomicFile instance for atomically
-// updating a key data file.
-func NewKeyDataFileWriter(path string) (*osutil.AtomicFile, error) {
-	f, err := osutil.NewAtomicFile(path, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
+// FileKeyDataWriter provides a mechanism to write a KeyData to a file.
+type FileKeyDataWriter struct {
+	name string
+	path string
+	*bytes.Buffer
+}
+
+func (w *FileKeyDataWriter) Commit() error {
+	f, err := osutil.NewAtomicFile(w.path, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
 	if err != nil {
-		return nil, xerrors.Errorf("cannot create new atomic file: %w", err)
+		return xerrors.Errorf("cannot create new atomic file: %w", err)
+	}
+	defer f.Cancel()
+
+	d := &fileKeyData{Name: w.name, Data: w.Bytes()}
+	enc := json.NewEncoder(f)
+	if err := enc.Encode(d); err != nil {
+		return xerrors.Errorf("cannot encode file key data: %w", err)
 	}
 
-	return f, nil
+	if err := f.Commit(); err != nil {
+		return xerrors.Errorf("cannot commit update: %w", err)
+	}
+
+	return nil
+}
+
+// NewFileKeyDataWriter creates a new FileKeyDataWriter for atomically writing a
+// KeyData to a file.
+func NewFileKeyDataWriter(name, path string) *FileKeyDataWriter {
+	return &FileKeyDataWriter{name, path, new(bytes.Buffer)}
 }

--- a/keydata_file.go
+++ b/keydata_file.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"os"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/sys"
+
+	"golang.org/x/xerrors"
+)
+
+// FileKeyDataReader corresponds to an open file from which key data can be read.
+type FileKeyDataReader struct {
+	*os.File
+}
+
+// ID is the unique ID of the key data contained within this file.
+func (r *FileKeyDataReader) ID() *KeyID {
+	return &KeyID{Loader: "file", Path: r.Name()}
+}
+
+// OpenKeyDataFile is used to open a file containing key data at the specified path.
+// The file must be closed when it is no longer needed.
+func OpenKeyDataFile(path string) (*FileKeyDataReader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot open file: %w", err)
+	}
+
+	return &FileKeyDataReader{f}, nil
+}
+
+// NewKeyDataFileWriter creates a new osutil.AtomicFile instance for atomically
+// updating a key data file.
+func NewKeyDataFileWriter(path string) (*osutil.AtomicFile, error) {
+	f, err := osutil.NewAtomicFile(path, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create new atomic file: %w", err)
+	}
+
+	return f, nil
+}

--- a/keydata_file_test.go
+++ b/keydata_file_test.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"crypto"
+	"os"
+	"path/filepath"
+
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/testutil"
+
+	"golang.org/x/sys/unix"
+
+	. "gopkg.in/check.v1"
+)
+
+type keyDataFileSuite struct {
+	snapModelTestBase
+	keyDataTestBase
+	dir string
+}
+
+func (s *keyDataFileSuite) SetUpTest(c *C) {
+	s.keyDataTestBase.SetUpTest(c)
+	s.dir = c.MkDir()
+}
+
+var _ = Suite(&keyDataFileSuite{})
+
+func (s *keyDataFileSuite) TestWriter(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	w, err := NewKeyDataFileWriter(filepath.Join(s.dir, "key"))
+	c.Assert(err, IsNil)
+
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	f, err := os.Open(filepath.Join(s.dir, "key"))
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	s.checkKeyDataJSON(c, f, protected, 0)
+}
+
+func (s *keyDataFileSuite) TestWriterIsAtomic(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	w, err := NewKeyDataFileWriter(filepath.Join(s.dir, "key"))
+	c.Assert(err, IsNil)
+
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	f, err := os.Open(filepath.Join(s.dir, "key"))
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	w, err = NewKeyDataFileWriter(filepath.Join(s.dir, "key"))
+	c.Assert(err, IsNil)
+
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	var st1 unix.Stat_t
+	c.Check(unix.Fstat(int(f.Fd()), &st1), IsNil)
+	var st2 unix.Stat_t
+	c.Check(unix.Stat(filepath.Join(s.dir, "key"), &st2), IsNil)
+	c.Check(st1.Ino, Not(Equals), st2.Ino)
+}
+
+func (s *keyDataFileSuite) TestReader(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	w, err := NewKeyDataFileWriter(filepath.Join(s.dir, "key"))
+	c.Assert(err, IsNil)
+
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	f, err := OpenKeyDataFile(filepath.Join(s.dir, "key"))
+	c.Assert(err, IsNil)
+	defer f.Close()
+	c.Check(f.ID().Equals(&KeyID{Loader: "file", Path: filepath.Join(s.dir, "key")}), testutil.IsTrue)
+
+	keyData, err = ReadKeyData(f)
+	c.Assert(err, IsNil)
+
+	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(recoveredKey, DeepEquals, key)
+	c.Check(recoveredAuxKey, DeepEquals, auxKey)
+
+	authorized, err := keyData.IsSnapModelAuthorized(recoveredAuxKey, models[0])
+	c.Check(err, IsNil)
+	c.Check(authorized, testutil.IsTrue)
+}

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -313,7 +313,7 @@ func (s *keyDataSuite) TestKeyPayloadUnmarshalInvalid2(c *C) {
 	payload = append(payload, 0xff)
 
 	key, auxKey, err := payload.Unmarshal()
-	c.Check(err, ErrorMatches, "excess bytes")
+	c.Check(err, ErrorMatches, "1 excess byte\\(s\\)")
 	c.Check(key, IsNil)
 	c.Check(auxKey, IsNil)
 }

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -330,19 +330,20 @@ func (s *keyDataSuite) testKeyIDString(c *C, data *testKeyIDStringData) {
 func (s *keyDataSuite) TestKeyIDStringFile(c *C) {
 	s.testKeyIDString(c, &testKeyIDStringData{
 		id: &KeyID{
+			Device: 0x801,
 			Loader: "file",
-			Path:   "/foo/bar"},
-		expected: "file:/foo/bar@0"})
+			Name:   "foo/bar"},
+		expected: "file:[8:1]:foo/bar@0"})
 }
 
 func (s *keyDataSuite) TestKeyIDStringLUKS(c *C) {
 	s.testKeyIDString(c, &testKeyIDStringData{
 		id: &KeyID{
+			Device:   0x10300,
 			Loader:   "luks2",
-			Path:     "/dev/sda1",
 			Name:     "primary",
 			Revision: 15},
-		expected: "luks2:/dev/sda1:primary@15"})
+		expected: "luks2:[259:0]:primary@15"})
 }
 
 func (s *keyDataSuite) TestRecoverKeys(c *C) {

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -1,0 +1,756 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/rand"
+
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/testutil"
+
+	"golang.org/x/xerrors"
+
+	. "gopkg.in/check.v1"
+)
+
+const mockPlatformName = "mock"
+
+const (
+	mockPlatformDeviceStateOK = iota
+	mockPlatformDeviceStateUnavailable
+	mockPlatformDeviceStateUninitialized
+)
+
+type mockPlatformKeyDataHandler struct {
+	state int
+}
+
+func (h *mockPlatformKeyDataHandler) RecoverKeys(data *PlatformKeyData) (KeyPayload, error) {
+	switch h.state {
+	case mockPlatformDeviceStateUnavailable:
+		return nil, &PlatformKeyRecoveryError{Type: PlatformKeyRecoveryErrorUnavailable, Err: errors.New("the platform device is unavailable")}
+	case mockPlatformDeviceStateUninitialized:
+		return nil, &PlatformKeyRecoveryError{Type: PlatformKeyRecoveryErrorUninitialized, Err: errors.New("the platform device is uninitialized")}
+	}
+
+	var str string
+	if err := json.Unmarshal(data.Handle, &str); err != nil {
+		return nil, &PlatformKeyRecoveryError{Type: PlatformKeyRecoveryErrorInvalidData, Err: xerrors.Errorf("JSON decode error: %w", err)}
+	}
+
+	handle, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return nil, &PlatformKeyRecoveryError{Type: PlatformKeyRecoveryErrorInvalidData, Err: xerrors.Errorf("base64 decode error: %w", err)}
+	}
+
+	if len(handle) != 48 {
+		return nil, &PlatformKeyRecoveryError{Type: PlatformKeyRecoveryErrorInvalidData, Err: errors.New("invalid handle length")}
+	}
+
+	b, err := aes.NewCipher(handle[:32])
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create cipher: %w", err)
+	}
+
+	s := cipher.NewCFBDecrypter(b, handle[32:])
+	out := make(KeyPayload, len(data.EncryptedPayload))
+	s.XORKeyStream(out, data.EncryptedPayload)
+	return out, nil
+}
+
+type mockKeyDataWriter struct {
+	tmp   *bytes.Buffer
+	final *bytes.Buffer
+}
+
+func (w *mockKeyDataWriter) Write(data []byte) (int, error) {
+	if w.tmp == nil {
+		return 0, errors.New("cancelled")
+	}
+	return w.tmp.Write(data)
+}
+
+func (w *mockKeyDataWriter) Cancel() error {
+	w.tmp = nil
+	return nil
+}
+
+func (w *mockKeyDataWriter) Commit() error {
+	if w.tmp == nil {
+		return errors.New("cancelled or already committed")
+	}
+	w.final = w.tmp
+	w.tmp = nil
+	return nil
+}
+
+func (w *mockKeyDataWriter) Read(data []byte) (int, error) {
+	if w.final == nil {
+		return 0, io.EOF
+	}
+	return w.final.Read(data)
+}
+
+func makeMockKeyDataWriter() *mockKeyDataWriter {
+	return &mockKeyDataWriter{tmp: new(bytes.Buffer)}
+}
+
+type mockKeyDataReader struct {
+	id *KeyID
+	io.Reader
+}
+
+func (r *mockKeyDataReader) ID() *KeyID {
+	return r.id
+}
+
+func toHash(c *C, v interface{}) crypto.Hash {
+	str, ok := v.(string)
+	c.Assert(ok, testutil.IsTrue)
+	switch str {
+	case "sha1":
+		return crypto.SHA1
+	case "sha224":
+		return crypto.SHA224
+	case "sha256":
+		return crypto.SHA256
+	case "sha384":
+		return crypto.SHA384
+	case "sha512":
+		return crypto.SHA512
+	default:
+		c.Fatalf("unrecognized hash algorithm")
+	}
+	return crypto.Hash(0)
+}
+
+type keyDataTestBase struct {
+	handler *mockPlatformKeyDataHandler
+}
+
+func (s *keyDataTestBase) SetUpSuite(c *C) {
+	s.handler = &mockPlatformKeyDataHandler{}
+	RegisterPlatformKeyDataHandler(mockPlatformName, s.handler)
+}
+
+func (s *keyDataTestBase) SetUpTest(c *C) {
+	s.handler.state = mockPlatformDeviceStateOK
+}
+
+func (s *keyDataTestBase) TearDownSuite(c *C) {
+	RegisterPlatformKeyDataHandler(mockPlatformName, nil)
+}
+
+func (s *keyDataTestBase) newKeys(c *C, sz1, sz2 int) (DiskUnlockKey, AuxiliaryKey) {
+	key := make([]byte, sz1)
+	auxKey := make([]byte, sz2)
+	_, err := rand.Read(key)
+	c.Assert(err, IsNil)
+	_, err = rand.Read(auxKey)
+	c.Assert(err, IsNil)
+	return key, auxKey
+}
+
+func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey AuxiliaryKey, modelAuthHash crypto.Hash) (out *KeyCreationData) {
+	payload := MarshalKeys(key, auxKey)
+
+	k := make([]byte, 48)
+	_, err := rand.Read(k)
+	c.Assert(err, IsNil)
+
+	handle, err := json.Marshal(base64.StdEncoding.EncodeToString(k))
+	c.Check(err, IsNil)
+
+	b, err := aes.NewCipher(k[:32])
+	c.Assert(err, IsNil)
+	stream := cipher.NewCFBEncrypter(b, k[32:])
+
+	out = &KeyCreationData{
+		PlatformName: mockPlatformName,
+		PlatformKeyData: PlatformKeyData{
+			Handle:           handle,
+			EncryptedPayload: make([]byte, len(payload))},
+		AuxiliaryKey:      auxKey,
+		SnapModelAuthHash: modelAuthHash}
+	stream.XORKeyStream(out.EncryptedPayload, payload)
+	return
+}
+
+func (s *keyDataTestBase) checkKeyDataJSON(c *C, r io.Reader, creationData *KeyCreationData, nmodels int) {
+	var j map[string]interface{}
+
+	d := json.NewDecoder(r)
+	c.Check(d.Decode(&j), IsNil)
+
+	c.Check(j["platform_name"], Equals, creationData.PlatformName)
+
+	handle, err := json.Marshal(j["platform_handle"])
+	c.Check(err, IsNil)
+	c.Check(handle, DeepEquals, creationData.Handle)
+
+	str, ok := j["encrypted_payload"].(string)
+	c.Check(ok, testutil.IsTrue)
+	encryptedPayload, err := base64.StdEncoding.DecodeString(str)
+	c.Check(err, IsNil)
+	c.Check(encryptedPayload, DeepEquals, creationData.EncryptedPayload)
+
+	c.Check(j, Not(testutil.HasKey), "passphrase_protected_payload")
+
+	m, ok := j["authorized_snap_models"].(map[string]interface{})
+	c.Check(ok, testutil.IsTrue)
+
+	h := toHash(c, m["alg"])
+	c.Check(h, Equals, creationData.SnapModelAuthHash)
+
+	str, ok = m["key_digest"].(string)
+	c.Check(ok, testutil.IsTrue)
+	keyDigest, err := base64.StdEncoding.DecodeString(str)
+	c.Check(err, IsNil)
+	c.Check(keyDigest, HasLen, h.Size())
+
+	c.Check(m, testutil.HasKey, "hmacs")
+	if nmodels == 0 {
+		c.Check(m["hmacs"], IsNil)
+	} else {
+		c.Check(m["hmacs"], HasLen, nmodels)
+		hmacs, ok := m["hmacs"].([]interface{})
+		c.Check(ok, testutil.IsTrue)
+		for _, v := range hmacs {
+			str, ok := v.(string)
+			c.Check(ok, testutil.IsTrue)
+			digest, err := base64.StdEncoding.DecodeString(str)
+			c.Check(err, IsNil)
+			c.Check(digest, HasLen, h.Size())
+		}
+	}
+}
+
+type keyDataSuite struct {
+	snapModelTestBase
+	keyDataTestBase
+}
+
+var _ = Suite(&keyDataSuite{})
+
+type testKeyPayloadData struct {
+	key    DiskUnlockKey
+	auxKey AuxiliaryKey
+}
+
+func (s *keyDataSuite) testKeyPayload(c *C, data *testKeyPayloadData) {
+	payload := MarshalKeys(data.key, data.auxKey)
+
+	key, auxKey, err := payload.Unmarshal()
+	c.Check(err, IsNil)
+	c.Check(key, DeepEquals, data.key)
+	c.Check(auxKey, DeepEquals, data.auxKey)
+}
+
+func (s *keyDataSuite) TestKeyPayload1(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+
+	s.testKeyPayload(c, &testKeyPayloadData{
+		key:    key,
+		auxKey: auxKey})
+}
+
+func (s *keyDataSuite) TestKeyPayload2(c *C) {
+	key, auxKey := s.newKeys(c, 64, 32)
+
+	s.testKeyPayload(c, &testKeyPayloadData{
+		key:    key,
+		auxKey: auxKey})
+}
+
+func (s *keyDataSuite) TestKeyPayload3(c *C) {
+	key, _ := s.newKeys(c, 32, 0)
+
+	s.testKeyPayload(c, &testKeyPayloadData{
+		key: key})
+}
+
+func (s *keyDataSuite) TestKeyPayloadUnmarshalInvalid1(c *C) {
+	payload := make(KeyPayload, 66)
+	for i := range payload {
+		payload[i] = 0xff
+	}
+
+	key, auxKey, err := payload.Unmarshal()
+	c.Check(err, ErrorMatches, "EOF")
+	c.Check(key, IsNil)
+	c.Check(auxKey, IsNil)
+}
+
+func (s *keyDataSuite) TestKeyPayloadUnmarshalInvalid2(c *C) {
+	payload := MarshalKeys(make(DiskUnlockKey, 32), make(AuxiliaryKey, 32))
+	payload = append(payload, 0xff)
+
+	key, auxKey, err := payload.Unmarshal()
+	c.Check(err, ErrorMatches, "excess bytes")
+	c.Check(key, IsNil)
+	c.Check(auxKey, IsNil)
+}
+
+type testKeyIDStringData struct {
+	id       *KeyID
+	expected string
+}
+
+func (s *keyDataSuite) testKeyIDString(c *C, data *testKeyIDStringData) {
+	c.Check(data.id.String(), Equals, data.expected)
+}
+
+func (s *keyDataSuite) TestKeyIDStringFile(c *C) {
+	s.testKeyIDString(c, &testKeyIDStringData{
+		id: &KeyID{
+			Loader: "file",
+			Path:   "/foo/bar"},
+		expected: "file:/foo/bar@0"})
+}
+
+func (s *keyDataSuite) TestKeyIDStringLUKS(c *C) {
+	s.testKeyIDString(c, &testKeyIDStringData{
+		id: &KeyID{
+			Loader:   "luks2",
+			Path:     "/dev/sda1",
+			Name:     "primary",
+			Revision: 15},
+		expected: "luks2:/dev/sda1:primary@15"})
+}
+
+func (s *keyDataSuite) TestRecoverKeys(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(recoveredKey, DeepEquals, key)
+	c.Check(recoveredAuxKey, DeepEquals, auxKey)
+}
+
+func (s *keyDataSuite) TestRecoverKeysUnrecognizedPlatform(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	protected.PlatformName = "foo"
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeys()
+	c.Check(err, ErrorMatches, "cannot recover key because there isn't a platform handler registered for it")
+	c.Check(recoveredKey, IsNil)
+	c.Check(recoveredAuxKey, IsNil)
+}
+
+func (s *keyDataSuite) TestRecoverKeysInvalidData(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	protected.Handle = []byte("\"\"")
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeys()
+	c.Check(err, ErrorMatches, "invalid key data: invalid handle length")
+	c.Check(recoveredKey, IsNil)
+	c.Check(recoveredAuxKey, IsNil)
+}
+
+type testSnapModelAuthData struct {
+	alg        crypto.Hash
+	authModels []SnapModel
+	model      SnapModel
+	authorized bool
+}
+
+func (s *keyDataSuite) testSnapModelAuth(c *C, data *testSnapModelAuthData) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, data.alg)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, data.authModels...), IsNil)
+
+	authorized, err := keyData.IsSnapModelAuthorized(auxKey, data.model)
+	c.Check(err, IsNil)
+	c.Check(authorized, Equals, data.authorized)
+}
+
+func (s *keyDataSuite) TestSnapModelAuth1(c *C) {
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	s.testSnapModelAuth(c, &testSnapModelAuthData{
+		alg:        crypto.SHA256,
+		authModels: models,
+		model:      models[0],
+		authorized: true})
+}
+
+func (s *keyDataSuite) TestSnapModelAuth2(c *C) {
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	s.testSnapModelAuth(c, &testSnapModelAuthData{
+		alg:        crypto.SHA256,
+		authModels: models,
+		model:      models[1],
+		authorized: true})
+}
+
+func (s *keyDataSuite) TestSnapModelAuth3(c *C) {
+	s.testSnapModelAuth(c, &testSnapModelAuthData{
+		alg: crypto.SHA256,
+		authModels: []SnapModel{
+			s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")},
+		model: s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		authorized: false})
+}
+
+func (s *keyDataSuite) TestSnapModelAuth4(c *C) {
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	s.testSnapModelAuth(c, &testSnapModelAuthData{
+		alg:        crypto.SHA512,
+		authModels: models,
+		model:      models[0],
+		authorized: true})
+}
+
+func (s *keyDataSuite) TestSetAuthorizedSnapModelsWithWrongKey(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(make(AuxiliaryKey, 32), models...), ErrorMatches, "incorrect key supplied")
+}
+
+type testWriteAtomicData struct {
+	keyData      *KeyData
+	creationData *KeyCreationData
+	nmodels      int
+}
+
+func (s *keyDataSuite) testWriteAtomic(c *C, data *testWriteAtomicData) {
+	w := makeMockKeyDataWriter()
+	c.Check(data.keyData.WriteAtomic(w), IsNil)
+
+	s.checkKeyDataJSON(c, w, data.creationData, data.nmodels)
+}
+
+func (s *keyDataSuite) TestWriteAtomic1(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	s.testWriteAtomic(c, &testWriteAtomicData{
+		keyData:      keyData,
+		creationData: protected})
+}
+
+func (s *keyDataSuite) TestWriteAtomic2(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA512)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	s.testWriteAtomic(c, &testWriteAtomicData{
+		keyData:      keyData,
+		creationData: protected})
+}
+
+func (s *keyDataSuite) TestWriteAtomic3(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	s.testWriteAtomic(c, &testWriteAtomicData{
+		keyData:      keyData,
+		creationData: protected,
+		nmodels:      len(models)})
+}
+
+func (s *keyDataSuite) TestWriteAtomic4(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	s.testWriteAtomic(c, &testWriteAtomicData{
+		keyData:      keyData,
+		creationData: protected,
+		nmodels:      len(models)})
+}
+
+type testReadKeyDataData struct {
+	key        DiskUnlockKey
+	auxKey     AuxiliaryKey
+	r          KeyDataReader
+	model      SnapModel
+	authorized bool
+}
+
+func (s *keyDataSuite) testReadKeyData(c *C, data *testReadKeyDataData) {
+	keyData, err := ReadKeyData(data.r)
+	c.Check(err, IsNil)
+
+	c.Check(keyData.ID().Equals(data.r.ID()), testutil.IsTrue)
+
+	key, auxKey, err := keyData.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(key, DeepEquals, data.key)
+	c.Check(auxKey, DeepEquals, data.auxKey)
+
+	authorized, err := keyData.IsSnapModelAuthorized(auxKey, data.model)
+	c.Check(err, IsNil)
+	c.Check(authorized, Equals, data.authorized)
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey), IsNil)
+}
+
+func (s *keyDataSuite) TestReadKeyData1(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	w := makeMockKeyDataWriter()
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	r := &mockKeyDataReader{&KeyID{}, w.final}
+
+	s.testReadKeyData(c, &testReadKeyDataData{
+		key:        key,
+		auxKey:     auxKey,
+		r:          r,
+		model:      models[0],
+		authorized: true})
+}
+
+func (s *keyDataSuite) TestReadKeyData2(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA512)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	w := makeMockKeyDataWriter()
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	r := &mockKeyDataReader{&KeyID{}, w.final}
+
+	s.testReadKeyData(c, &testReadKeyDataData{
+		key:        key,
+		auxKey:     auxKey,
+		r:          r,
+		model:      models[0],
+		authorized: true})
+}
+
+func (s *keyDataSuite) TestReadKeyData3(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	w := makeMockKeyDataWriter()
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	r := &mockKeyDataReader{&KeyID{}, w.final}
+
+	s.testReadKeyData(c, &testReadKeyDataData{
+		key:        key,
+		auxKey:     auxKey,
+		r:          r,
+		model:      models[1],
+		authorized: true})
+}
+
+func (s *keyDataSuite) TestReadKeyData4(c *C) {
+	key, auxKey := s.newKeys(c, 32, 32)
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA512)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	w := makeMockKeyDataWriter()
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	r := &mockKeyDataReader{&KeyID{}, w.final}
+
+	s.testReadKeyData(c, &testReadKeyDataData{
+		key:    key,
+		auxKey: auxKey,
+		r:      r,
+		model: s.makeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		authorized: false})
+}

--- a/platform.go
+++ b/platform.go
@@ -1,0 +1,99 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+// PlatformKeyRecoveryErrorType describes the type of error returned from one of
+// the PlatformKeyDataHandler.RecoverKeys* functions.
+type PlatformKeyRecoveryErrorType int
+
+const (
+	// PlatformKeyRecoveryErrorInvalidData indicates that keys could not be
+	// recovered successfully because the supplied data is invalid.
+	PlatformKeyRecoveryErrorInvalidData PlatformKeyRecoveryErrorType = iota + 1
+
+	// PlatformKeyRecoveryErrorUninitialized indicates that keys could not be
+	// recovered successfully because the platform's secure device is not properly
+	// initialized.
+	PlatformKeyRecoveryErrorUninitialized
+
+	// PlatformKeyRecoveryErrorUnavailable indicates that keys could not be
+	// recovered successfully because the platform's secure device is unavailable.
+	PlatformKeyRecoveryErrorUnavailable
+)
+
+// PlatformKeyRecoveryError is returned from any of the PlatformKeyDataHandler.RecoverKeys*
+// functions if the keys cannot be successfully recovered by the platform's secure device.
+type PlatformKeyRecoveryError struct {
+	Type PlatformKeyRecoveryErrorType // type of the error
+	Err  error                        // underlying error
+}
+
+func (e *PlatformKeyRecoveryError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PlatformKeyRecoveryError) Unwrap() error {
+	return e.Err
+}
+
+// PlatformKeyData represents the data exchanged between this package and
+// platform implementations.
+type PlatformKeyData struct {
+	// Handle contains metadata required by the platform in order to recover
+	// this key. It is opaque to this go package. It should be an encoded JSON
+	// value, which could be something as simple as a single string containing
+	// a base64 encoded binary payload or a more complex JSON object, depending
+	// on the requirements of the implementation.
+	Handle []byte
+
+	EncryptedPayload []byte // The encrypted payload
+}
+
+// PlatormKeyDataHandler is the interface that this go package uses to
+// interact with a platform's secure device for the purpose of recovering keys.
+type PlatformKeyDataHandler interface {
+	// RecoverKeys attempts to recover the cleartext keys from the supplied key
+	// data using this platform's secure device.
+	RecoverKeys(data *PlatformKeyData) (KeyPayload, error)
+
+	// RecoverKeysWithAuthValue attempts to recover the cleartext keys from the
+	// supplied data using this platform's secure device. The authValue parameter
+	// is a passphrase derived key to enable passphrase support to be integrated
+	// with the secure device. The platform implementation doesn't provide the primary
+	// mechanism of protecting keys with a passphrase - this is done in the platform
+	// agnostic API. Some devices (such as TPMs) support this integration natively. For
+	// other devices, the integration should provide a way of validating the authValue in
+	// a way that requires the use of the secure device (eg, such as computing a HMAC of
+	// it using a hardware backed key).
+	// RecoverKeysWithAuthValue(data *PlatformKeyData, authValue []byte) (KeyPayload, error)
+
+	// ChangeAuthValue is called to notify the platform implementation that the
+	// passphrase is being changed. The oldAuthValue and newAuthValue parameters
+	// are passphrase derived keys. On success, it should return an updated
+	// PlatformKeyData.
+	// ChangeAuthValue(data *PlatformKeyData, oldAuthValue, newAuthValue []byte) (*PlatformKeyData, error)
+}
+
+var handlers = make(map[string]PlatformKeyDataHandler)
+
+// RegisterPlatformKeyDataHandler registers a handler for the specified platform name.
+func RegisterPlatformKeyDataHandler(name string, handler PlatformKeyDataHandler) {
+	handlers[name] = handler
+}

--- a/snap.go
+++ b/snap.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"crypto"
+	"crypto/hmac"
+	_ "crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/binary"
+	"hash"
+
+	"github.com/snapcore/snapd/asserts"
+
+	"golang.org/x/xerrors"
+)
+
+var sha3_384oid = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 9}
+
+// SnapModel exposes the details of a snap device model that are bound
+// to an encrypted container.
+type SnapModel interface {
+	Series() string
+	BrandID() string
+	Model() string
+	Grade() asserts.ModelGrade
+	SignKeyID() string
+}
+
+func computeSnapModelHMAC(alg crypto.Hash, key []byte, model SnapModel) (snapModelHMAC, error) {
+	// XXX: Probably would be nice to know the hash algorithm used for the signing key,
+	// rather than just assuming SHA3-384 here. Note that the actual algorithm ID here
+	// isn't important - what is important is that this ID changes if the hash algorithm
+	// changes to one with a different length.
+	signKeyHashAlg, err := asn1.Marshal(sha3_384oid)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot marshal sign key hash algorithm: %w", err)
+	}
+
+	signKeyId, err := base64.RawURLEncoding.DecodeString(model.SignKeyID())
+	if err != nil {
+		return nil, xerrors.Errorf("cannot decode signing key ID: %w", err)
+	}
+
+	h := hmac.New(func() hash.Hash { return alg.New() }, key)
+	h.Write(signKeyHashAlg)
+	h.Write(signKeyId)
+	h.Write([]byte(model.BrandID()))
+	d := h.Sum(nil)
+
+	h = hmac.New(func() hash.Hash { return alg.New() }, key)
+	h.Write(d)
+	h.Write([]byte(model.Model()))
+	d = h.Sum(nil)
+
+	h = hmac.New(func() hash.Hash { return alg.New() }, key)
+	h.Write(d)
+	h.Write([]byte(model.Series()))
+	binary.Write(h, binary.LittleEndian, model.Grade().Code())
+
+	return h.Sum(nil), nil
+}

--- a/snap_test.go
+++ b/snap_test.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"time"
+
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/snapd/asserts"
+
+	. "gopkg.in/check.v1"
+)
+
+type snapModelTestBase struct{}
+
+func (tb *snapModelTestBase) makeMockCore20ModelAssertion(c *C, headers map[string]interface{}, signKeyHash string) SnapModel {
+	template := map[string]interface{}{
+		"type":              "model",
+		"architecture":      "amd64",
+		"base":              "core20",
+		"timestamp":         time.Now().Format(time.RFC3339),
+		"sign-key-sha3-384": signKeyHash,
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "fake-linux",
+				"id":   "fakelinuxidididididididididididi",
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "fake-gadget",
+				"id":   "fakegadgetididididididididididid",
+				"type": "gadget",
+			},
+		},
+	}
+	for k, v := range headers {
+		template[k] = v
+	}
+
+	assertion, err := asserts.Assemble(template, nil, nil, []byte("AXNpZw=="))
+	c.Assert(err, IsNil)
+	return assertion.(SnapModel)
+}

--- a/snapmodel_policy.go
+++ b/snapmodel_policy.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 
 	"github.com/canonical/go-tpm2"
-	"github.com/snapcore/snapd/asserts"
 
 	"golang.org/x/xerrors"
 )
@@ -36,15 +35,6 @@ func computeSnapSystemEpochDigest(alg tpm2.HashAlgorithmId, epoch uint32) tpm2.D
 	h := alg.NewHash()
 	binary.Write(h, binary.LittleEndian, epoch)
 	return h.Sum(nil)
-}
-
-// SnapModel exposes the details of a snap device model that are to be measured.
-type SnapModel interface {
-	Series() string
-	BrandID() string
-	Model() string
-	Grade() asserts.ModelGrade
-	SignKeyID() string
 }
 
 func computeSnapModelDigest(alg tpm2.HashAlgorithmId, model SnapModel) (tpm2.Digest, error) {

--- a/snapmodel_policy_test.go
+++ b/snapmodel_policy_test.go
@@ -21,46 +21,13 @@ package secboot_test
 
 import (
 	"encoding/binary"
-	"time"
 
 	"github.com/canonical/go-tpm2"
 	. "github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/testutil"
-	"github.com/snapcore/snapd/asserts"
 
 	. "gopkg.in/check.v1"
 )
-
-type snapModelTestBase struct{}
-
-func (tb *snapModelTestBase) makeMockCore20ModelAssertion(c *C, headers map[string]interface{}, signKeyHash string) SnapModel {
-	template := map[string]interface{}{
-		"type":              "model",
-		"architecture":      "amd64",
-		"base":              "core20",
-		"timestamp":         time.Now().Format(time.RFC3339),
-		"sign-key-sha3-384": signKeyHash,
-		"snaps": []interface{}{
-			map[string]interface{}{
-				"name": "fake-linux",
-				"id":   "fakelinuxidididididididididididi",
-				"type": "kernel",
-			},
-			map[string]interface{}{
-				"name": "fake-gadget",
-				"id":   "fakegadgetididididididididididid",
-				"type": "gadget",
-			},
-		},
-	}
-	for k, v := range headers {
-		template[k] = v
-	}
-
-	assertion, err := asserts.Assemble(template, nil, nil, []byte("AXNpZw=="))
-	c.Assert(err, IsNil)
-	return assertion.(SnapModel)
-}
 
 type snapModelProfileSuite struct {
 	snapModelTestBase

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "CT15zzEmXx3dQ7/PJCSwZhqSV/o=",
+			"path": "github.com/canonical/go-sp800.90a-drbg",
+			"revision": "6eeb1040d6c3a6b618a8da5e42ef66b35e7a3ddd",
+			"revisionTime": "2021-03-12T20:55:53Z"
+		},
+		{
 			"checksumSHA1": "HeHu/+gGhFD5UH8iApKz14DxJaw=",
 			"path": "github.com/canonical/go-tpm2",
 			"revision": "14cc20cfdf983fc6894fce8659c40acf3e6d3a73",


### PR DESCRIPTION
This adds an initial implementation of a platform-agnostic key API.
Several new types are added:

- KeyData, which is the main representation of a key.
- KeyDataReader, which is the interface that KeyData uses to read
key data from persistent storage.
- KeyDataWriter, which is the interface that KeyData uses to write
key data to persistent storage.
- KeyCreationData, which contains the information required to create
a new KeyData.
- KeyPayload, which represents the data protected by a KeyData object.
- PlatformKeyData, which represents the data exchanged between this
package and platform implementations.
- PlatformKeyDataHandler, which is the interface used by this package
to communicate with platform implementations.

Key data is stored in JSON.

The new API contains a mechanism to bind the key data to snap models,
so that the early boot environment can restrict access to encrypted
data to a previously authorized model. The binding is by way of a HMAC
created with a key that is stored in the encrypted payload along with
the disk unlock key.

Note that this doesn't yet contain a mechanism to unlock a volume using
this new API.

This is based on top of https://github.com/snapcore/secboot/pull/130