### PR TITLE
Expose the TPM error when the public part of the elliptic key is invalid *debug only PR*

### DIFF
--- a/internal/testutil/suites.go
+++ b/internal/testutil/suites.go
@@ -76,7 +76,7 @@ func (b *TPMTestBase) setUpTestBase(c *C, tpm *secboot.TPMConnection) {
 				hc, err = b.TPM.CreateResourceContextFromTPM(h)
 				c.Check(err, IsNil)
 			case tpm2.HandleTypeHMACSession:
-				hc = tpm2.CreateIncompleteSessionContext(h)
+				hc = tpm2.CreatePartialHandleContext(h)
 			default:
 				c.Fatalf("Unexpected handle type")
 			}

--- a/policy.go
+++ b/policy.go
@@ -769,7 +769,7 @@ func executePolicySession(tpm *tpm2.TPMContext, policySession tpm2.SessionContex
 	if err != nil {
 		if tpm2.IsTPMParameterError(err, tpm2.AnyErrorCode, tpm2.CommandLoadExternal, 2) {
 			// staticInput.AuthPublicKey is invalid
-			return staticPolicyDataError{errors.New("public area of dynamic authorization policy signing key is invalid")}
+			return staticPolicyDataError{xerrors.Errorf("public area of dynamic authorization policy signing key is invalid: %w", err)}
 		}
 		return xerrors.Errorf("cannot load public area for dynamic authorization policy signing key: %w", err)
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2021-03-12T20:55:53Z"
 		},
 		{
-			"checksumSHA1": "HeHu/+gGhFD5UH8iApKz14DxJaw=",
+			"checksumSHA1": "UYqZjF/41DZxSoSdAOnYlL1yrKQ=",
 			"path": "github.com/canonical/go-tpm2",
-			"revision": "14cc20cfdf983fc6894fce8659c40acf3e6d3a73",
-			"revisionTime": "2021-01-29T14:51:58Z"
+			"revision": "3926e4dcfeedab70d07ebd55425f8283b18f4a20",
+			"revisionTime": "2021-04-29T19:17:09Z"
 		},
 		{
 			"checksumSHA1": "bT/rC7K8St3lNRXf/XJGpB4wNJU=",


### PR DESCRIPTION
There is a test failure in travis which isn't reproducible locally