### PR TITLE
Use internal luks2 package

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -541,6 +541,10 @@ func InitializeLUKS2Container(devicePath, label string, key []byte, options *Ini
 		return err
 	}
 
+	// Configure the KDF with reduced cost. This is done because the supplied input key has an
+	// entropy of at least 32 bytes, and increased cost doesn't provide a security benefit because
+	// this key and these settings are already more secure than the 16-byte recovery key. Increased
+	// cost here only slows down unlocking.
 	opts := luks2.FormatOptions{KDFTime: 100 * time.Millisecond}
 	if options != nil {
 		opts.MetadataKiBSize = options.MetadataKiBSize
@@ -591,6 +595,10 @@ func ChangeLUKS2KeyUsingRecoveryKey(devicePath string, recoveryKey RecoveryKey, 
 		return xerrors.Errorf("cannot kill existing slot: %w", err)
 	}
 
+	// Configure the KDF with reduced cost. This is done because the supplied input key has an
+	// entropy of at least 32 bytes, and increased cost doesn't provide a security benefit because
+	// this key and these settings are already more secure than the 16-byte recovery key. Increased
+	// cost here only slows down unlocking.
 	options := luks2.AddKeyOptions{
 		KDFTime: 100 * time.Millisecond,
 		Slot:    0}

--- a/crypt.go
+++ b/crypt.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/snapcore/secboot/internal/keyring"
 	"github.com/snapcore/secboot/internal/luks2"
-	"github.com/snapcore/snapd/osutil"
 
 	"golang.org/x/xerrors"
 )
