### PR TITLE
Add SealKeyToExternalTPMStorageKey API

### DIFF
--- a/keydata_tpm.go
+++ b/keydata_tpm.go
@@ -386,6 +386,10 @@ func (d *tpmKeyData) Unmarshal(r mu.Reader) error {
 	return nil
 }
 
+// ensureImported will import the sealed key object into the TPM's storage hierarchy if
+// required, as indicated by an import symmetric seed of non-zero length. The tpmKeyData
+// structure will be updated with the newly imported private area and the import
+// symmetric seed will be cleared.
 func (d *tpmKeyData) ensureImported(tpm *tpm2.TPMContext, session tpm2.SessionContext) error {
 	if len(d.importSymSeed) == 0 {
 		return nil

--- a/seal.go
+++ b/seal.go
@@ -27,6 +27,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/canonical/go-tpm2"
@@ -44,29 +45,48 @@ func makeSealedKeyTemplate() *tpm2.Public {
 		Params:  &tpm2.PublicParamsU{KeyedHashDetail: &tpm2.KeyedHashParams{Scheme: tpm2.KeyedHashScheme{Scheme: tpm2.KeyedHashSchemeNull}}}}
 }
 
+func makeImportableSealedKeyTemplate() *tpm2.Public {
+	tmpl := makeSealedKeyTemplate()
+	tmpl.Attrs &^= tpm2.AttrFixedTPM | tpm2.AttrFixedParent
+	return tmpl
+}
+
 func computeSealedKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, version uint32, alg, signAlg tpm2.HashAlgorithmId, authKey crypto.PrivateKey,
 	counterPub *tpm2.NVPublic, counterAuthPolicies tpm2.DigestList, pcrProfile *PCRProtectionProfile,
 	session tpm2.SessionContext) (*dynamicPolicyData, error) {
-	// Obtain the count for the new policy
+
 	var nextPolicyCount uint64
 	var counterName tpm2.Name
-	if counterPub != nil {
+	var supportedPcrs tpm2.PCRSelectionList
+	if tpm != nil {
 		var err error
-		nextPolicyCount, err = readPcrPolicyCounter(tpm, version, counterPub, counterAuthPolicies, session)
-		if err != nil {
-			return nil, xerrors.Errorf("cannot read policy counter: %w", err)
-		}
-		nextPolicyCount += 1
+		// Obtain the count for the new policy
+		if counterPub != nil {
+			nextPolicyCount, err = readPcrPolicyCounter(tpm, version, counterPub, counterAuthPolicies, session)
+			if err != nil {
+				return nil, xerrors.Errorf("cannot read policy counter: %w", err)
+			}
+			nextPolicyCount += 1
 
-		counterName, err = counterPub.Name()
-		if err != nil {
-			return nil, xerrors.Errorf("cannot compute name of policy counter: %w", err)
+			counterName, err = counterPub.Name()
+			if err != nil {
+				return nil, xerrors.Errorf("cannot compute name of policy counter: %w", err)
+			}
 		}
-	}
 
-	supportedPcrs, err := tpm.GetCapabilityPCRs(session.IncludeAttrs(tpm2.AttrAudit))
-	if err != nil {
-		return nil, xerrors.Errorf("cannot determine supported PCRs: %w", err)
+		supportedPcrs, err = tpm.GetCapabilityPCRs(session.IncludeAttrs(tpm2.AttrAudit))
+		if err != nil {
+			return nil, xerrors.Errorf("cannot determine supported PCRs: %w", err)
+		}
+	} else {
+		if counterPub != nil {
+			return nil, errors.New("use of policy counter requires a TPM connection")
+		}
+
+		// Defined as mandatory in the TCG PC Client Platform TPM Profile Specification for TPM 2.0
+		supportedPcrs = tpm2.PCRSelectionList{
+			{Hash: tpm2.HashAlgorithmSHA1, Select: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}},
+			{Hash: tpm2.HashAlgorithmSHA256, Select: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}}}
 	}
 
 	// Compute PCR digests
@@ -133,6 +153,148 @@ type KeyCreationParams struct {
 	// If set a key from elliptic.P256 must be used,
 	// if not set one is generated.
 	AuthKey *ecdsa.PrivateKey
+}
+
+// SealKeyToTPMStorageKey seals the supplied disk encryption key to the TPM storage key associated with the supplied public tpmKey.
+// This creates an importable sealed key and is suitable in environments that don't have access to the TPM but do have access to
+// the public part of the TPM's storage primary key. The sealed key object and associated metadata that is required during early
+// boot in order to unseal the key again and unlock the associated encrypted volume is written to a file at the path specified by
+// keyPath.
+//
+// The tpmKey argument must correspond to the storage primary key on the target TPM, persisted at the standard handle.
+//
+// This function expects there to be no file at the specified path. If keyPath references a file that already exists, a wrapped
+// *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be returned if
+// the file cannot be created and opened for writing.
+//
+// This function cannot create a sealed key that uses a PCR policy counter. The PCRPolicyCounterHandle field of the params argument
+// must be tpm2.HandleNull.
+//
+// The key will be protected with a PCR policy computed from the PCRProtectionProfile supplied via the PCRProfile field of the params
+// argument.
+//
+// On success, this function returns the private part of the key used for authorizing PCR policy updates with
+// UpdateKeyPCRProtectionPolicy. This key doesn't need to be stored anywhere, and certainly mustn't be stored outside of the encrypted
+// volume protected with this sealed key file. The key is stored encrypted inside this sealed key file and returned from future calls
+// to SealedKeyObject.UnsealFromTPM.
+//
+// The authorization key can also be chosen and provided by setting
+// AuthKey in the params argument.
+func SealKeyToTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath string, params *KeyCreationParams) (authKey TPMPolicyAuthKey, err error) {
+	// params is mandatory.
+	if params == nil {
+		return nil, errors.New("no KeyCreationParams provided")
+	}
+
+	// Perform some sanity checks on params.
+	if params.AuthKey != nil && params.AuthKey.Curve != elliptic.P256() {
+		return nil, errors.New("provided AuthKey must be from elliptic.P256, no other curve is supported")
+	}
+
+	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		return nil, errors.New("PCRPolicyCounter must be tpm2.HandleNull when creating an importable sealed key")
+	}
+
+	succeeded := false
+
+	// Compute metadata.
+
+	var goAuthKey *ecdsa.PrivateKey
+	// Use the provided authorization key,
+	// otherwise create an asymmetric key for signing
+	// authorization policy updates, and authorizing dynamic
+	// authorization policy revocations.
+	if params.AuthKey != nil {
+		goAuthKey = params.AuthKey
+	} else {
+		goAuthKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot generate key for signing dynamic authorization policies: %w", err)
+		}
+	}
+	authPublicKey := createTPMPublicAreaForECDSAKey(&goAuthKey.PublicKey)
+	authKey = goAuthKey.D.Bytes()
+
+	pub := makeImportableSealedKeyTemplate()
+
+	// Compute the static policy - this never changes for the lifetime of this key file
+	staticPolicyData, authPolicy, err := computeStaticPolicy(pub.NameAlg, &staticPolicyComputeParams{key: authPublicKey})
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute static authorization policy: %w", err)
+	}
+
+	pub.AuthPolicy = authPolicy
+
+	// Create a dynamic authorization policy
+	pcrProfile := params.PCRProfile
+	if pcrProfile == nil {
+		pcrProfile = &PCRProtectionProfile{}
+	}
+	dynamicPolicyData, err := computeSealedKeyDynamicAuthPolicy(nil, currentMetadataVersion, pub.NameAlg, authPublicKey.NameAlg,
+		goAuthKey, nil, nil, pcrProfile, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
+	}
+
+	// Clean up files on failure.
+	defer func() {
+		if succeeded {
+			return
+		}
+		os.Remove(keyPath)
+	}()
+
+	// Seal key
+
+	// Create the destination file
+	f, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create key data file: %w", err)
+	}
+	defer f.Close()
+
+	// Create the sensitive data
+	sealedData, err := mu.MarshalToBytes(sealedData{Key: key, AuthPrivateKey: authKey})
+	if err != nil {
+		panic(fmt.Sprintf("cannot marshal sensitive data: %v", err))
+	}
+	sensitive := tpm2.Sensitive{
+		Type:      pub.Type,
+		AuthValue: make(tpm2.Auth, pub.NameAlg.Size()),
+		SeedValue: make(tpm2.Digest, pub.NameAlg.Size()),
+		Sensitive: &tpm2.SensitiveCompositeU{Bits: sealedData}}
+	if _, err := io.ReadFull(rand.Reader, sensitive.SeedValue); err != nil {
+		return nil, xerrors.Errorf("cannot create seed value: %w", err)
+	}
+
+	// Compute the public ID
+	h := pub.NameAlg.NewHash()
+	h.Write(sensitive.SeedValue)
+	h.Write(sensitive.Sensitive.Bits)
+	pub.Unique = &tpm2.PublicIDU{KeyedHash: h.Sum(nil)}
+
+	// Now create the importable sealed key object (duplication object).
+	_, priv, importSymSeed, err := tpm2.CreateDuplicationObjectFromSensitive(&sensitive, pub, tpmKey, nil, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create duplication object: %w", err)
+	}
+
+	// Marshal the entire object (sealed key object and auxiliary data) to disk
+	data := tpmKeyData{
+		version:           currentMetadataVersion,
+		keyPrivate:        priv,
+		keyPublic:         pub,
+		authModeHint:      authModeNone,
+		importSymSeed:     importSymSeed,
+		staticPolicyData:  staticPolicyData,
+		dynamicPolicyData: dynamicPolicyData}
+
+	if err := data.write(f); err != nil {
+		return nil, xerrors.Errorf("cannot write key data file: %w", err)
+	}
+
+	succeeded = true
+	return authKey, nil
 }
 
 // SealKeyRequest corresponds to a key that should be sealed by SealKeyToTPMMultiple

