### PR TITLE
Remove ActivateOptions field from ActivateVolumeOptions

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -46,7 +46,7 @@ func keyringPrefixOrDefault(prefix string) string {
 
 // GetDiskUnlockKeyFromKernel retrieves the key that was used to unlock the
 // encrypted container at the specified path. The value of prefix must match
-// the prefix that was supplied via ActivateOptions during unlocking.
+// the prefix that was supplied via ActivateVolumeOptions during unlocking.
 //
 // If remove is true, the key will be removed from the kernel keyring prior
 // to returning.
@@ -74,8 +74,8 @@ func GetDiskUnlockKeyFromKernel(prefix, devicePath string, remove bool) (DiskUnl
 
 // GetAuxiliaryKeyFromKernel retrieves the auxiliary key associated with the
 // KeyData that was used to unlock the encrypted container at the specified path.
-// The value of prefix must match the prefix that was supplied via ActivateOptions
-// during unlocking.
+// The value of prefix must match the prefix that was supplied via
+// ActivateVolumeOptions during unlocking.
 //
 // If remove is true, the key will be removed from the kernel keyring prior
 // to returning.


### PR DESCRIPTION
This is currently unused by snapd.

The field is problematic because it exposes all of systemd-cryptsetup's
options, many of which are incompatible with how we use it in secboot.

If there is a genuine need in the future to expose some extra options,
this can be done with a more explicit API instead.

This also makes it slightly easier to move the TPM code out of the
core secboot package because it's not necessary to duplicate
makeActivateOptions or move it to an internal package.