### PR TITLE
Support provisioning the TPM with a custom SRK

### DIFF
--- a/crypt_tpm.go
+++ b/crypt_tpm.go
@@ -30,12 +30,13 @@ import (
 func unsealKeyFromTPM(tpm *TPMConnection, k *SealedKeyObject, pin string) ([]byte, error) {
 	sealedKey, _, err := k.UnsealFromTPM(tpm, pin)
 	if err == ErrTPMProvisioning {
+		// XXX: We should update this to execute on InvalidKeyFileError as well.
 		// ErrTPMProvisioning in this context might indicate that there isn't a valid persistent SRK. Have a go at creating one now and then
 		// retrying the unseal operation - if the previous SRK was evicted, the TPM owner hasn't changed and the storage hierarchy still
 		// has a null authorization value, then this will allow us to unseal the key without requiring any type of manual recovery. If the
-		// storage hierarchy has a non-null authorization value, ProvionTPM will fail. If the TPM owner has changed, ProvisionTPM might
-		// succeed, but UnsealFromTPM will fail with InvalidKeyFileError when retried.
-		if pErr := tpm.EnsureProvisioned(ProvisionModeWithoutLockout, nil); pErr == nil || pErr == ErrTPMProvisioningRequiresLockout {
+		// storage hierarchy has a non-null authorization value, creating a new SRK will fail. If the TPM owner has changed, we might be
+		// able to create a new SRK but UnsealFromTPM will fail with InvalidKeyFileError when retried.
+		if _, pErr := provisionStoragePrimaryKey(tpm.TPMContext, tpm.HmacSession()); pErr == nil {
 			sealedKey, _, err = k.UnsealFromTPM(tpm, pin)
 		}
 	}

--- a/export_test.go
+++ b/export_test.go
@@ -30,6 +30,7 @@ import (
 const (
 	CurrentMetadataVersion = currentMetadataVersion
 	LockNVHandle           = lockNVHandle
+	SrkTemplateHandle      = srkTemplateHandle
 )
 
 // Export variables and unexported functions for testing

--- a/provisioning.go
+++ b/provisioning.go
@@ -43,6 +43,10 @@ const (
 	recoveryTime    uint32 = 7200
 	lockoutRecovery uint32 = 86400
 
+	// srkTemplateHandle is the NV index at which we can find a custom template for
+	// the storage primary key, if one is supplied during provisioning. The handle
+	// here is in the range reserved for owner indices, so there shouldn't be
+	// anything here on a new installation.
 	srkTemplateHandle tpm2.Handle = 0x01810001
 )
 

--- a/provisioning.go
+++ b/provisioning.go
@@ -25,6 +25,7 @@ import (
 	"os"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 	"github.com/snapcore/secboot/internal/tcg"
 
 	"golang.org/x/xerrors"
@@ -41,6 +42,8 @@ const (
 	maxTries        uint32 = 32
 	recoveryTime    uint32 = 7200
 	lockoutRecovery uint32 = 86400
+
+	srkTemplateHandle tpm2.Handle = 0x01810001
 )
 
 // ProvisionMode is used to control the behaviour of TPMConnection.EnsureProvisioned.
@@ -90,7 +93,87 @@ func provisionPrimaryKey(tpm *tpm2.TPMContext, hierarchy tpm2.ResourceContext, t
 	return obj, nil
 }
 
-// EnsureProvisioned prepares the TPM for full disk encryption. The mode parameter specifies the behaviour of this function.
+func selectSrkTemplate(tpm *tpm2.TPMContext, session tpm2.SessionContext) *tpm2.Public {
+	nv, err := tpm.CreateResourceContextFromTPM(srkTemplateHandle)
+	if err != nil {
+		return tcg.SRKTemplate
+	}
+
+	nvPub, _, err := tpm.NVReadPublic(nv, session.IncludeAttrs(tpm2.AttrAudit))
+	if err != nil {
+		return tcg.SRKTemplate
+	}
+
+	b, err := tpm.NVRead(tpm.OwnerHandleContext(), nv, nvPub.Size, 0, session)
+	if err != nil {
+		return tcg.SRKTemplate
+	}
+
+	var tmpl *tpm2.Public
+	if _, err := mu.UnmarshalFromBytes(b, &tmpl); err != nil {
+		return tcg.SRKTemplate
+	}
+
+	if !tmpl.IsParent() {
+		return tcg.SRKTemplate
+	}
+
+	return tmpl
+}
+
+func provisionStoragePrimaryKey(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
+	return provisionPrimaryKey(tpm, tpm.OwnerHandleContext(), selectSrkTemplate(tpm, session), tcg.SRKHandle, session)
+}
+
+func storeSrkTemplate(tpm *tpm2.TPMContext, template *tpm2.Public, session tpm2.SessionContext) error {
+	tmplB, err := mu.MarshalToBytes(template)
+	if err != nil {
+		return xerrors.Errorf("cannot marshal template: %w", err)
+	}
+
+	nvPub := tpm2.NVPublic{
+		Index:   srkTemplateHandle,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVOwnerRead | tpm2.AttrNVNoDA),
+		Size:    uint16(len(tmplB))}
+	nv, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &nvPub, session)
+	if err != nil {
+		return xerrors.Errorf("cannot define NV index: %w", err)
+	}
+
+	if err := tpm.NVWrite(nv, nv, tmplB, 0, session); err != nil {
+		return xerrors.Errorf("cannot write NV index: %w", err)
+	}
+
+	if err := tpm.NVWriteLock(nv, nv, session); err != nil {
+		return xerrors.Errorf("cannot write lock NV index: %w", err)
+	}
+
+	return nil
+}
+
+func removeStoredSrkTemplate(tpm *tpm2.TPMContext, session tpm2.SessionContext) error {
+	nv, err := tpm.CreateResourceContextFromTPM(srkTemplateHandle)
+	switch {
+	case err != nil && !tpm2.IsResourceUnavailableError(err, srkTemplateHandle):
+		// Unexpected error
+		return xerrors.Errorf("cannot create resource context: %w", err)
+	case tpm2.IsResourceUnavailableError(err, srkTemplateHandle):
+		// Ok, nothing to do
+		return nil
+	}
+
+	if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), nv, session); err != nil {
+		return xerrors.Errorf("cannot undefine index: %w", err)
+	}
+
+	return nil
+}
+
+// EnsureProvisionedWithCustomSRK prepares the TPM for full disk encryption. The mode parameter specifies the behaviour of this
+// function.
+//
+// EnsureProvisioned is generally preferred over this function.
 //
 // If mode is ProvisionModeClear, this function will attempt to clear the TPM before provisioning it. If owner clear has been
 // disabled (which will be the case if the TPM has previously been provisioned with this function), then ErrTPMClearRequiresPPI
@@ -114,25 +197,32 @@ func provisionPrimaryKey(tpm *tpm2.TPMContext, hierarchy tpm2.ResourceContext, t
 // If mode is ProvisionModeFull or ProvisionModeWithoutLockout, this function will not affect the ability to recover sealed keys that
 // can currently be recovered.
 //
-// In all modes, this function will create and persist both a storage root key and an endorsement key. Both of these will be created
-// using the RSA templates defined in and persisted at the handles specified in the "TCG EK Credential Profile for TPM Family 2.0"
-// and "TCG TPM v2.0 Provisioning Guidance" specifications. If there are any objects already stored at the locations required for
-// either primary key, then this function will evict them automatically from the TPM. These operations both require the use of the
-// storage and endorsement hierarchies. If mode is ProvisionModeFull or ProvisionModeWithoutLockout, then knowledge of the
-// authorization values for these hierarchies is required. Whilst these will be empty after clearing the TPM, if they have been set
-// since clearing the TPM then they will need to be provided by calling TPMConnection.EndorsementHandleContext().SetAuthValue() and
-// TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the wrong value is provided for either
-// authorization, then a AuthFailError error will be returned. If the correct authorization values are not known, then the only way
-// to recover from this is to clear the TPM either by calling this function with mode set to ProvisionModeClear (and providing the
-// correct authorization value for the lockout hierarchy), or by using the physical presence interface.
+// In all modes, this function will create and persist both a storage root key and an endorsement key. Both of these will be
+// persisted at the handles specied in the "TCG TPM v2.0 Provisioning Guidance" specification. The endorsement key will be
+// created using the RSA template defined in the "TCG EK Credential Profile for TPM Family 2.0" specification. The storage root
+// key will be created using the RSA template defined in the "TCG TPM v2.0 Provisioning Guidance" specification unless the
+// srkTemplate argument is supplied, in which case, this template will be used instead. If there are any objects already stored
+// at the locations required for either primary key, then this function will evict them automatically from the TPM. These
+// operations both require the use of the storage and endorsement hierarchies. If mode is ProvisionModeFull or
+// ProvisionModeWithoutLockout, then knowledge of the authorization values for these hierarchies is required. Whilst these will be
+// empty after clearing the TPM, if they have been set since clearing the TPM then they will need to be provided by calling
+// TPMConnection.EndorsementHandleContext().SetAuthValue() and TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling
+// this function. If the wrong value is provided for either authorization, then a AuthFailError error will be returned. If the
+// correct authorization values are not known, then the only way to recover from this is to clear the TPM either by calling this
+// function with mode set to ProvisionModeClear (and providing the correct authorization value for the lockout hierarchy), or by
+// using the physical presence interface.
 //
 // If mode is ProvisionModeWithoutLockout but the TPM indicates that use of the lockout hierarchy is required to fully provision the
 // TPM (eg, to disable owner clear, set the lockout hierarchy authorization value or configure the DA lockout parameters), then a
 // ErrTPMProvisioningRequiresLockout error will be returned. In this scenario, the function will complete all operations that can be
 // completed without using the lockout hierarchy, but the function should be called again either with mode set to ProvisionModeFull
 // (if the authorization value for the lockout hierarchy is known), or ProvisionModeClear.
-func (t *TPMConnection) EnsureProvisioned(mode ProvisionMode, newLockoutAuth []byte) error {
+func (t *TPMConnection) EnsureProvisionedWithCustomSRK(mode ProvisionMode, newLockoutAuth []byte, srkTemplate *tpm2.Public) error {
 	session := t.HmacSession()
+
+	if srkTemplate != nil && !srkTemplate.IsParent() {
+		return errors.New("supplied SRK template is not valid for a parent key")
+	}
 
 	props, err := t.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1, session.IncludeAttrs(tpm2.AttrAudit))
 	if err != nil {
@@ -180,8 +270,18 @@ func (t *TPMConnection) EnsureProvisioned(mode ProvisionMode, newLockoutAuth []b
 	}
 	session = t.HmacSession()
 
+	if srkTemplate != nil {
+		if err := storeSrkTemplate(t.TPMContext, srkTemplate, session); err != nil {
+			return xerrors.Errorf("cannot store custom SRK template: %w", err)
+		}
+	} else if mode != ProvisionModeClear {
+		if err := removeStoredSrkTemplate(t.TPMContext, session); err != nil {
+			return xerrors.Errorf("cannot remove stored custom SRK template: %w", err)
+		}
+	}
+
 	// Provision a storage root key
-	srk, err := provisionPrimaryKey(t.TPMContext, t.OwnerHandleContext(), tcg.SRKTemplate, tcg.SRKHandle, session)
+	srk, err := provisionStoragePrimaryKey(t.TPMContext, session)
 	if err != nil {
 		switch {
 		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
@@ -244,6 +344,51 @@ func (t *TPMConnection) EnsureProvisioned(mode ProvisionMode, newLockoutAuth []b
 	}
 
 	return nil
+}
+
+// EnsureProvisioned prepares the TPM for full disk encryption. The mode parameter specifies the behaviour of this function.
+//
+// If mode is ProvisionModeClear, this function will attempt to clear the TPM before provisioning it. If owner clear has been
+// disabled (which will be the case if the TPM has previously been provisioned with this function), then ErrTPMClearRequiresPPI
+// will be returned. In this case, the TPM must be cleared via the physical presence interface by calling RequestTPMClearUsingPPI
+// and performing a system restart. Note that clearing the TPM makes all previously sealed keys permanently unrecoverable. This
+// mode should normally be used when resetting a device to factory settings (ie, performing a new installation).
+//
+// If mode is ProvisionModeClear or ProvisionModeFull, then the authorization value for the lockout hierarchy will be set to
+// newLockoutAuth, owner clear will be disabled, and the parameters of the TPM's dictionary attack logic will be configured to
+// appropriate values.
+//
+// If mode is ProvisionModeClear or ProvisionModeFull, this function performs operations that require the use of the lockout
+// hierarchy (detailed above), and knowledge of the lockout hierarchy's authorization value. This must be provided by calling
+// TPMConnection.LockoutHandleContext().SetAuthValue() prior to this call. If the wrong lockout hierarchy authorization value is
+// provided, then a AuthFailError error will be returned. If this happens, the TPM will have entered dictionary attack lockout mode
+// for the lockout hierarchy. Further calls will result in a ErrTPMLockout error being returned. The only way to recover from this is
+// to either wait for the pre-programmed recovery time to expire, or to clear the TPM via the physical presence interface by calling
+// RequestTPMClearUsingPPI. If the lockout hierarchy authorization value is not known then mode should be set to
+// ProvisionModeWithoutLockout, with the caveat that this mode cannot fully provision the TPM.
+//
+// If mode is ProvisionModeFull or ProvisionModeWithoutLockout, this function will not affect the ability to recover sealed keys that
+// can currently be recovered.
+//
+// In all modes, this function will create and persist both a storage root key and an endorsement key. Both of these will be created
+// using the RSA templates defined in and persisted at the handles specified in the "TCG EK Credential Profile for TPM Family 2.0"
+// and "TCG TPM v2.0 Provisioning Guidance" specifications. If there are any objects already stored at the locations required for
+// either primary key, then this function will evict them automatically from the TPM. These operations both require the use of the
+// storage and endorsement hierarchies. If mode is ProvisionModeFull or ProvisionModeWithoutLockout, then knowledge of the
+// authorization values for these hierarchies is required. Whilst these will be empty after clearing the TPM, if they have been set
+// since clearing the TPM then they will need to be provided by calling TPMConnection.EndorsementHandleContext().SetAuthValue() and
+// TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the wrong value is provided for either
+// authorization, then a AuthFailError error will be returned. If the correct authorization values are not known, then the only way
+// to recover from this is to clear the TPM either by calling this function with mode set to ProvisionModeClear (and providing the
+// correct authorization value for the lockout hierarchy), or by using the physical presence interface.
+//
+// If mode is ProvisionModeWithoutLockout but the TPM indicates that use of the lockout hierarchy is required to fully provision the
+// TPM (eg, to disable owner clear, set the lockout hierarchy authorization value or configure the DA lockout parameters), then a
+// ErrTPMProvisioningRequiresLockout error will be returned. In this scenario, the function will complete all operations that can be
+// completed without using the lockout hierarchy, but the function should be called again either with mode set to ProvisionModeFull
+// (if the authorization value for the lockout hierarchy is known), or ProvisionModeClear.
+func (t *TPMConnection) EnsureProvisioned(mode ProvisionMode, newLockoutAuth []byte) error {
+	return t.EnsureProvisionedWithCustomSRK(mode, newLockoutAuth, nil)
 }
 
 // RequestTPMClearUsingPPI submits a request to the firmware to clear the TPM on the next reboot. This is the only way to clear

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -580,6 +580,10 @@ func TestProvisionWithCustomSRKTemplate(t *testing.T) {
 				t.Fatalf("NVReadPublic failed: %v", err)
 			}
 
+			if nvPub.Attrs != tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVOwnerRead | tpm2.AttrNVNoDA | tpm2.AttrNVWriteLocked | tpm2.AttrNVWritten) {
+				t.Errorf("Unexpected attributes")
+			}
+
 			tmplB, err := tpm.NVRead(tpm.OwnerHandleContext(), nv, nvPub.Size, 0, nil)
 			if err != nil {
 				t.Errorf("NVRead failed: %v", err)

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -630,7 +630,7 @@ func TestProvisionWithInvalidCustomSRKTemplate(t *testing.T) {
 	}
 }
 
-func TestRemoveStoredCustomSRKTemplate(t *testing.T) {
+func TestProvisionDefaultRemovesCustomSRKTemplate(t *testing.T) {
 	tpm, _ := openTPMSimulatorForTesting(t)
 	defer func() {
 		clearTPMWithPlatformAuth(t, tpm)

--- a/seal.go
+++ b/seal.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
-	"github.com/snapcore/secboot/internal/tcg"
 
 	"golang.org/x/xerrors"
 )
@@ -198,7 +197,7 @@ func SealKeyToTPMMultiple(tpm *TPMConnection, keys []*SealKeyRequest, params *Ke
 	srk := tpm.provisionedSrk
 	if srk == nil {
 		var err error
-		srk, err = provisionPrimaryKey(tpm.TPMContext, tpm.OwnerHandleContext(), tcg.SRKTemplate, tcg.SRKHandle, session)
+		srk, err = provisionStoragePrimaryKey(tpm.TPMContext, session)
 		switch {
 		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
 			return nil, AuthFailError{tpm2.HandleOwner}

--- a/seal_test.go
+++ b/seal_test.go
@@ -197,7 +197,7 @@ func TestSealKeyToTPM(t *testing.T) {
 			Params: &tpm2.PublicParamsU{
 				RSADetail: &tpm2.RSAParams{
 					Symmetric: tpm2.SymDefObject{Algorithm: tpm2.SymObjectAlgorithmNull},
-					Scheme:   tpm2.RSAScheme{
+					Scheme: tpm2.RSAScheme{
 						Scheme: tpm2.RSASchemeRSAPSS,
 						Details: &tpm2.AsymSchemeU{
 							RSAPSS: &tpm2.SigSchemeRSAPSS{HashAlg: tpm2.HashAlgorithmSHA256},

--- a/seal_test.go
+++ b/seal_test.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 	. "github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/tcg"
 	"github.com/snapcore/secboot/internal/testutil"
@@ -102,6 +103,7 @@ func TestSealKeyToTPM(t *testing.T) {
 	})
 
 	t.Run("NoSRK", func(t *testing.T) {
+		// Ensure that calling SealKeyToTPM recreates the SRK with the standard template
 		tpm := openTPMForTesting(t)
 		defer closeTPM(t, tpm)
 
@@ -114,6 +116,61 @@ func TestSealKeyToTPM(t *testing.T) {
 		}
 
 		run(t, tpm, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
+
+		validateSRK(t, tpm.TPMContext)
+	})
+
+	t.Run("NoCustomSRK", func(t *testing.T) {
+		// Ensure that calling SealKeyToTPM recreates the SRK with the custom
+		// template originally supplied during provisioning
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+		if err != nil {
+			t.Fatalf("No SRK: %v", err)
+		}
+		if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), srk, srk.Handle(), nil); err != nil {
+			t.Errorf("EvictControl failed: %v", err)
+		}
+
+		template := tpm2.Public{
+			Type:    tpm2.ObjectTypeRSA,
+			NameAlg: tpm2.HashAlgorithmSHA256,
+			Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrUserWithAuth | tpm2.AttrNoDA |
+				tpm2.AttrRestricted | tpm2.AttrDecrypt,
+			Params: &tpm2.PublicParamsU{
+				RSADetail: &tpm2.RSAParams{
+					Symmetric: tpm2.SymDefObject{
+						Algorithm: tpm2.SymObjectAlgorithmAES,
+						KeyBits:   &tpm2.SymKeyBitsU{Sym: 128},
+						Mode:      &tpm2.SymModeU{Sym: tpm2.SymModeCFB}},
+					Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
+					KeyBits:  2048,
+					Exponent: 0}}}
+
+		tmplB, err := mu.MarshalToBytes(template)
+		if err != nil {
+			t.Errorf("MarshalToBytes failed: %v", err)
+		}
+
+		nvPub := tpm2.NVPublic{
+			Index:   SrkTemplateHandle,
+			NameAlg: tpm2.HashAlgorithmSHA256,
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVOwnerRead | tpm2.AttrNVNoDA),
+			Size:    uint16(len(tmplB))}
+		nv, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &nvPub, nil)
+		if err != nil {
+			t.Fatalf("MarshalToBytes failed: %v", err)
+		}
+
+		if err := tpm.NVWrite(nv, nv, tmplB, 0, nil); err != nil {
+			t.Errorf("NVWrite failed: %v", err)
+		}
+
+		run(t, tpm, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: 0x01810000})
+
+		validatePrimaryKeyAgainstTemplate(t, tpm.TPMContext, tpm2.HandleOwner, tcg.SRKHandle, &template)
 	})
 
 	t.Run("NilPCRProfile", func(t *testing.T) {


### PR DESCRIPTION
TPMConnection.EnsureProvisioned will create and persist a storage
primary key as described in the "TCG TPM v2.0 Provisioning Guidance"
specification (https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf).

This specification says that the unique field of the storage primary
key template should be 256 bytes of zeroes, which is the same as the
endorsement key template.

However, many existing tools (including tpm2-tools) define the template
for the storage primary key with an empty unique field, and this creates
a different primary key. This is a deviation from the TCG specifications.

Whilst this isn't a problem for Ubuntu Core, it may be a problem on
systems where the initial encryption and key protection happens before
first boot, and the disk unlock key is protected with a primary key that
is created with third party tools.

In order to support this scenario, introduce a new
TPMConnection.EnsureProvisionedWithCustomSRK API. It is not expected that
this API will be used on Ubuntu Core, but may be used elsewhere.

Note that SealKeyToTPM unconditionally recreates the storage primary
key if it is executed with a TPMConnection that didn't perform the
provisioning step. The reason for this is that creating the primary
key is really the only way to ensure that we are sealing to a key that
we know we can recreate if it is deleted in the future. In order to
avoid extending the SealKeyToTPM API, the new EnsureProvisionedWithCustomSRK
function will store the custom template used to create the primary key
inside the TPM. SealKeyToTPM will use this template stored inside the TPM
(if it exists) to recreate the storage primary key.