--- a/seal.go
+++ b/seal.go
@@ -258,9 +258,11 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath str
 	if err != nil {
 		panic(fmt.Sprintf("cannot marshal sensitive data: %v", err))
 	}
+	// Define the actual sensitive area. The initial auth value is empty - note
+	// that tpm2.CreateDuplicationObjectFromSensitive pads this to the length of
+	// the name algorithm for us so we don't define it here.
 	sensitive := tpm2.Sensitive{
 		Type:      pub.Type,
-		AuthValue: make(tpm2.Auth, pub.NameAlg.Size()),
 		SeedValue: make(tpm2.Digest, pub.NameAlg.Size()),
 		Sensitive: &tpm2.SensitiveCompositeU{Bits: sealedData}}
 	if _, err := io.ReadFull(rand.Reader, sensitive.SeedValue); err != nil {

--- a/seal.go
+++ b/seal.go
@@ -51,6 +51,17 @@ func makeImportableSealedKeyTemplate() *tpm2.Public {
 	return tmpl
 }
 
+// computeSealedKeyDynamicAuthPolicy is a helper to compute a new PCR policy using the supplied
+// pcrProfile, signed with the supplied authKey.
+//
+// If tpm is not nil, this function will verify that the supplied pcrProfile produces a PCR
+// selection that is supported by the TPM. If tpm is nil, it will be assumed that the target
+// TPM supports the PCRs and algorithms defined in the TCG PC Client Platform TPM Profile
+// Specification for TPM 2.0.
+//
+// If tpm is not nil and counterPub is supplied, the current policy count will be read from
+// the TPM and the new PCR policy will have a count of this value + 1. If tpm is nil then
+// counterPub must also be nil, else an error will be returned.
 func computeSealedKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, version uint32, alg, signAlg tpm2.HashAlgorithmId, authKey crypto.PrivateKey,
 	counterPub *tpm2.NVPublic, counterAuthPolicies tpm2.DigestList, pcrProfile *PCRProtectionProfile,
 	session tpm2.SessionContext) (*dynamicPolicyData, error) {

--- a/seal.go
+++ b/seal.go
@@ -155,11 +155,11 @@ type KeyCreationParams struct {
 	AuthKey *ecdsa.PrivateKey
 }
 
-// SealKeyToTPMStorageKey seals the supplied disk encryption key to the TPM storage key associated with the supplied public tpmKey.
-// This creates an importable sealed key and is suitable in environments that don't have access to the TPM but do have access to
-// the public part of the TPM's storage primary key. The sealed key object and associated metadata that is required during early
-// boot in order to unseal the key again and unlock the associated encrypted volume is written to a file at the path specified by
-// keyPath.
+// SealKeyToExternalTPMStorageKey seals the supplied disk encryption key to the TPM storage key associated with the supplied public
+// tpmKey. This creates an importable sealed key and is suitable in environments that don't have access to the TPM but do have
+// access to the public part of the TPM's storage primary key. The sealed key object and associated metadata that is required
+// during early boot in order to unseal the key again and unlock the associated encrypted volume is written to a file at the path
+// specified by keyPath.
 //
 // The tpmKey argument must correspond to the storage primary key on the target TPM, persisted at the standard handle.
 //
@@ -180,7 +180,7 @@ type KeyCreationParams struct {
 //
 // The authorization key can also be chosen and provided by setting
 // AuthKey in the params argument.
-func SealKeyToTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath string, params *KeyCreationParams) (authKey TPMPolicyAuthKey, err error) {
+func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath string, params *KeyCreationParams) (authKey TPMPolicyAuthKey, err error) {
 	// params is mandatory.
 	if params == nil {
 		return nil, errors.New("no KeyCreationParams provided")

--- a/seal_test.go
+++ b/seal_test.go
@@ -394,7 +394,7 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 	})
 }
 