@@ -462,15 +461,6 @@ func ActivateVolumeWithKey(volumeName, sourceDevicePath string, key []byte, opti
 // This makes use of systemd-cryptsetup.
 func DeactivateVolume(volumeName string) error {
 	return luks2Deactivate(volumeName)
-}
-
-func setLUKS2KeyslotPreferred(devicePath string, slot int) error {
-	cmd := exec.Command("cryptsetup", "config", "--priority", "prefer", "--key-slot", strconv.Itoa(slot), devicePath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return osutil.OutputErr(output, err)
-	}
-
-	return nil
 }
 
 // InitializeLUKS2ContainerOptions carries options for initializing LUKS2

--- a/crypt.go
+++ b/crypt.go
@@ -651,9 +651,7 @@ func addKeyToLUKS2Container(devicePath string, existingKey, key []byte, extraOpt
 //
 // The recovery key is provided via the recoveryKey argument and must be a cryptographically secure 16-byte number.
 func AddRecoveryKeyToLUKS2Container(devicePath string, key []byte, recoveryKey RecoveryKey) error {
-	return addKeyToLUKS2Container(devicePath, key, recoveryKey[:], []string{
-		// use argon2i as the KDF with an increased cost
-		"--pbkdf", "argon2i", "--iter-time", "5000"})
+	return luks2.AddKey(devicePath, key, recoveryKey[:], 5*time.Second)
 }
 
 // ChangeLUKS2KeyUsingRecoveryKey changes the key normally used for unlocking the LUKS2 container at devicePath. This function

--- a/crypt.go
+++ b/crypt.go
@@ -33,10 +33,10 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	"github.com/snapcore/secboot/internal/keyring"
 	"github.com/snapcore/secboot/internal/luks2"
-
-	"golang.org/x/xerrors"
 )
 
 var (

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1596,13 +1596,13 @@ type testChangeLUKS2KeyUsingRecoveryKeyData struct {
 func (s *cryptSuite) testChangeLUKS2KeyUsingRecoveryKey(c *C, data *testChangeLUKS2KeyUsingRecoveryKeyData) {
 	c.Check(ChangeLUKS2KeyUsingRecoveryKey(data.devicePath, data.recoveryKey, data.key), IsNil)
 	c.Assert(len(s.mockCryptsetup.Calls()), Equals, 3)
-	c.Check(s.mockCryptsetup.Calls()[0], DeepEquals, []string{"cryptsetup", "luksKillSlot", "--key-file", "-", data.devicePath, "0"})
+	c.Check(s.mockCryptsetup.Calls()[0], DeepEquals, []string{"cryptsetup", "luksKillSlot", "--type", "luks2", "--key-file", "-", data.devicePath, "0"})
 
 	call := s.mockCryptsetup.Calls()[1]
-	c.Assert(len(call), Equals, 12)
-	c.Check(call[0:3], DeepEquals, []string{"cryptsetup", "luksAddKey", "--key-file"})
-	c.Check(call[3], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-	c.Check(call[4:12], DeepEquals, []string{"--pbkdf", "argon2i", "--iter-time", "100", "--key-slot", "0", data.devicePath, "-"})
+	c.Assert(len(call), Equals, 14)
+	c.Check(call[0:5], DeepEquals, []string{"cryptsetup", "luksAddKey", "--type", "luks2", "--key-file"})
+	c.Check(call[5], Matches, filepath.Join(paths.RunDir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
+	c.Check(call[6:14], DeepEquals, []string{"--pbkdf", "argon2i", "--iter-time", "100", "--key-slot", "0", data.devicePath, "-"})
 
 	c.Check(s.mockCryptsetup.Calls()[2], DeepEquals, []string{"cryptsetup", "config", "--priority", "prefer", "--key-slot", "0", data.devicePath})
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1650,19 +1650,19 @@ func (s *cryptSuite) TestChangeLUKS2KeyUsingRecoveryKey4(c *C) {
 	})
 }
 
-type cryptSuiteFull struct {
+type cryptSuiteExpensive struct {
 	cryptTestBase
 }
 
-func (s *cryptSuiteFull) SetUpTest(c *C) {
+func (s *cryptSuiteExpensive) SetUpTest(c *C) {
 	s.cryptTestBase.SetUpTest(c)
 
 	s.AddCleanup(luks2test.WrapCryptsetup(c))
 }
 
-var _ = Suite(&cryptSuiteFull{})
+var _ = Suite(&cryptSuiteExpensive{})
 
-func (s *cryptSuiteFull) testInitializeLUKS2Container(c *C, options *InitializeLUKS2ContainerOptions) {
+func (s *cryptSuiteExpensive) testInitializeLUKS2Container(c *C, options *InitializeLUKS2ContainerOptions) {
 	key := s.newPrimaryKey()
 	path := luks2test.CreateEmptyDiskImage(c, 20)
 
@@ -1703,18 +1703,18 @@ func (s *cryptSuiteFull) testInitializeLUKS2Container(c *C, options *InitializeL
 	c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntLessThan, int(float64(expectedKDFTime/time.Millisecond)*1.2)+500)
 }
 
-func (s *cryptSuiteFull) TestInitializeLUKS2Container(c *C) {
+func (s *cryptSuiteExpensive) TestInitializeLUKS2Container(c *C) {
 	s.testInitializeLUKS2Container(c, nil)
 }
 
-func (s *cryptSuiteFull) TestInitializeLUKS2ContainerWithOptions(c *C) {
+func (s *cryptSuiteExpensive) TestInitializeLUKS2ContainerWithOptions(c *C) {
 	s.testInitializeLUKS2Container(c, &InitializeLUKS2ContainerOptions{
 		MetadataKiBSize:     2 * 1024, // 2MiB
 		KeyslotsAreaKiBSize: 3 * 1024, // 3MiB
 	})
 }
 
-func (s *cryptSuiteFull) TestAddRecoveryKeyToLUKS2Container(c *C) {
+func (s *cryptSuiteExpensive) TestAddRecoveryKeyToLUKS2Container(c *C) {
 	key := s.newPrimaryKey()
 	path := luks2test.CreateEmptyDiskImage(c, 20)
 
@@ -1755,7 +1755,7 @@ func (s *cryptSuiteFull) TestAddRecoveryKeyToLUKS2Container(c *C) {
 	c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntLessThan, int(float64(expectedKDFTime/time.Millisecond)*1.2)+500)
 }
 
-func (s *cryptSuiteFull) ChangeLUKS2KeyUsingRecoveryKey(c *C) {
+func (s *cryptSuiteExpensive) ChangeLUKS2KeyUsingRecoveryKey(c *C) {
 	key := s.newPrimaryKey()
 	recoveryKey := s.newRecoveryKey()
 	path := luks2test.CreateEmptyDiskImage(c, 20)

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1653,6 +1653,14 @@ type cryptSuiteExpensive struct {
 	cryptTestBase
 }
 
+func (s *cryptSuiteExpensive) SetUpSuite(c *C) {
+	for _, e := range os.Environ() {
+		if e == "NO_EXPENSIVE_CRYPTSETUP_TESTS=1" {
+			c.Skip("skipping expensive cryptsetup tests")
+		}
+	}
+}
+
 func (s *cryptSuiteExpensive) SetUpTest(c *C) {
 	s.cryptTestBase.SetUpTest(c)
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -63,7 +63,6 @@ func (ctb *cryptTestBase) SetUpTest(c *C) {
 	ctb.KeyringTestBase.SetUpTest(c)
 
 	ctb.dir = c.MkDir()
-	ctb.AddCleanup(MockRunDir(ctb.dir))
 	ctb.AddCleanup(pathstest.MockRunDir(ctb.dir))
 
 	ctb.passwordFile = filepath.Join(ctb.dir, "password") // passwords to be returned by the mock sd-ask-password

--- a/crypt_tpm.go
+++ b/crypt_tpm.go
@@ -49,7 +49,7 @@ func unsealKeyFromTPMAndActivate(tpm *TPMConnection, volumeName, sourceDevicePat
 		return xerrors.Errorf("cannot unseal key: %w", err)
 	}
 
-	if err := activate(volumeName, sourceDevicePath, sealedKey); err != nil {
+	if err := luks2Activate(volumeName, sourceDevicePath, sealedKey); err != nil {
 		return xerrors.Errorf("cannot activate volume: %w", err)
 	}
 

--- a/crypt_tpm_test.go
+++ b/crypt_tpm_test.go
@@ -91,15 +91,15 @@ func (s *cryptTPMSimulatorSuite) TearDownTest(c *C) {
 }
 
 type testActivateVolumeWithMultipleTPMSealedKeysData struct {
-	volumeName        string
-	sourceDevicePath  string
-	keyFiles          []string
-	pinTries          int
-	recoveryKeyTries  int
-	keyringPrefix     string
-	sdCryptsetupCalls int
-	pins              []string
-	authPrivateKey    TPMPolicyAuthKey
+	volumeName       string
+	sourceDevicePath string
+	keyFiles         []string
+	pinTries         int
+	recoveryKeyTries int
+	keyringPrefix    string
+	activateTries    int
+	pins             []string
+	authPrivateKey   TPMPolicyAuthKey
 }
 
 func (s *cryptTPMSimulatorSuite) testActivateVolumeWithMultipleTPMSealedKeys(c *C, data *testActivateVolumeWithMultipleTPMSealedKeysData) {
@@ -119,12 +119,10 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithMultipleTPMSealedKeys(c *
 			filepath.Base(os.Args[0]) + ":" + data.sourceDevicePath, "Please enter the PIN for disk " + data.sourceDevicePath + ":"})
 	}
 
-	c.Check(len(s.mockSdCryptsetup.Calls()), Equals, data.sdCryptsetupCalls)
-	for _, call := range s.mockSdCryptsetup.Calls() {
-		c.Assert(call, HasLen, 6)
-		c.Check(call[0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", data.volumeName, data.sourceDevicePath})
-		c.Check(call[4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-		c.Check(call[5], Equals, "tries=1")
+	c.Check(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
+	for _, call := range s.mockLUKS2ActivateCalls {
+		c.Check(call.volumeName, Equals, data.volumeName)
+		c.Check(call.sourceDevicePath, Equals, data.sourceDevicePath)
 	}
 }
 
@@ -139,11 +137,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys1(c 
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{s.keyFile, keyFile},
-		sdCryptsetupCalls: 1,
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{s.keyFile, keyFile},
+		activateTries:    1,
+		authPrivateKey:   s.authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys2(c *C) {
@@ -158,11 +156,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys2(c 
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "foo",
-		sourceDevicePath:  "/dev/vda2",
-		keyFiles:          []string{s.keyFile, keyFile},
-		sdCryptsetupCalls: 1,
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "foo",
+		sourceDevicePath: "/dev/vda2",
+		keyFiles:         []string{s.keyFile, keyFile},
+		activateTries:    1,
+		authPrivateKey:   s.authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys3(c *C) {
@@ -177,11 +175,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys3(c 
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{keyFile, s.keyFile},
-		sdCryptsetupCalls: 1,
-		authPrivateKey:    authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{keyFile, s.keyFile},
+		activateTries:    1,
+		authPrivateKey:   authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys4(c *C) {
@@ -201,11 +199,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys4(c 
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{s.keyFile, keyFile},
-		sdCryptsetupCalls: 1,
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{s.keyFile, keyFile},
+		activateTries:    1,
+		authPrivateKey:   s.authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys5(c *C) {
@@ -221,11 +219,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys5(c 
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{keyFile, s.keyFile},
-		sdCryptsetupCalls: 1,
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{keyFile, s.keyFile},
+		activateTries:    1,
+		authPrivateKey:   s.authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys6(c *C) {
@@ -242,11 +240,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys6(c 
 	c.Assert(ChangePIN(s.TPM, keyFile, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{keyFile, s.keyFile},
-		sdCryptsetupCalls: 1,
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{keyFile, s.keyFile},
+		activateTries:    1,
+		authPrivateKey:   s.authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys7(c *C) {
@@ -263,13 +261,13 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys7(c 
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{s.keyFile, keyFile},
-		pinTries:          1,
-		sdCryptsetupCalls: 1,
-		pins:              []string{"1234"},
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{s.keyFile, keyFile},
+		pinTries:         1,
+		activateTries:    1,
+		pins:             []string{"1234"},
+		authPrivateKey:   s.authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys8(c *C) {
@@ -287,13 +285,13 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys8(c 
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{s.keyFile, keyFile},
-		pinTries:          1,
-		sdCryptsetupCalls: 1,
-		pins:              []string{"foo", "1234"},
-		authPrivateKey:    authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{s.keyFile, keyFile},
+		pinTries:         1,
+		activateTries:    1,
+		pins:             []string{"foo", "1234"},
+		authPrivateKey:   authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys9(c *C) {
@@ -311,13 +309,13 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys9(c 
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{s.keyFile, keyFile},
-		pinTries:          2,
-		sdCryptsetupCalls: 1,
-		pins:              []string{"foo", "1234"},
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{s.keyFile, keyFile},
+		pinTries:         2,
+		activateTries:    1,
+		pins:             []string{"foo", "1234"},
+		authPrivateKey:   s.authPrivateKey})
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys10(c *C) {
@@ -335,25 +333,25 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeys10(c
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeys(c, &testActivateVolumeWithMultipleTPMSealedKeysData{
-		volumeName:        "data",
-		sourceDevicePath:  "/dev/sda1",
-		keyFiles:          []string{keyFile, s.keyFile},
-		pinTries:          1,
-		sdCryptsetupCalls: 1,
-		pins:              []string{"1234"},
-		authPrivateKey:    s.authPrivateKey})
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		keyFiles:         []string{keyFile, s.keyFile},
+		pinTries:         1,
+		activateTries:    1,
+		pins:             []string{"1234"},
+		authPrivateKey:   s.authPrivateKey})
 }
 
 type testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData struct {
-	keyFiles          []string
-	pinTries          int
-	recoveryKeyTries  int
-	keyringPrefix     string
-	passphrases       []string
-	sdCryptsetupCalls int
-	success           bool
-	errChecker        Checker
-	errCheckerArgs    []interface{}
+	keyFiles         []string
+	pinTries         int
+	recoveryKeyTries int
+	keyringPrefix    string
+	passphrases      []string
+	activateTries    int
+	success          bool
+	errChecker       Checker
+	errCheckerArgs   []interface{}
 }
 
 func (s *cryptTPMSimulatorSuite) testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c *C, data *testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData) {
@@ -376,12 +374,11 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithMultipleTPMSealedKeysErro
 		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
 			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the " + passphraseType + " for disk /dev/sda1:"})
 	}
-	c.Check(len(s.mockSdCryptsetup.Calls()), Equals, data.sdCryptsetupCalls)
-	for _, call := range s.mockSdCryptsetup.Calls() {
-		c.Assert(len(call), Equals, 6)
-		c.Check(call[0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", "data", "/dev/sda1"})
-		c.Check(call[4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-		c.Check(call[5], Equals, "tries=1")
+
+	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
+	for _, call := range s.mockLUKS2ActivateCalls {
+		c.Check(call.volumeName, Equals, "data")
+		c.Check(call.sourceDevicePath, Equals, "/dev/sda1")
 	}
 
 	if !data.success {
@@ -409,12 +406,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	}()
 
 	s.testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData{
-		keyFiles:          []string{s.keyFile, keyFile},
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		keyFiles:         []string{s.keyFile, keyFile},
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
 			"\n- .*/keydata2: cannot unseal key: the TPM is in DA lockout mode" +
@@ -442,12 +439,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	defer s.TPM.OwnerHandleContext().SetAuthValue(testAuth)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData{
-		keyFiles:          []string{s.keyFile, keyFile},
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		keyFiles:         []string{s.keyFile, keyFile},
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is not correctly provisioned" +
 			"\n- .*/keydata2: cannot unseal key: the TPM is not correctly provisioned" +
@@ -471,15 +468,15 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData{
-		keyFiles:          []string{s.keyFile, keyFile},
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 3,
-		success:           true,
-		errChecker:        ErrorMatches,
+		keyFiles:         []string{s.keyFile, keyFile},
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    3,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
-			"\n- .*/keydata: cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5" +
-			"\n- .*/keydata2: cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5" +
+			"\n- .*/keydata: cannot activate volume: systemd-cryptsetup failed with: exit status 1" +
+			"\n- .*/keydata2: cannot activate volume: systemd-cryptsetup failed with: exit status 1" +
 			"\nbut activation with recovery key was successful"},
 	})
 }
@@ -527,16 +524,16 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	}()
 
 	s.testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData{
-		keyFiles:          []string{s.keyFile, keyFile},
-		sdCryptsetupCalls: 1,
-		recoveryKeyTries:  1,
-		passphrases:       []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
-		errChecker:        ErrorMatches,
+		keyFiles:         []string{s.keyFile, keyFile},
+		activateTries:    1,
+		recoveryKeyTries: 1,
+		passphrases:      []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
 			"\n- .*/keydata2: cannot unseal key: the TPM is in DA lockout mode" +
 			"\nand activation with recovery key failed: " +
-			"cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5"},
+			"cannot activate volume: systemd-cryptsetup failed with: exit status 1"},
 	})
 }
 
@@ -555,12 +552,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData{
-		keyFiles:          []string{s.keyFile, keyFile},
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		keyFiles:         []string{s.keyFile, keyFile},
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: no PIN tries permitted when a PIN is required" +
 			"\n- .*/keydata2: no PIN tries permitted when a PIN is required" +
@@ -583,12 +580,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData{
-		keyFiles:          []string{s.keyFile, keyFile},
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		keyFiles:         []string{s.keyFile, keyFile},
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
 			"complete OR assertions: current session digest not found in policy data" +
@@ -614,13 +611,13 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 
 	s.testActivateVolumeWithMultipleTPMSealedKeysErrorHandling(c, &testActivateVolumeWithMultipleTPMSealedKeysErrorHandlingData{
-		keyFiles:          []string{s.keyFile, keyFile},
-		pinTries:          1,
-		recoveryKeyTries:  1,
-		passphrases:       []string{"foo", s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		keyFiles:         []string{s.keyFile, keyFile},
+		pinTries:         1,
+		recoveryKeyTries: 1,
+		passphrases:      []string{"foo", s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the provided PIN is incorrect" +
 			"\n- .*/keydata2: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
@@ -652,9 +649,9 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleTPMSealedKeysErro
 			"00000-00000-00000-00000-00000-00000-00000-00000",
 			s.recoveryKey.String(),
 		},
-		sdCryptsetupCalls: 2,
-		success:           true,
-		errChecker:        ErrorMatches,
+		activateTries: 2,
+		success:       true,
+		errChecker:    ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
 			"\n- .*/keydata: cannot unseal key: the TPM is in DA lockout mode" +
 			"\n- .*/keydata2: cannot unseal key: the TPM is in DA lockout mode" +
@@ -680,12 +677,10 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyNo2FA(c *C, d
 	c.Check(err, IsNil)
 
 	c.Check(len(s.mockSdAskPassword.Calls()), Equals, 0)
-	c.Assert(len(s.mockSdCryptsetup.Calls()), Equals, 1)
-	c.Assert(len(s.mockSdCryptsetup.Calls()[0]), Equals, 6)
 
-	c.Check(s.mockSdCryptsetup.Calls()[0][0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", data.volumeName, data.sourceDevicePath})
-	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
+	c.Assert(s.mockLUKS2ActivateCalls, HasLen, 1)
+	c.Check(s.mockLUKS2ActivateCalls[0].volumeName, Equals, data.volumeName)
+	c.Check(s.mockLUKS2ActivateCalls[0].sourceDevicePath, Equals, data.sourceDevicePath)
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyNo2FA1(c *C) {
@@ -780,12 +775,10 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyMissingCustom
 	c.Check(err, IsNil)
 
 	c.Check(len(s.mockSdAskPassword.Calls()), Equals, 0)
-	c.Assert(len(s.mockSdCryptsetup.Calls()), Equals, 1)
-	c.Assert(len(s.mockSdCryptsetup.Calls()[0]), Equals, 6)
 
-	c.Check(s.mockSdCryptsetup.Calls()[0][0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", "data", "/dev/sda1"})
-	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
+	c.Assert(s.mockLUKS2ActivateCalls, HasLen, 1)
+	c.Check(s.mockLUKS2ActivateCalls[0].volumeName, Equals, "data")
+	c.Check(s.mockLUKS2ActivateCalls[0].sourceDevicePath, Equals, "/dev/sda1")
 }
 
 type testActivateVolumeWithTPMSealedKeyAndPINData struct {
@@ -807,12 +800,9 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyAndPIN(c *C, 
 			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the PIN for disk /dev/sda1:"})
 	}
 
-	c.Assert(len(s.mockSdCryptsetup.Calls()), Equals, 1)
-	c.Assert(len(s.mockSdCryptsetup.Calls()[0]), Equals, 6)
-
-	c.Check(s.mockSdCryptsetup.Calls()[0][0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", "data", "/dev/sda1"})
-	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
+	c.Assert(s.mockLUKS2ActivateCalls, HasLen, 1)
+	c.Check(s.mockLUKS2ActivateCalls[0].volumeName, Equals, "data")
+	c.Check(s.mockLUKS2ActivateCalls[0].sourceDevicePath, Equals, "/dev/sda1")
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPIN1(c *C) {
@@ -860,12 +850,9 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyAndPINUsingPI
 			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the PIN for disk /dev/sda1:"})
 	}
 
-	c.Assert(len(s.mockSdCryptsetup.Calls()), Equals, 1)
-	c.Assert(len(s.mockSdCryptsetup.Calls()[0]), Equals, 6)
-
-	c.Check(s.mockSdCryptsetup.Calls()[0][0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", "data", "/dev/sda1"})
-	c.Check(s.mockSdCryptsetup.Calls()[0][4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-	c.Check(s.mockSdCryptsetup.Calls()[0][5], Equals, "tries=1")
+	c.Assert(s.mockLUKS2ActivateCalls, HasLen, 1)
+	c.Check(s.mockLUKS2ActivateCalls[0].volumeName, Equals, "data")
+	c.Check(s.mockLUKS2ActivateCalls[0].sourceDevicePath, Equals, "/dev/sda1")
 }
 
 func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPINReader1(c *C) {
@@ -914,14 +901,14 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyAndPINUsingPI
 }
 
 type testActivateVolumeWithTPMSealedKeyErrorHandlingData struct {
-	pinTries          int
-	recoveryKeyTries  int
-	keyringPrefix     string
-	passphrases       []string
-	sdCryptsetupCalls int
-	success           bool
-	errChecker        Checker
-	errCheckerArgs    []interface{}
+	pinTries         int
+	recoveryKeyTries int
+	keyringPrefix    string
+	passphrases      []string
+	activateTries    int
+	success          bool
+	errChecker       Checker
+	errCheckerArgs   []interface{}
 }
 
 func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyErrorHandling(c *C, data *testActivateVolumeWithTPMSealedKeyErrorHandlingData) {
@@ -944,12 +931,11 @@ func (s *cryptTPMSimulatorSuite) testActivateVolumeWithTPMSealedKeyErrorHandling
 		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
 			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the " + passphraseType + " for disk /dev/sda1:"})
 	}
-	c.Check(len(s.mockSdCryptsetup.Calls()), Equals, data.sdCryptsetupCalls)
-	for _, call := range s.mockSdCryptsetup.Calls() {
-		c.Assert(len(call), Equals, 6)
-		c.Check(call[0:4], DeepEquals, []string{"systemd-cryptsetup", "attach", "data", "/dev/sda1"})
-		c.Check(call[4], Matches, filepath.Join(s.dir, filepath.Base(os.Args[0]))+"\\.[0-9]+/fifo")
-		c.Check(call[5], Equals, "tries=1")
+
+	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
+	for _, call := range s.mockLUKS2ActivateCalls {
+		c.Check(call.volumeName, Equals, "data")
+		c.Check(call.sourceDevicePath, Equals, "/dev/sda1")
 	}
 
 	if !data.success {
@@ -986,11 +972,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 	}()
 
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is in DA lockout mode\\) but " +
 			"activation with recovery key was successful"},
 	})
@@ -1012,9 +998,9 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 			"00000-00000-00000-00000-00000-00000-00000-00000",
 			s.recoveryKey.String(),
 		},
-		sdCryptsetupCalls: 2,
-		success:           true,
-		errChecker:        ErrorMatches,
+		activateTries: 2,
+		success:       true,
+		errChecker:    ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is not correctly " +
 			"provisioned\\) but activation with recovery key was successful"},
 	})
@@ -1028,13 +1014,13 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 	s.addMockKeyslot(c, incorrectKey)
 
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 2,
-		success:           true,
-		errChecker:        ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() +
-			" failed: exit status 5\\) but activation with recovery key was successful"},
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    2,
+		success:          true,
+		errChecker:       ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot activate volume: " +
+			"systemd-cryptsetup failed with: exit status 1\\) but activation with recovery key was successful"},
 	})
 }
 
@@ -1061,13 +1047,13 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 	}()
 
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
-		recoveryKeyTries:  1,
-		passphrases:       []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
-		sdCryptsetupCalls: 1,
-		success:           false,
-		errChecker:        ErrorMatches,
+		recoveryKeyTries: 1,
+		passphrases:      []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
+		activateTries:    1,
+		success:          false,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the TPM is in DA lockout mode\\) " +
-			"and activation with recovery key failed \\(cannot activate volume: " + s.mockSdCryptsetup.Exe() + " failed: exit status 5\\)"},
+			"and activation with recovery key failed \\(cannot activate volume: systemd-cryptsetup failed with: exit status 1\\)"},
 	})
 }
 
@@ -1082,9 +1068,9 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 			"",
 			s.recoveryKey.String(),
 		},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		activateTries: 1,
+		success:       true,
+		errChecker:    ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: the provided PIN is incorrect\\) but " +
 			"activation with recovery key was successful"},
 	})
@@ -1094,11 +1080,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 	// Test that recovery fallback works if a PIN is set but no PIN attempts are permitted.
 	c.Assert(ChangePIN(s.TPM, s.keyFile, "", "1234"), IsNil)
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(no PIN tries permitted when a PIN is required\\) but " +
 			"activation with recovery key was successful"},
 	})
@@ -1110,11 +1096,11 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
-		recoveryKeyTries:  1,
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		recoveryKeyTries: 1,
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data file: cannot complete " +
 			"authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data\\) but " +
 			"activation with recovery key was successful"},
@@ -1128,12 +1114,12 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithTPMSealedKeyErrorHandling
 	c.Assert(err, IsNil)
 
 	s.testActivateVolumeWithTPMSealedKeyErrorHandling(c, &testActivateVolumeWithTPMSealedKeyErrorHandlingData{
-		recoveryKeyTries:  1,
-		keyringPrefix:     "test",
-		passphrases:       []string{s.recoveryKey.String()},
-		sdCryptsetupCalls: 1,
-		success:           true,
-		errChecker:        ErrorMatches,
+		recoveryKeyTries: 1,
+		keyringPrefix:    "test",
+		passphrases:      []string{s.recoveryKey.String()},
+		activateTries:    1,
+		success:          true,
+		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data file: cannot complete " +
 			"authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data\\) but " +
 			"activation with recovery key was successful"},

--- a/export_test.go
+++ b/export_test.go
@@ -141,19 +141,27 @@ func MakeMockPolicyPCRValuesFull(params []MockPolicyPCRParam) (out []tpm2.PCRVal
 	return
 }
 
+func MockLUKS2Activate(fn func(string, string, []byte) error) (restore func()) {
+	origActivate := luks2Activate
+	luks2Activate = fn
+	return func() {
+		luks2Activate = origActivate
+	}
+}
+
+func MockLUKS2Deactivate(fn func(string) error) (restore func()) {
+	origDeactivate := luks2Deactivate
+	luks2Deactivate = fn
+	return func() {
+		luks2Deactivate = origDeactivate
+	}
+}
+
 func MockRunDir(path string) (restore func()) {
 	origRunDir := runDir
 	runDir = path
 	return func() {
 		runDir = origRunDir
-	}
-}
-
-func MockSystemdCryptsetupPath(path string) (restore func()) {
-	origSystemdCryptsetupPath := systemdCryptsetupPath
-	systemdCryptsetupPath = path
-	return func() {
-		systemdCryptsetupPath = origSystemdCryptsetupPath
 	}
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -157,14 +157,6 @@ func MockLUKS2Deactivate(fn func(string) error) (restore func()) {
 	}
 }
 
-func MockRunDir(path string) (restore func()) {
-	origRunDir := runDir
-	runDir = path
-	return func() {
-		runDir = origRunDir
-	}
-}
-
 func NewDynamicPolicyComputeParams(key *ecdsa.PrivateKey, signAlg tpm2.HashAlgorithmId, pcrs tpm2.PCRSelectionList,
 	pcrDigests tpm2.DigestList, policyCounterName tpm2.Name, policyCount uint64) *dynamicPolicyComputeParams {
 	return &dynamicPolicyComputeParams{

--- a/internal/luks2/activate.go
+++ b/internal/luks2/activate.go
@@ -21,6 +21,7 @@ package luks2
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -40,7 +41,20 @@ func Activate(volumeName, sourceDevicePath string, key []byte) error {
 	cmd.Stdin = bytes.NewReader(key)
 
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return osutil.OutputErr(output, err)
+		return fmt.Errorf("systemd-cryptsetup failed with: %v", osutil.OutputErr(output, err))
+	}
+
+	return nil
+}
+
+// Deactivate detaches the LUKS volume with the supplied name.
+func Deactivate(volumeName string) error {
+	cmd := exec.Command(systemdCryptsetupPath, "detach", volumeName)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "SYSTEMD_LOG_TARGET=console")
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("systemd-cryptsetup failed with: %v", osutil.OutputErr(output, err))
 	}
 
 	return nil

--- a/internal/luks2/activate_test.go
+++ b/internal/luks2/activate_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	. "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/paths/pathstest"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 
 	. "gopkg.in/check.v1"
@@ -46,7 +47,7 @@ func (s *activateSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	s.runDir = c.MkDir()
-	s.AddCleanup(MockRunDir(s.runDir))
+	s.AddCleanup(pathstest.MockRunDir(s.runDir))
 
 	s.mockKeyslotsDir = c.MkDir()
 	s.mockKeyslotsCount = 0

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -64,7 +64,7 @@ func cryptsetupCmd(stdin io.Reader, callback func(cmd *exec.Cmd) error, args ...
 	case cbErr != nil:
 		return cbErr
 	case err != nil:
-		return osutil.OutputErr(b.Bytes(), err)
+		return fmt.Errorf("cryptsetup failed with: %v", osutil.OutputErr(b.Bytes(), err))
 	}
 
 	return nil

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -34,6 +34,12 @@ import (
 	"golang.org/x/xerrors"
 )
 
+const (
+	// AnySlot tells a command to automatically choose an appropriate slot
+	// as opposed to hard coding one.
+	AnySlot = -1
+)
+
 var (
 	keySize = 64
 )
@@ -121,10 +127,22 @@ func Format(devicePath, label string, key []byte, opts *FormatOptions) error {
 	return cryptsetupCmd(bytes.NewReader(key), nil, args...)
 }
 
+// AddKeyOptions provides the options for adding a key to a LUKS2 volume
+type AddKeyOptions struct {
+	KDFTime time.Duration // the KDF benchmark time for the new key
+
+	// Slot is the keyslot to use. Note that the default value is slot 0. In
+	// order to automatically choose a slot, use AnySlot.
+	Slot int
+}
+
 // AddKey adds the supplied key in to a new keyslot for specified LUKS2 container. In order to do this,
 // an existing key must be provided. The KDF for the new keyslot will be configured to use argon2i with
-// the supplied benchmark time.
-func AddKey(devicePath string, existingKey, key []byte, kdfTime time.Duration) error {
+// the supplied benchmark time. The key will be added to the supplied slot.
+//
+// If options is not supplied, the default KDF benchmark time is used and the command will
+// automatically choose an appropriate slot.
+func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) error {
 	fifoPath, cleanupFifo, err := mkFifo()
 	if err != nil {
 		return xerrors.Errorf("cannot create FIFO for passing existing key to cryptsetup: %w", err)
@@ -140,9 +158,14 @@ func AddKey(devicePath string, existingKey, key []byte, kdfTime time.Duration) e
 		"--key-file", fifoPath,
 		// use argon2i as the KDF
 		"--pbkdf", "argon2i"}
-	if kdfTime != 0 {
-		// set the KDF benchmark time
-		args = append(args, "--iter-time", strconv.FormatUint(uint64(kdfTime/time.Millisecond), 10))
+	if options != nil {
+		if options.KDFTime != 0 {
+			// set the KDF benchmark time
+			args = append(args, "--iter-time", strconv.FormatUint(uint64(options.KDFTime/time.Millisecond), 10))
+		}
+		if options.Slot != AnySlot {
+			args = append(args, "--key-slot", strconv.Itoa(options.Slot))
+		}
 	}
 	args = append(args,
 		// container to add key to

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "github.com/snapcore/secboot/internal/luks2"
 	"github.com/snapcore/secboot/internal/luks2/luks2test"
+	"github.com/snapcore/secboot/internal/paths/pathstest"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 
 	. "gopkg.in/check.v1"
@@ -40,7 +41,7 @@ type cryptsetupSuite struct {
 func (s *cryptsetupSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	s.AddCleanup(MockRunDir(c.MkDir()))
+	s.AddCleanup(pathstest.MockRunDir(c.MkDir()))
 
 	s.AddCleanup(luks2test.WrapCryptsetup(c))
 }

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -22,14 +22,12 @@ package luks2_test
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"math/rand"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	. "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luks2/luks2test"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 
 	. "gopkg.in/check.v1"
@@ -44,28 +42,7 @@ func (s *cryptsetupSuite) SetUpTest(c *C) {
 
 	s.AddCleanup(MockRunDir(c.MkDir()))
 
-	cryptsetupWrapperBottom := `
-# Set max locked memory to 0. Without this and without CAP_IPC_LOCK, mlockall will
-# succeed but subsequent calls to mmap will fail because the limit is too low. Setting
-# this to 0 here will cause mlockall to fail, which cryptsetup ignores.
-ulimit -l 0
-exec %[1]s "$@" </dev/stdin
-`
-
-	cryptsetup, err := exec.LookPath("cryptsetup")
-	c.Assert(err, IsNil)
-
-	cryptsetupWrapper := snapd_testutil.MockCommand(c, "cryptsetup", fmt.Sprintf(cryptsetupWrapperBottom, cryptsetup))
-	s.AddCleanup(cryptsetupWrapper.Restore)
-}
-
-func (s *cryptsetupSuite) createEmptyDiskImage(c *C, sz int) string {
-	f, err := os.OpenFile(filepath.Join(c.MkDir(), "disk.img"), os.O_RDWR|os.O_CREATE, 0600)
-	c.Assert(err, IsNil)
-	defer f.Close()
-
-	c.Assert(f.Truncate(int64(sz)*1024*1024), IsNil)
-	return f.Name()
+	s.AddCleanup(luks2test.WrapCryptsetup(c))
 }
 
 func (s *cryptsetupSuite) checkLUKS2Passphrase(c *C, path string, key []byte) {
@@ -83,7 +60,7 @@ type testFormatData struct {
 }
 
 func (s *cryptsetupSuite) testFormat(c *C, data *testFormatData) {
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 
 	c.Check(Format(devicePath, data.label, data.key, data.options), IsNil)
 
@@ -125,7 +102,7 @@ func (s *cryptsetupSuite) testFormat(c *C, data *testFormatData) {
 	}
 
 	start := time.Now()
-	s.checkLUKS2Passphrase(c, devicePath, data.key)
+	luks2test.CheckLUKS2Passphrase(c, devicePath, data.key)
 	elapsed := time.Now().Sub(start)
 	// Check KDF time here with +/-20% tolerance and additional 500ms for cryptsetup exec and other activities
 	c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntGreaterThan, int(float64(expectedKDFTime/time.Millisecond)*0.8))
@@ -190,7 +167,7 @@ func (s *cryptsetupSuite) testAddKey(c *C, data *testAddKeyData) {
 	primaryKey := make([]byte, 32)
 	rand.Read(primaryKey)
 
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", primaryKey, &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 
 	startInfo, err := ReadHeader(devicePath, LockModeBlocking)
@@ -224,7 +201,7 @@ func (s *cryptsetupSuite) testAddKey(c *C, data *testAddKeyData) {
 	}
 
 	start := time.Now()
-	s.checkLUKS2Passphrase(c, devicePath, data.key)
+	luks2test.CheckLUKS2Passphrase(c, devicePath, data.key)
 	elapsed := time.Now().Sub(start)
 	// Check KDF time here with +/-20% tolerance and additional 500ms for cryptsetup exec and other activities
 	c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntGreaterThan, int(float64(expectedKDFTime/time.Millisecond)*0.8))
@@ -248,11 +225,11 @@ func (s *cryptsetupSuite) TestAddKeyWithIncorrectExistingKey(c *C) {
 	primaryKey := make([]byte, 32)
 	rand.Read(primaryKey)
 
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 
 	c.Assert(Format(devicePath, "", primaryKey, &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 
-	c.Check(AddKey(devicePath, make([]byte, 32), []byte("foo"), 0), ErrorMatches, "No key available with this passphrase.")
+	c.Check(AddKey(devicePath, make([]byte, 32), []byte("foo"), 0), ErrorMatches, "cryptsetup failed with: No key available with this passphrase.")
 
 	info, err := ReadHeader(devicePath, LockModeBlocking)
 	c.Assert(err, IsNil)
@@ -260,7 +237,7 @@ func (s *cryptsetupSuite) TestAddKeyWithIncorrectExistingKey(c *C) {
 	_, ok := info.Metadata.Keyslots[0]
 	c.Check(ok, Equals, true)
 
-	s.checkLUKS2Passphrase(c, devicePath, primaryKey)
+	luks2test.CheckLUKS2Passphrase(c, devicePath, primaryKey)
 }
 
 type testImportTokenData struct {
@@ -269,7 +246,7 @@ type testImportTokenData struct {
 }
 
 func (s *cryptsetupSuite) testImportToken(c *C, data *testImportTokenData) {
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", make([]byte, 32), &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 	c.Assert(AddKey(devicePath, make([]byte, 32), make([]byte, 32), 100*time.Millisecond), IsNil)
 
@@ -335,7 +312,7 @@ func (s *cryptsetupSuite) TestImportToken3(c *C) {
 }
 
 func (s *cryptsetupSuite) testRemoveToken(c *C, tokenId int) {
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", make([]byte, 32), &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 	c.Assert(AddKey(devicePath, make([]byte, 32), make([]byte, 32), 100*time.Millisecond), IsNil)
 	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []int{0}}), IsNil)
@@ -365,11 +342,11 @@ func (s *cryptsetupSuite) TestRemoveToken2(c *C) {
 }
 
 func (s *cryptsetupSuite) TestRemoveNonExistantToken(c *C) {
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", make([]byte, 32), &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 	c.Assert(ImportToken(devicePath, &Token{Type: "secboot-foo", Keyslots: []int{0}}), IsNil)
 
-	c.Check(RemoveToken(devicePath, 10), ErrorMatches, "Token 10 is not in use.")
+	c.Check(RemoveToken(devicePath, 10), ErrorMatches, "cryptsetup failed with: Token 10 is not in use.")
 
 	info, err := ReadHeader(devicePath, LockModeBlocking)
 	c.Assert(err, IsNil)
@@ -387,7 +364,7 @@ type testKillSlotData struct {
 }
 
 func (s *cryptsetupSuite) testKillSlot(c *C, data *testKillSlotData) {
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", data.key1, &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 	c.Assert(AddKey(devicePath, data.key1, data.key2, 100*time.Millisecond), IsNil)
 
@@ -405,7 +382,7 @@ func (s *cryptsetupSuite) testKillSlot(c *C, data *testKillSlotData) {
 	_, ok = info.Metadata.Keyslots[data.slotId]
 	c.Check(ok, Equals, false)
 
-	s.checkLUKS2Passphrase(c, devicePath, data.testKey)
+	luks2test.CheckLUKS2Passphrase(c, devicePath, data.testKey)
 }
 
 func (s *cryptsetupSuite) TestKillSlot1(c *C) {
@@ -442,26 +419,26 @@ func (s *cryptsetupSuite) TestKillSlotWithWrongPassphrase(c *C) {
 	key2 := make([]byte, 32)
 	rand.Read(key2)
 
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", key1, &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 	c.Assert(AddKey(devicePath, key1, key2, 100*time.Millisecond), IsNil)
 
-	c.Check(KillSlot(devicePath, 1, key2), ErrorMatches, "No key available with this passphrase.")
+	c.Check(KillSlot(devicePath, 1, key2), ErrorMatches, "cryptsetup failed with: No key available with this passphrase.")
 
-	s.checkLUKS2Passphrase(c, devicePath, key1)
-	s.checkLUKS2Passphrase(c, devicePath, key2)
+	luks2test.CheckLUKS2Passphrase(c, devicePath, key1)
+	luks2test.CheckLUKS2Passphrase(c, devicePath, key2)
 }
 
 func (s *cryptsetupSuite) TestKillNonExistantSlot(c *C) {
 	key := make([]byte, 32)
 	rand.Read(key)
 
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", key, &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 
-	c.Check(KillSlot(devicePath, 8, key), ErrorMatches, "Keyslot 8 is not active.")
+	c.Check(KillSlot(devicePath, 8, key), ErrorMatches, "cryptsetup failed with: Keyslot 8 is not active.")
 
-	s.checkLUKS2Passphrase(c, devicePath, key)
+	luks2test.CheckLUKS2Passphrase(c, devicePath, key)
 }
 
 type testSetSlotPriorityData struct {
@@ -470,7 +447,7 @@ type testSetSlotPriorityData struct {
 }
 
 func (s *cryptsetupSuite) testSetSlotPriority(c *C, data *testSetSlotPriorityData) {
-	devicePath := s.createEmptyDiskImage(c, 20)
+	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 	c.Assert(Format(devicePath, "", make([]byte, 32), &FormatOptions{KDFTime: 100 * time.Millisecond}), IsNil)
 	c.Assert(AddKey(devicePath, make([]byte, 32), make([]byte, 32), 100*time.Millisecond), IsNil)
 

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"math/rand"
+	"os"
 	"os/exec"
 	"time"
 
@@ -36,6 +37,14 @@ import (
 
 type cryptsetupSuite struct {
 	snapd_testutil.BaseTest
+}
+
+func (s *cryptsetupSuite) SetUpSuite(c *C) {
+	for _, e := range os.Environ() {
+		if e == "NO_EXPENSIVE_CRYPTSETUP_TESTS=1" {
+			c.Skip("skipping expensive cryptsetup tests")
+		}
+	}
 }
 
 func (s *cryptsetupSuite) SetUpTest(c *C) {

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -27,12 +27,13 @@ import (
 	"os/exec"
 	"time"
 
-	. "github.com/snapcore/secboot/internal/luks2"
-	"github.com/snapcore/secboot/internal/luks2/luks2test"
-	"github.com/snapcore/secboot/internal/paths/pathstest"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 
 	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luks2/luks2test"
+	"github.com/snapcore/secboot/internal/paths/pathstest"
 )
 
 type cryptsetupSuite struct {

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -65,14 +65,6 @@ func MockDataDeviceInfo(stMock *unix.Stat_t) (restore func()) {
 	}
 }
 
-func MockRunDir(path string) (restore func()) {
-	origRunDir := runDir
-	runDir = path
-	return func() {
-		runDir = origRunDir
-	}
-}
-
 func MockSystemdCryptsetupPath(path string) (restore func()) {
 	origSystemdCryptsetupPath := systemdCryptsetupPath
 	systemdCryptsetupPath = path

--- a/internal/luks2/fifo.go
+++ b/internal/luks2/fifo.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/snapcore/secboot/internal/paths"
+
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 )
@@ -33,7 +35,7 @@ func mkFifo() (string, func(), error) {
 	// /run is not world writable but we create a unique directory here because this
 	// code can be invoked by a public API and we shouldn't fail if more than one
 	// process reaches here at the same time.
-	dir, err := ioutil.TempDir(runDir, filepath.Base(os.Args[0])+".")
+	dir, err := ioutil.TempDir(paths.RunDir, filepath.Base(os.Args[0])+".")
 	if err != nil {
 		return "", nil, xerrors.Errorf("cannot create temporary directory: %w", err)
 	}

--- a/internal/luks2/luks2.go
+++ b/internal/luks2/luks2.go
@@ -25,7 +25,6 @@ import (
 )
 
 var (
-	runDir           = "/run"
 	stderr io.Writer = os.Stderr
 )
 

--- a/internal/luks2/luks2test/luks2test.go
+++ b/internal/luks2/luks2test/luks2test.go
@@ -56,8 +56,8 @@ func CreateEmptyDiskImage(c *C, sz int) string {
 	return f.Name()
 }
 
-func CheckLUKS2Passphrase(c *C, path string, key []byte) {
-	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", path)
+func CheckLUKS2Passphrase(c *C, devicePath string, key []byte) {
+	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", devicePath)
 	cmd.Stdin = bytes.NewReader(key)
 	c.Check(cmd.Run(), IsNil)
 }

--- a/internal/luks2/luks2test/luks2test.go
+++ b/internal/luks2/luks2test/luks2test.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020-2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+func WrapCryptsetup(c *C) (restore func()) {
+	cryptsetupWrapperBottom := `
+# Set max locked memory to 0. Without this and without CAP_IPC_LOCK, mlockall will
+# succeed but subsequent calls to mmap will fail because the limit is too low. Setting
+# this to 0 here will cause mlockall to fail, which cryptsetup ignores.
+ulimit -l 0
+exec %[1]s "$@" </dev/stdin
+`
+
+	cryptsetup, err := exec.LookPath("cryptsetup")
+	c.Assert(err, IsNil)
+
+	cmd := testutil.MockCommand(c, "cryptsetup", fmt.Sprintf(cryptsetupWrapperBottom, cryptsetup))
+	return cmd.Restore
+}
+
+func CreateEmptyDiskImage(c *C, sz int) string {
+	f, err := os.OpenFile(filepath.Join(c.MkDir(), "disk.img"), os.O_RDWR|os.O_CREATE, 0600)
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	c.Assert(f.Truncate(int64(sz)*1024*1024), IsNil)
+	return f.Name()
+}
+
+func CheckLUKS2Passphrase(c *C, path string, key []byte) {
+	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", path)
+	cmd.Stdin = bytes.NewReader(key)
+	c.Check(cmd.Run(), IsNil)
+}

--- a/internal/luks2/metadata.go
+++ b/internal/luks2/metadata.go
@@ -37,6 +37,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/snapcore/secboot/internal/paths"
+
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 )
@@ -46,7 +48,7 @@ var (
 )
 
 func cryptsetupLockDir() string {
-	return filepath.Join(runDir, "cryptsetup")
+	return filepath.Join(paths.RunDir, "cryptsetup")
 }
 
 var isBlockDevice = func(mode os.FileMode) bool {

--- a/internal/luks2/metadata_test.go
+++ b/internal/luks2/metadata_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	. "github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/paths/pathstest"
 	"github.com/snapcore/secboot/internal/testutil"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 
@@ -48,7 +49,7 @@ func (s *metadataSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	s.runDir = c.MkDir()
-	s.AddCleanup(MockRunDir(s.runDir))
+	s.AddCleanup(pathstest.MockRunDir(s.runDir))
 }
 
 func (s *metadataSuite) decompress(c *C, path string) string {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package paths
+
+var RunDir = "/run"

--- a/internal/paths/pathstest/pathstest.go
+++ b/internal/paths/pathstest/pathstest.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package pathstest
+
+import (
+	"github.com/snapcore/secboot/internal/paths"
+)
+
+func MockRunDir(path string) (restore func()) {
+	orig := paths.RunDir
+	paths.RunDir = path
+	return func() {
+		paths.RunDir = orig
+	}
+}

--- a/run-tests
+++ b/run-tests
@@ -9,6 +9,10 @@ while [ $# -gt 0 ]; do
                         WITH_MSSIM=1
                         shift
                         ;;
+                --no-expensive-cryptsetup-tests)
+                        ENV="env NO_EXPENSIVE_CRYPTSETUP_TESTS=1"
+                        shift
+                        ;;
                 --)
                         shift
                         break
@@ -24,4 +28,4 @@ if [ $WITH_MSSIM -eq 1 ]; then
 fi
 
 
-go test -v -race -p 1 ./... -args -check.v $MSSIM_ARGS $@
+$ENV go test -v -race -p 1 ./... -args -check.v $MSSIM_ARGS $@


### PR DESCRIPTION
This ports crypt.go to use internal/luks2, with no other changes yet.

I've kept the original tests that use a mocked cryptsetup, but added
some additional tests that use a real cryptsetup. As these take a while
to run, I've added a --no-expensive-cryptsetup-tests option to run-tests
which skips the new tests (and the cryptsetup tests in internal/luks2).
This just passes an option in via the environment to avoid having to
parse a new argument in every test binary, and to avoid splitting the
single call to go test.

The existing API needs to be able to use the luksAddKey command
with the --key-slot option which internal/luks2 didn't support, so I've
added that too.