-func TestSealKeyToTPMStorageKey(t *testing.T) {
+func TestSealKeyToExternalTPMStorageKey(t *testing.T) {
 	var srkPub *tpm2.Public
 
 	func() {
@@ -424,7 +424,7 @@ func TestSealKeyToTPMStorageKey(t *testing.T) {
 	rand.Read(key)
 
 	run := func(t *testing.T, params *KeyCreationParams) (authKeyBytes []byte) {
-		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPMStorageKey_")
+		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToExternalTPMStorageKey_")
 		if err != nil {
 			t.Fatalf("Creating temporary directory failed: %v", err)
 		}
@@ -432,9 +432,9 @@ func TestSealKeyToTPMStorageKey(t *testing.T) {
 
 		keyFile := tmpDir + "/keydata"
 
-		authPrivateKey, err := SealKeyToTPMStorageKey(srkPub, key, keyFile, params)
+		authPrivateKey, err := SealKeyToExternalTPMStorageKey(srkPub, key, keyFile, params)
 		if err != nil {
-			t.Errorf("SealKeyToTPMStorageKey failed: %v", err)
+			t.Errorf("SealKeyToExternalTPMStorageKey failed: %v", err)
 		}
 
 		tpm := openTPMForTesting(t)
@@ -467,7 +467,7 @@ func TestSealKeyToTPMStorageKey(t *testing.T) {
 	})
 }
 
-func TestSealKeyToTPMStorageKeyErrorHandling(t *testing.T) {
+func TestSealKeyToExternalTPMStorageKeyErrorHandling(t *testing.T) {
 	var srkPub *tpm2.Public
 
 	func() {
@@ -495,7 +495,7 @@ func TestSealKeyToTPMStorageKeyErrorHandling(t *testing.T) {
 	run := func(t *testing.T, tmpDir string, params *KeyCreationParams) error {
 		if tmpDir == "" {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "_TestSealKeyToTPMStorageKeyErrorHandling_")
+			tmpDir, err = ioutil.TempDir("", "_TestSealKeyToExternalTPMStorageKeyErrorHandling_")
 			if err != nil {
 				t.Fatalf("Creating temporary directory failed: %v", err)
 			}
@@ -505,7 +505,7 @@ func TestSealKeyToTPMStorageKeyErrorHandling(t *testing.T) {
 		keyFile := tmpDir + "/keydata"
 		origKeyFileInfo, _ := os.Stat(keyFile)
 
-		_, err := SealKeyToTPMStorageKey(srkPub, key, keyFile, params)
+		_, err := SealKeyToExternalTPMStorageKey(srkPub, key, keyFile, params)
 
 		if fi, err := os.Stat(keyFile); err == nil && (origKeyFileInfo == nil || origKeyFileInfo.ModTime() != fi.ModTime()) {
 			t.Errorf("SealKeyToTPM created a key file")

--- a/seal_test.go
+++ b/seal_test.go
@@ -394,6 +394,201 @@ func TestSealKeyToTPMErrorHandling(t *testing.T) {
 	})
 }
 
+func TestSealKeyToTPMStorageKey(t *testing.T) {
+	var srkPub *tpm2.Public
+
+	func() {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		if err := tpm.EnsureProvisioned(ProvisionModeFull, nil); err != nil {
+			t.Errorf("Failed to provision TPM for test: %v", err)
+		}
+
+		srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+		if err != nil {
+			t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
+		}
+
+		srkPub, _, _, err = tpm.ReadPublic(srk)
+		if err != nil {
+			t.Fatalf("ReadPublic failed: %v", err)
+		}
+	}()
+
+	pcrProfile := func() *PCRProtectionProfile {
+		return NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, make([]byte, 32))
+	}
+
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	run := func(t *testing.T, params *KeyCreationParams) (authKeyBytes []byte) {
+		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPMStorageKey_")
+		if err != nil {
+			t.Fatalf("Creating temporary directory failed: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		keyFile := tmpDir + "/keydata"
+
+		authPrivateKey, err := SealKeyToTPMStorageKey(srkPub, key, keyFile, params)
+		if err != nil {
+			t.Errorf("SealKeyToTPMStorageKey failed: %v", err)
+		}
+
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		if err := ValidateKeyDataFile(tpm.TPMContext, keyFile, authPrivateKey, tpm.HmacSession()); err != nil {
+			t.Errorf("ValidateKeyDataFile failed: %v", err)
+		}
+
+		return authPrivateKey
+	}
+
+	t.Run("Standard", func(t *testing.T) {
+		run(t, &KeyCreationParams{PCRProfile: pcrProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
+	})
+
+	t.Run("NilPCRProfile", func(t *testing.T) {
+		run(t, &KeyCreationParams{PCRPolicyCounterHandle: tpm2.HandleNull})
+	})
+
+	t.Run("WithProvidedAuthKey", func(t *testing.T) {
+		authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
+		if err != nil {
+			t.Fatalf("GenerateKey failed: %v", err)
+		}
+		pkb := run(t, &KeyCreationParams{PCRProfile: pcrProfile(), PCRPolicyCounterHandle: tpm2.HandleNull, AuthKey: authKey})
+		if !bytes.Equal(pkb, authKey.D.Bytes()) {
+			t.Fatalf("AuthKey private part bytes do not match provided one")
+		}
+	})
+}
+
+func TestSealKeyToTPMStorageKeyErrorHandling(t *testing.T) {
+	var srkPub *tpm2.Public
+
+	func() {
+		tpm := openTPMForTesting(t)
+		defer closeTPM(t, tpm)
+
+		if err := tpm.EnsureProvisioned(ProvisionModeFull, nil); err != nil {
+			t.Errorf("Failed to provision TPM for test: %v", err)
+		}
+
+		srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+		if err != nil {
+			t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
+		}
+
+		srkPub, _, _, err = tpm.ReadPublic(srk)
+		if err != nil {
+			t.Fatalf("ReadPublic failed: %v", err)
+		}
+	}()
+
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	run := func(t *testing.T, tmpDir string, params *KeyCreationParams) error {
+		if tmpDir == "" {
+			var err error
+			tmpDir, err = ioutil.TempDir("", "_TestSealKeyToTPMStorageKeyErrorHandling_")
+			if err != nil {
+				t.Fatalf("Creating temporary directory failed: %v", err)
+			}
+		}
+		defer os.RemoveAll(tmpDir)
+
+		keyFile := tmpDir + "/keydata"
+		origKeyFileInfo, _ := os.Stat(keyFile)
+
+		_, err := SealKeyToTPMStorageKey(srkPub, key, keyFile, params)
+
+		if fi, err := os.Stat(keyFile); err == nil && (origKeyFileInfo == nil || origKeyFileInfo.ModTime() != fi.ModTime()) {
+			t.Errorf("SealKeyToTPM created a key file")
+		}
+
+		return err
+	}
+
+	t.Run("NilParams", func(t *testing.T) {
+		err := run(t, "", nil)
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "no KeyCreationParams provided" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("FileExists", func(t *testing.T) {
+		tmpDir, err := ioutil.TempDir("", "_TestSealKeyToTPMErrors_")
+		if err != nil {
+			t.Fatalf("Creating temporary directory failed: %v", err)
+		}
+		f, err := os.OpenFile(tmpDir+"/keydata", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err != nil {
+			t.Fatalf("OpenFile failed: %v", err)
+		}
+		defer f.Close()
+		err = run(t, tmpDir, &KeyCreationParams{PCRPolicyCounterHandle: tpm2.HandleNull})
+		var e *os.PathError
+		if !xerrors.As(err, &e) || e.Path != tmpDir+"/keydata" || e.Err != syscall.EEXIST {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("InvalidPCRProfile", func(t *testing.T) {
+		pcrProfile := NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 7)
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: tpm2.HandleNull})
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "cannot compute dynamic authorization policy: cannot compute PCR digests from protection profile: cannot read "+
+			"current value of PCR 7 from bank TPM_ALG_SHA256: no TPM context" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("InvalidPCRProfileSelection", func(t *testing.T) {
+		pcrProfile := NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 50, make([]byte, tpm2.HashAlgorithmSHA256.Size()))
+		err := run(t, "", &KeyCreationParams{PCRProfile: pcrProfile, PCRPolicyCounterHandle: tpm2.HandleNull})
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "cannot compute dynamic authorization policy: PCR protection profile contains digests for unsupported PCRs" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("WrongCurve", func(t *testing.T) {
+		authKey, err := ecdsa.GenerateKey(elliptic.P384(), testutil.RandReader)
+		if err != nil {
+			t.Fatalf("GenerateKey failed: %v", err)
+		}
+		err = run(t, "", &KeyCreationParams{PCRPolicyCounterHandle: tpm2.HandleNull, AuthKey: authKey})
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "provided AuthKey must be from elliptic.P256, no other curve is supported" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("WithPCRPolicyCounter", func(t *testing.T) {
+		err := run(t, "", &KeyCreationParams{PCRPolicyCounterHandle: 0x01810000})
+		if err == nil {
+			t.Fatalf("Expected an error")
+		}
+		if err.Error() != "PCRPolicyCounter must be tpm2.HandleNull when creating an importable sealed key" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+}
+
 func TestUpdateKeyPCRProtectionPolicy(t *testing.T) {
 	tpm, _ := openTPMSimulatorForTesting(t)
 	defer closeTPM(t, tpm)

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -90,6 +90,76 @@ func TestUnsealWithNo2FA(t *testing.T) {
 	})
 }
 
+func TestUnsealImportable(t *testing.T) {
+	tpm := openTPMForTesting(t)
+	defer closeTPM(t, tpm)
+
+	if err := tpm.EnsureProvisioned(ProvisionModeFull, nil); err != nil {
+		t.Fatalf("Failed to provision TPM for test: %v", err)
+	}
+
+	srk, err := tpm.CreateResourceContextFromTPM(tcg.SRKHandle)
+	if err != nil {
+		t.Fatalf("CreateResourceContextFromTPM failed: %v", err)
+	}
+
+	srkPub, _, _, err := tpm.ReadPublic(srk)
+	if err != nil {
+		t.Fatalf("ReadPublic failed: %v", err)
+	}
+
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	pcrProfile := func(t *testing.T) *PCRProtectionProfile {
+		_, pcrValues, err := tpm.PCRRead(tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
+		if err != nil {
+			t.Fatalf("PCRRead failed: %v", err)
+		}
+		return NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, pcrValues[tpm2.HashAlgorithmSHA256][7])
+	}
+
+	run := func(t *testing.T, params *KeyCreationParams) {
+		tmpDir, err := ioutil.TempDir("", "_TestUnsealImportable_")
+		if err != nil {
+			t.Fatalf("Creating temporary directory failed: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		keyFile := tmpDir + "/keydata"
+
+		authKey, err := SealKeyToTPMStorageKey(srkPub, key, keyFile, params)
+		if err != nil {
+			t.Fatalf("SealKeyToTPMStorageKey failed: %v", err)
+		}
+
+		k, err := ReadSealedKeyObject(keyFile)
+		if err != nil {
+			t.Fatalf("ReadSealedKeyObject failed: %v", err)
+		}
+
+		keyUnsealed, authKeyUnsealed, err := k.UnsealFromTPM(tpm, "")
+		if err != nil {
+			t.Fatalf("UnsealFromTPM failed: %v", err)
+		}
+
+		if !bytes.Equal(key, keyUnsealed) {
+			t.Errorf("TPM returned the wrong key")
+		}
+		if !bytes.Equal(authKey, authKeyUnsealed) {
+			t.Errorf("TPM returned the wrong auth key")
+		}
+	}
+
+	t.Run("SimplePCRProfile", func(t *testing.T) {
+		run(t, &KeyCreationParams{PCRProfile: pcrProfile(t), PCRPolicyCounterHandle: tpm2.HandleNull})
+	})
+
+	t.Run("NilPCRProfile", func(t *testing.T) {
+		run(t, &KeyCreationParams{PCRPolicyCounterHandle: tpm2.HandleNull})
+	})
+}
+
 func TestUnsealRelated(t *testing.T) {
 	tpm := openTPMForTesting(t)
 	defer closeTPM(t, tpm)

--- a/unseal_test.go
+++ b/unseal_test.go
@@ -128,9 +128,9 @@ func TestUnsealImportable(t *testing.T) {
 
 		keyFile := tmpDir + "/keydata"
 
-		authKey, err := SealKeyToTPMStorageKey(srkPub, key, keyFile, params)
+		authKey, err := SealKeyToExternalTPMStorageKey(srkPub, key, keyFile, params)
 		if err != nil {
-			t.Fatalf("SealKeyToTPMStorageKey failed: %v", err)
+			t.Fatalf("SealKeyToExternalTPMStorageKey failed: %v", err)
 		}
 
 		k, err := ReadSealedKeyObject(keyFile)


### PR DESCRIPTION
This allows a key to be protected by an arbitrary TPM key without
access to the actual TPM. The key will be protected by a duplication
object that has to be imported into the target TPM before it is used.

Note that this doesn't yet include an API to persist the imported object,
although unsealing works ok as it imports the object automatically.
The imported object will be persisted automatically on the first modification
to the key data.