### PR TITLE
tpm2: Make ReadSealedKeyObject take a io.Reader

### DIFF
--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -151,7 +151,7 @@ func (s *compatTestSuiteBase) copyFile(c *C, path string) string {
 }
 
 func (s *compatTestSuiteBase) testUnsealCommon(c *C) {
-	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	k, err := secboot_tpm2.ReadSealedKeyObjectFromFile(s.absPath("key"))
 	c.Assert(err, IsNil)
 
 	key, authPrivateKey, err := k.UnsealFromTPM(s.TPM)
@@ -176,7 +176,7 @@ func (s *compatTestSuiteBase) testUnseal(c *C, pcrEventsFile string) {
 }
 
 func (s *compatTestSuiteBase) testUnsealErrorMatchesCommon(c *C, pattern string) {
-	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	k, err := secboot_tpm2.ReadSealedKeyObjectFromFile(s.absPath("key"))
 	c.Assert(err, IsNil)
 
 	_, _, err = k.UnsealFromTPM(s.TPM)

--- a/internal/compattest/v0_test.go
+++ b/internal/compattest/v0_test.go
@@ -71,7 +71,7 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicy(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	k, err := secboot_tpm2.ReadSealedKeyObjectFromFile(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
 }
@@ -83,13 +83,13 @@ func (s *compatTestV0Suite) TestRevokeOldPCRProtectionPolicies(c *C) {
 
 	key2 := s.copyFile(c, s.absPath("key"))
 
-	k, err := secboot_tpm2.ReadSealedKeyObject(key2)
+	k, err := secboot_tpm2.ReadSealedKeyObjectFromFile(key2)
 	c.Assert(err, IsNil)
 
 	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
 	c.Check(k.RevokeOldPCRProtectionPoliciesV0(s.TPM, s.absPath("pud")), IsNil)
 	s.replayPCRSequenceFromFile(c, s.absPath("pcrSequence.1"))
-	s.testUnsealErrorMatchesCommon(c, "invalid key data file: cannot complete authorization policy assertions: the PCR policy has been revoked")
+	s.testUnsealErrorMatchesCommon(c, "invalid key data: cannot complete authorization policy assertions: the PCR policy has been revoked")
 }
 
 func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAndUnseal(c *C) {
@@ -97,9 +97,12 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAndUnseal(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	k, err := secboot_tpm2.ReadSealedKeyObjectFromFile(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
+
+	w := secboot_tpm2.NewFileSealedKeyObjectWriter(s.absPath("key"))
+	c.Check(k.WriteAtomic(w), IsNil)
 
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "7 11 %x\n", testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
@@ -116,7 +119,7 @@ func (s *compatTestV0Suite) TestUpdateKeyPCRProtectionPolicyAfterLock(c *C) {
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 7, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "foo"))
 	profile.ExtendPCR(tpm2.HashAlgorithmSHA256, 12, testutil.MakePCREventDigest(tpm2.HashAlgorithmSHA256, "bar"))
 
-	k, err := secboot_tpm2.ReadSealedKeyObject(s.absPath("key"))
+	k, err := secboot_tpm2.ReadSealedKeyObjectFromFile(s.absPath("key"))
 	c.Assert(err, IsNil)
 	c.Check(k.UpdatePCRProtectionPolicyV0(s.TPM, s.absPath("pud"), profile), IsNil)
 }
@@ -127,5 +130,5 @@ func (s *compatTestV0Suite) TestUnsealAfterLock(c *C) {
 	// but keep this here just to make sure.
 	s.replayPCRSequenceFromFile(c, s.absPath("pcrSequence.1"))
 	c.Assert(secboot_tpm2.BlockPCRProtectionPolicies(s.TPM, []int{12}), IsNil)
-	s.testUnsealErrorMatchesCommon(c, "invalid key data file: cannot complete authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data")
+	s.testUnsealErrorMatchesCommon(c, "invalid key data: cannot complete authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data")
 }

--- a/tpm2/crypt_test.go
+++ b/tpm2/crypt_test.go
@@ -549,9 +549,9 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithMultipleSealedKeysErrorHa
 		success:          true,
 		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"(?sm)cannot activate with TPM sealed keys:" +
-			"\n- .*/keydata: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
+			"\n- .*/keydata: cannot unseal key: invalid key data: cannot complete authorization policy assertions: cannot " +
 			"complete OR assertions: current session digest not found in policy data" +
-			"\n- .*/keydata2: cannot unseal key: invalid key data file: cannot complete authorization policy assertions: cannot " +
+			"\n- .*/keydata2: cannot unseal key: invalid key data: cannot complete authorization policy assertions: cannot " +
 			"complete OR assertions: current session digest not found in policy data" +
 			"\nbut activation with recovery key was successful"},
 	})
@@ -861,7 +861,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyErrorHandling10(
 		activateTries:    1,
 		success:          true,
 		errChecker:       ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data file: cannot complete " +
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data: cannot complete " +
 			"authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data\\) but " +
 			"activation with recovery key was successful"},
 	})
@@ -880,7 +880,7 @@ func (s *cryptTPMSimulatorSuite) TestActivateVolumeWithSealedKeyErrorHandling11(
 		activateTries:    1,
 		success:          true,
 		errChecker:       ErrorMatches,
-		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data file: cannot complete " +
+		errCheckerArgs: []interface{}{"cannot activate with TPM sealed key \\(cannot unseal key: invalid key data: cannot complete " +
 			"authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data\\) but " +
 			"activation with recovery key was successful"},
 	})

--- a/tpm2/errors.go
+++ b/tpm2/errors.go
@@ -108,19 +108,19 @@ func isTPMVerificationError(err error) bool {
 	return xerrors.As(err, &e)
 }
 
-// InvalidKeyFileError indicates that the provided key data file is invalid. This error may also be returned in some
+// InvalidKeyDataError indicates that the provided key data file is invalid. This error may also be returned in some
 // scenarious where the TPM is incorrectly provisioned, but it isn't possible to determine whether the error is with
 // the provisioning status or because the key data file is invalid.
-type InvalidKeyFileError struct {
+type InvalidKeyDataError struct {
 	msg string
 }
 
-func (e InvalidKeyFileError) Error() string {
-	return fmt.Sprintf("invalid key data file: %s", e.msg)
+func (e InvalidKeyDataError) Error() string {
+	return fmt.Sprintf("invalid key data: %s", e.msg)
 }
 
-func isInvalidKeyFileError(err error) bool {
-	var e InvalidKeyFileError
+func isInvalidKeyDataError(err error) bool {
+	var e InvalidKeyDataError
 	return xerrors.As(err, &e)
 }
 

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -177,12 +177,7 @@ func NewStaticPolicyComputeParams(key *tpm2.Public, pcrPolicyCounterPub *tpm2.NV
 	return &staticPolicyComputeParams{key: key, pcrPolicyCounterPub: pcrPolicyCounterPub}
 }
 
-func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authPrivateKey PolicyAuthKey, session tpm2.SessionContext) error {
-	k, err := ReadSealedKeyObject(keyFile)
-	if err != nil {
-		return err
-	}
-
+func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authPrivateKey PolicyAuthKey, session tpm2.SessionContext) error {
 	authKey, err := createECDSAPrivateKeyFromTPM(k.data.staticPolicyData.authPublicKey, tpm2.ECCParameter(authPrivateKey))
 	if err != nil {
 		return err
@@ -190,4 +185,13 @@ func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authPrivateKey Po
 
 	_, err = k.data.validate(tpm, authKey, session)
 	return err
+}
+
+func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authPrivateKey PolicyAuthKey, session tpm2.SessionContext) error {
+	k, err := ReadSealedKeyObjectFromFile(keyFile)
+	if err != nil {
+		return err
+	}
+
+	return k.Validate(tpm, authPrivateKey, session)
 }

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -42,6 +42,7 @@ import (
 
 	"maze.io/x/crypto/afis"
 
+	"github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/tcg"
 )
 
@@ -57,97 +58,6 @@ type PolicyAuthKey []byte
 type sealedData struct {
 	Key            []byte
 	AuthPrivateKey PolicyAuthKey
-}
-
-type afSplitDataRawHdr struct {
-	Stripes uint32
-	HashAlg tpm2.HashAlgorithmId
-	Size    uint32
-}
-
-// afSlitDataRaw is the on-disk version of afSplitData.
-type afSplitDataRaw struct {
-	Hdr  afSplitDataRawHdr
-	Data mu.RawBytes
-}
-
-func (d afSplitDataRaw) Marshal(w io.Writer) error {
-	_, err := mu.MarshalToWriter(w, d.Hdr, d.Data)
-	return err
-}
-
-func (d *afSplitDataRaw) Unmarshal(r mu.Reader) error {
-	var h afSplitDataRawHdr
-	if _, err := mu.UnmarshalFromReader(r, &h); err != nil {
-		return xerrors.Errorf("cannot unmarshal header: %w", err)
-	}
-
-	data := make([]byte, h.Size)
-	if _, err := io.ReadFull(r, data); err != nil {
-		return xerrors.Errorf("cannot read data: %w", err)
-	}
-
-	d.Hdr = h
-	d.Data = data
-	return nil
-}
-
-func (d *afSplitDataRaw) data() *afSplitData {
-	return &afSplitData{
-		stripes: d.Hdr.Stripes,
-		hashAlg: d.Hdr.HashAlg,
-		data:    d.Data}
-}
-
-// makeAfSplitDataRaw converts afSplitData to its on disk form.
-func makeAfSplitDataRaw(d *afSplitData) *afSplitDataRaw {
-	return &afSplitDataRaw{
-		Hdr: afSplitDataRawHdr{
-			Stripes: d.stripes,
-			HashAlg: d.hashAlg,
-			Size:    uint32(len(d.data))},
-		Data: d.data}
-}
-
-// afSplitData is a container for data that has been passed through an Anti-Forensic Information Splitter, to support
-// secure destruction of on-disk key material by increasing the size of the data stored and requiring every bit to survive
-// in order to recover the original data.
-type afSplitData struct {
-	stripes uint32
-	hashAlg tpm2.HashAlgorithmId
-	data    []byte
-}
-
-// merge recovers the original data from this container.
-func (d *afSplitData) merge() ([]byte, error) {
-	if d.stripes < 1 {
-		return nil, errors.New("invalid number of stripes")
-	}
-	if !d.hashAlg.Available() {
-		return nil, errors.New("unsupported digest algorithm")
-	}
-	return afis.MergeHash(d.data, int(d.stripes), func() hash.Hash { return d.hashAlg.NewHash() })
-}
-
-// makeAfSplitData passes the supplied data through an Anti-Forensic Information Splitter to increase the size of the data to at
-// least the size specified by the minSz argument.
-func makeAfSplitData(data []byte, minSz int, hashAlg tpm2.HashAlgorithmId) (*afSplitData, error) {
-	stripes := uint32((minSz / len(data)) + 1)
-
-	split, err := afis.SplitHash(data, int(stripes), func() hash.Hash { return hashAlg.NewHash() })
-	if err != nil {
-		return nil, err
-	}
-
-	return &afSplitData{stripes: stripes, hashAlg: hashAlg, data: split}, nil
-}
-
-func (d afSplitData) Marshal(w io.Writer) (nbytes int, err error) {
-	panic("cannot be marshalled")
-}
-
-func (d *afSplitData) Unmarshal(r io.Reader) (nbytes int, err error) {
-	panic("cannot be unmarshalled")
 }
 
 // keyPolicyUpdateDataRaw_v0 is version 0 of the on-disk format of keyPolicyUpdateData.
@@ -283,22 +193,14 @@ func (d keyData) Marshal(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal raw data: %w", err)
 		}
 	case 2:
-		var tmpW bytes.Buffer
 		raw := keyDataRaw_v2{
 			KeyPrivate:        d.keyPrivate,
 			KeyPublic:         d.keyPublic,
 			ImportSymSeed:     d.importSymSeed,
 			StaticPolicyData:  makeStaticPolicyDataRaw_v1(d.staticPolicyData),
 			DynamicPolicyData: makeDynamicPolicyDataRaw_v0(d.dynamicPolicyData)}
-		if _, err := mu.MarshalToWriter(&tmpW, raw); err != nil {
+		if _, err := mu.MarshalToWriter(w, raw); err != nil {
 			return xerrors.Errorf("cannot marshal raw data: %w", err)
-		}
-		splitData, err := makeAfSplitData(tmpW.Bytes(), 128*1024, tpm2.HashAlgorithmSHA256)
-		if err != nil {
-			return xerrors.Errorf("cannot split data: %w", err)
-		}
-		if _, err := mu.MarshalToWriter(w, makeAfSplitDataRaw(splitData)); err != nil {
-			return xerrors.Errorf("cannot marshal split data: %w", err)
 		}
 	default:
 		return fmt.Errorf("unexpected version number (%d)", d.version)
@@ -325,18 +227,8 @@ func (d *keyData) Unmarshal(r mu.Reader) error {
 			staticPolicyData:  raw.StaticPolicyData.data(),
 			dynamicPolicyData: raw.DynamicPolicyData.data()}
 	case 1:
-		var splitData afSplitDataRaw
-		if _, err := mu.UnmarshalFromReader(r, &splitData); err != nil {
-			return xerrors.Errorf("cannot unmarshal split data: %w", err)
-		}
-
-		merged, err := splitData.data().merge()
-		if err != nil {
-			return xerrors.Errorf("cannot merge data: %w", err)
-		}
-
 		var raw keyDataRaw_v1
-		if _, err := mu.UnmarshalFromBytes(merged, &raw); err != nil {
+		if _, err := mu.UnmarshalFromReader(r, &raw); err != nil {
 			return xerrors.Errorf("cannot unmarshal data: %w", err)
 		}
 		*d = keyData{
@@ -346,18 +238,8 @@ func (d *keyData) Unmarshal(r mu.Reader) error {
 			staticPolicyData:  raw.StaticPolicyData.data(),
 			dynamicPolicyData: raw.DynamicPolicyData.data()}
 	case 2:
-		var splitData afSplitDataRaw
-		if _, err := mu.UnmarshalFromReader(r, &splitData); err != nil {
-			return xerrors.Errorf("cannot unmarshal split data: %w", err)
-		}
-
-		merged, err := splitData.data().merge()
-		if err != nil {
-			return xerrors.Errorf("cannot merge data: %w", err)
-		}
-
 		var raw keyDataRaw_v2
-		if _, err := mu.UnmarshalFromBytes(merged, &raw); err != nil {
+		if _, err := mu.UnmarshalFromReader(r, &raw); err != nil {
 			return xerrors.Errorf("cannot unmarshal data: %w", err)
 		}
 		*d = keyData{
@@ -390,7 +272,7 @@ func (d *keyData) ensureImported(tpm *tpm2.TPMContext, session tpm2.SessionConte
 	priv, err := tpm.Import(srkContext, nil, d.keyPublic, d.keyPrivate, d.importSymSeed, nil, session)
 	if err != nil {
 		if tpm2.IsTPMParameterError(err, tpm2.AnyErrorCode, tpm2.CommandImport, tpm2.AnyParameterIndex) {
-			return keyFileError{errors.New("cannot import sealed key object in to TPM: bad sealed key object, invalid symmetric seed, TPM owner changed or wrong TPM")}
+			return keyDataError{errors.New("cannot import sealed key object in to TPM: bad sealed key object, invalid symmetric seed, TPM owner changed or wrong TPM")}
 		}
 		return xerrors.Errorf("cannot import sealed key object in to TPM: %w", err)
 	}
@@ -423,7 +305,7 @@ func (d *keyData) load(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.
 			invalidObject = true
 		}
 		if invalidObject {
-			return nil, keyFileError{errors.New("cannot load sealed key object in to TPM: bad sealed key object or TPM owner changed")}
+			return nil, keyDataError{errors.New("cannot load sealed key object in to TPM: bad sealed key object or TPM owner changed")}
 		}
 		return nil, xerrors.Errorf("cannot load sealed key object in to TPM: %w", err)
 	}
@@ -435,7 +317,7 @@ func (d *keyData) load(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.
 // for the PCR policy counter.
 func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
 	if d.version > currentMetadataVersion {
-		return nil, keyFileError{errors.New("invalid metadata version")}
+		return nil, keyDataError{errors.New("invalid metadata version")}
 	}
 
 	sealedKeyTemplate := makeImportableSealedKeyTemplate()
@@ -444,10 +326,10 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 
 	// Perform some initial checks on the sealed data object's public area
 	if keyPublic.Type != sealedKeyTemplate.Type {
-		return nil, keyFileError{errors.New("sealed key object has the wrong type")}
+		return nil, keyDataError{errors.New("sealed key object has the wrong type")}
 	}
 	if keyPublic.Attrs&^(tpm2.AttrFixedTPM|tpm2.AttrFixedParent) != sealedKeyTemplate.Attrs {
-		return nil, keyFileError{errors.New("sealed key object has the wrong attributes")}
+		return nil, keyDataError{errors.New("sealed key object has the wrong attributes")}
 	}
 
 	// Load the sealed data object in to the TPM for integrity checking
@@ -463,7 +345,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 		index, err := tpm.CreateResourceContextFromTPM(lockNVHandle, session.IncludeAttrs(tpm2.AttrAudit))
 		if err != nil {
 			if tpm2.IsResourceUnavailableError(err, lockNVHandle) {
-				return nil, keyFileError{errors.New("lock NV index is unavailable")}
+				return nil, keyDataError{errors.New("lock NV index is unavailable")}
 			}
 			return nil, xerrors.Errorf("cannot create context for lock NV index: %w", err)
 		}
@@ -484,7 +366,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 	// revocation, and also for PIN integration with v0 metadata only.
 	pcrPolicyCounterHandle := d.staticPolicyData.pcrPolicyCounterHandle
 	if (pcrPolicyCounterHandle != tpm2.HandleNull || d.version == 0) && pcrPolicyCounterHandle.Type() != tpm2.HandleTypeNVIndex {
-		return nil, keyFileError{errors.New("PCR policy counter handle is invalid")}
+		return nil, keyDataError{errors.New("PCR policy counter handle is invalid")}
 	}
 
 	var pcrPolicyCounter tpm2.ResourceContext
@@ -492,7 +374,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 		pcrPolicyCounter, err = tpm.CreateResourceContextFromTPM(pcrPolicyCounterHandle, session.IncludeAttrs(tpm2.AttrAudit))
 		if err != nil {
 			if tpm2.IsResourceUnavailableError(err, pcrPolicyCounterHandle) {
-				return nil, keyFileError{errors.New("PCR policy counter is unavailable")}
+				return nil, keyDataError{errors.New("PCR policy counter is unavailable")}
 			}
 			return nil, xerrors.Errorf("cannot create context for PCR policy counter: %w", err)
 		}
@@ -507,7 +389,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 	authPublicKey := d.staticPolicyData.authPublicKey
 	authKeyName, err := authPublicKey.Name()
 	if err != nil {
-		return nil, keyFileError{xerrors.Errorf("cannot compute name of dynamic authorization policy key: %w", err)}
+		return nil, keyDataError{xerrors.Errorf("cannot compute name of dynamic authorization policy key: %w", err)}
 	}
 	var expectedAuthKeyType tpm2.ObjectTypeId
 	var expectedAuthKeyScheme tpm2.AsymSchemeId
@@ -520,21 +402,21 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 		expectedAuthKeyScheme = tpm2.AsymSchemeECDSA
 	}
 	if authPublicKey.Type != expectedAuthKeyType {
-		return nil, keyFileError{errors.New("public area of dynamic authorization policy signing key has the wrong type")}
+		return nil, keyDataError{errors.New("public area of dynamic authorization policy signing key has the wrong type")}
 	}
 	authKeyScheme := authPublicKey.Params.AsymDetail(authPublicKey.Type).Scheme
 	if authKeyScheme.Scheme != tpm2.AsymSchemeNull {
 		if authKeyScheme.Scheme != expectedAuthKeyScheme {
-			return nil, keyFileError{errors.New("dynamic authorization policy signing key has unexpected scheme")}
+			return nil, keyDataError{errors.New("dynamic authorization policy signing key has unexpected scheme")}
 		}
 		if authKeyScheme.Details.Any(authKeyScheme.Scheme).HashAlg != authPublicKey.NameAlg {
-			return nil, keyFileError{errors.New("dynamic authorization policy signing key algorithm must match name algorithm")}
+			return nil, keyDataError{errors.New("dynamic authorization policy signing key algorithm must match name algorithm")}
 		}
 	}
 
 	// Make sure that the static authorization policy data is consistent with the sealed key object's policy.
 	if !keyPublic.NameAlg.Available() {
-		return nil, keyFileError{errors.New("cannot determine if static authorization policy matches sealed key object: algorithm unavailable")}
+		return nil, keyDataError{errors.New("cannot determine if static authorization policy matches sealed key object: algorithm unavailable")}
 	}
 	trial := util.ComputeAuthPolicy(keyPublic.NameAlg)
 
@@ -548,7 +430,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 	}
 
 	if !bytes.Equal(trial.GetDigest(), keyPublic.AuthPolicy) {
-		return nil, keyFileError{errors.New("the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")}
+		return nil, keyDataError{errors.New("the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")}
 	}
 
 	// Read the public area of the PCR policy counter
@@ -563,24 +445,24 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 	// For v0 metadata, validate that the OR policy digests for the PCR policy counter match the public area of the index.
 	if d.version == 0 {
 		if !pcrPolicyCounterPub.NameAlg.Available() {
-			return nil, keyFileError{errors.New("cannot determine if PCR policy counter has a valid authorization policy: algorithm unavailable")}
+			return nil, keyDataError{errors.New("cannot determine if PCR policy counter has a valid authorization policy: algorithm unavailable")}
 		}
 
 		pcrPolicyCounterAuthPolicies := d.staticPolicyData.v0PinIndexAuthPolicies
 		expectedPcrPolicyCounterAuthPolicies := computeV0PinNVIndexPostInitAuthPolicies(pcrPolicyCounterPub.NameAlg, authKeyName)
 		if len(pcrPolicyCounterAuthPolicies)-1 != len(expectedPcrPolicyCounterAuthPolicies) {
-			return nil, keyFileError{errors.New("unexpected number of OR policy digests for PCR policy counter")}
+			return nil, keyDataError{errors.New("unexpected number of OR policy digests for PCR policy counter")}
 		}
 		for i, expected := range expectedPcrPolicyCounterAuthPolicies {
 			if !bytes.Equal(expected, pcrPolicyCounterAuthPolicies[i+1]) {
-				return nil, keyFileError{errors.New("unexpected OR policy digest for PCR policy counter")}
+				return nil, keyDataError{errors.New("unexpected OR policy digest for PCR policy counter")}
 			}
 		}
 
 		trial = util.ComputeAuthPolicy(pcrPolicyCounterPub.NameAlg)
 		trial.PolicyOR(pcrPolicyCounterAuthPolicies)
 		if !bytes.Equal(pcrPolicyCounterPub.AuthPolicy, trial.GetDigest()) {
-			return nil, keyFileError{errors.New("PCR policy counter has unexpected authorization policy")}
+			return nil, keyDataError{errors.New("PCR policy counter has unexpected authorization policy")}
 		}
 	}
 
@@ -593,89 +475,43 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, authKey crypto.PrivateKey, sess
 			N: new(big.Int).SetBytes(authPublicKey.Unique.RSA),
 			E: int(authPublicKey.Params.RSADetail.Exponent)}
 		if k.E != goAuthPublicKey.E || k.N.Cmp(goAuthPublicKey.N) != 0 {
-			return nil, keyFileError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
+			return nil, keyDataError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
 		}
 	case *ecdsa.PrivateKey:
 		if d.version == 0 {
-			return nil, keyFileError{errors.New("unexpected dynamic authorization policy signing private key type")}
+			return nil, keyDataError{errors.New("unexpected dynamic authorization policy signing private key type")}
 		}
 		expectedX, expectedY := k.Curve.ScalarBaseMult(k.D.Bytes())
 		if expectedX.Cmp(k.X) != 0 || expectedY.Cmp(k.Y) != 0 {
-			return nil, keyFileError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
+			return nil, keyDataError{errors.New("dynamic authorization policy signing private key doesn't match public key")}
 		}
 	case nil:
 	default:
-		return nil, keyFileError{errors.New("unexpected dynamic authorization policy signing private key type")}
+		return nil, keyDataError{errors.New("unexpected dynamic authorization policy signing private key type")}
 	}
 
 	return pcrPolicyCounterPub, nil
 }
 
-// write serializes keyData in to the provided io.Writer.
-func (d *keyData) write(w io.Writer) error {
-	if _, err := mu.MarshalToWriter(w, keyDataHeader, d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// writeToFileAtomic serializes keyData and writes it atomically to the file at the specified path.
-func (d *keyData) writeToFileAtomic(dest string) error {
-	f, err := osutil.NewAtomicFile(dest, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
-	if err != nil {
-		return xerrors.Errorf("cannot create new atomic file: %w", err)
-	}
-	defer f.Cancel()
-
-	if err := d.write(f); err != nil {
-		return xerrors.Errorf("cannot write to temporary file: %w", err)
-	}
-
-	if err := f.Commit(); err != nil {
-		return xerrors.Errorf("cannot atomically replace file: %w", err)
-	}
-
-	return nil
-}
-
-// decodeKeyData deserializes keyData from the provided io.Reader.
-func decodeKeyData(r io.Reader) (*keyData, error) {
-	var header uint32
-	if _, err := mu.UnmarshalFromReader(r, &header); err != nil {
-		return nil, xerrors.Errorf("cannot unmarshal header: %w", err)
-	}
-	if header != keyDataHeader {
-		return nil, fmt.Errorf("unexpected header (%d)", header)
-	}
-
-	var d keyData
-	if _, err := mu.UnmarshalFromReader(r, &d); err != nil {
-		return nil, xerrors.Errorf("cannot unmarshal data: %w", err)
-	}
-
-	return &d, nil
-}
-
-type keyFileError struct {
+type keyDataError struct {
 	err error
 }
 
-func (e keyFileError) Error() string {
+func (e keyDataError) Error() string {
 	return e.err.Error()
 }
 
-func (e keyFileError) Unwrap() error {
+func (e keyDataError) Unwrap() error {
 	return e.err
 }
 
-func isKeyFileError(err error) bool {
-	var e keyFileError
+func isKeyDataError(err error) bool {
+	var e keyDataError
 	return xerrors.As(err, &e)
 }
 
 // SealedKeyObject corresponds to a sealed key data file.
 type SealedKeyObject struct {
-	path string // XXX: This is here temporarily and will be removed in a future PR
 	data *keyData
 }
 
@@ -690,21 +526,187 @@ func (k *SealedKeyObject) PCRPolicyCounterHandle() tpm2.Handle {
 	return k.data.staticPolicyData.pcrPolicyCounterHandle
 }
 
-// ReadSealedKeyObject loads a sealed key data file created by SealKeyToTPM from the specified path. If the file cannot be opened,
-// a wrapped *os.PathError error is returned. If the key data file cannot be deserialized successfully, a InvalidKeyFileError error
-// will be returned.
-func ReadSealedKeyObject(path string) (*SealedKeyObject, error) {
-	// Open the key data file
+// WriteAtomic will serialize this SealedKeyObject to the supplied writer.
+func (k *SealedKeyObject) WriteAtomic(w secboot.KeyDataWriter) error {
+	if _, err := mu.MarshalToWriter(w, k.data); err != nil {
+		return err
+	}
+	return w.Commit()
+}
+
+// ReadSealedKeyObject reads a SealedKeyObject from the supplied io.Reader. If it
+// cannot be correctly decoded, an InvalidKeyDataError error will be returned.
+func ReadSealedKeyObject(r io.Reader) (*SealedKeyObject, error) {
+	ko := new(SealedKeyObject)
+	if _, err := mu.UnmarshalFromReader(r, &ko.data); err != nil {
+		return nil, InvalidKeyDataError{err.Error()}
+	}
+	return ko, nil
+}
+
+type fileKeyDataHdr struct {
+	Magic   uint32
+	Version uint32
+}
+
+type stripedFileKeyDataHdr struct {
+	Stripes uint32
+	HashAlg tpm2.HashAlgorithmId
+	Size    uint32
+}
+
+// NewFileSealedKeyObjectReader creates an io.Reader from the file at the specified
+// path that can be passed to ReadSealedKeyObject. The file will have been previously
+// created by SealKeyToTPM. If the file cannot be opened, an *os.PathError error will
+// be returned.
+//
+// This function decodes part of the metadata specific to key files. If this fails,
+// an InvalidKeyDataError error will be returned.
+func NewFileSealedKeyObjectReader(path string) (io.Reader, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot open key data file: %w", err)
+		return nil, err
 	}
 	defer f.Close()
 
-	data, err := decodeKeyData(f)
-	if err != nil {
-		return nil, InvalidKeyFileError{err.Error()}
+	// v0 files contain the following structure:
+	//  magic   uint32 // 0x55534b24
+	//  version uint32 // 0
+	//  data    []byte
+	//
+	// post-v0 files contain the following structure:
+	//  magic	uint32 // 0x55534b24
+	//  version	uint32
+	//  stripes	uint32
+	//  hashAlg	tpm2.HashAlgorithmId
+	//  size	uint32
+	//  stripedData [size]byte
+	//
+	// We want to use the version field to encode the keyData structure
+	// version for all sources, but we only want to use the AF splitter
+	// for files. Ideally the key data version would be after the afis
+	// header, but it isn't. We do some manipulation here to move it so
+	// that the keyData unmarshaller can access it.
+
+	var hdr fileKeyDataHdr
+	if _, err := mu.UnmarshalFromReader(f, &hdr); err != nil {
+		return nil, InvalidKeyDataError{fmt.Sprintf("cannot unmarshal file header: %v", err)}
 	}
 
-	return &SealedKeyObject{path: path, data: data}, nil
+	if hdr.Magic != keyDataHeader {
+		return nil, InvalidKeyDataError{fmt.Sprintf("unexpected magic (%d)", hdr.Magic)}
+	}
+
+	// Prepare a buffer for unmarshalling keyData.
+	buf := new(bytes.Buffer)
+	mu.MarshalToWriter(buf, hdr.Version)
+
+	if hdr.Version == 0 {
+		if _, err := io.Copy(buf, f); err != nil {
+			return nil, InvalidKeyDataError{fmt.Sprintf("cannot read data: %v", err)}
+		}
+		return buf, nil
+	}
+
+	var afisHdr stripedFileKeyDataHdr
+	if _, err := mu.UnmarshalFromReader(f, &afisHdr); err != nil {
+		return nil, InvalidKeyDataError{fmt.Sprintf("cannot unmarshal AFIS header: %v", err)}
+	}
+
+	if afisHdr.Stripes == 0 {
+		return nil, InvalidKeyDataError{"invalid number of stripes"}
+	}
+	if !afisHdr.HashAlg.Available() {
+		return nil, InvalidKeyDataError{"digest algorithm unavailable"}
+	}
+
+	data := make([]byte, afisHdr.Size)
+	if _, err := io.ReadFull(f, data); err != nil {
+		return nil, InvalidKeyDataError{fmt.Sprintf("cannot read striped data: %v", err)}
+	}
+
+	merged, err := afis.MergeHash(data, int(afisHdr.Stripes), func() hash.Hash { return afisHdr.HashAlg.NewHash() })
+	if err != nil {
+		return nil, InvalidKeyDataError{fmt.Sprintf("cannot merge data: %v", err)}
+	}
+
+	if _, err := buf.Write(merged); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+type FileSealedKeyObjectWriter struct {
+	*bytes.Buffer
+	path string
+}
+
+func (w *FileSealedKeyObjectWriter) Commit() (err error) {
+	f, err := osutil.NewAtomicFile(w.path, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			f.Cancel()
+		} else {
+			err = f.Commit()
+		}
+	}()
+
+	hdr := fileKeyDataHdr{Magic: keyDataHeader}
+	if _, err := mu.UnmarshalFromReader(w, &hdr.Version); err != nil {
+		return err
+	}
+
+	if _, err := mu.MarshalToWriter(f, &hdr); err != nil {
+		return err
+	}
+
+	if hdr.Version == 0 {
+		if _, err := io.Copy(f, w); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	stripes := uint32((128 * 1024 / w.Len()) + 1)
+
+	data, err := afis.SplitHash(w.Bytes(), int(stripes), func() hash.Hash { return crypto.SHA256.New() })
+	if err != nil {
+		return err
+	}
+
+	afisHdr := stripedFileKeyDataHdr{
+		Stripes: stripes,
+		HashAlg: tpm2.HashAlgorithmSHA256,
+		Size:    uint32(len(data))}
+	if _, err := mu.MarshalToWriter(f, &afisHdr); err != nil {
+		return err
+	}
+
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewFileSealedKeyObjectWriter creates a new writer for atomically updating a sealed key
+// data file using SealedKeyObject.WriteAtomic.
+func NewFileSealedKeyObjectWriter(path string) *FileSealedKeyObjectWriter {
+	return &FileSealedKeyObjectWriter{new(bytes.Buffer), path}
+}
+
+// ReadSealedKeyObjectFromFile reads a SealedKeyObject from the file created by SealKeyToTPM at the specified path.
+// If the file cannot be opened, an *os.PathError error is returned. If the file cannot be deserialized successfully,
+// an InvalidKeyDataError error will be returned.
+func ReadSealedKeyObjectFromFile(path string) (*SealedKeyObject, error) {
+	r, err := NewFileSealedKeyObjectReader(path)
+	if err != nil {
+		return nil, err
+	}
+	return ReadSealedKeyObject(r)
 }

--- a/tpm2/keydata_test.go
+++ b/tpm2/keydata_test.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand"
+	"path/filepath"
+
+	"github.com/canonical/go-tpm2"
+
+	"golang.org/x/sys/unix"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot/internal/testutil"
+	. "github.com/snapcore/secboot/tpm2"
+)
+
+type keydataSuite struct {
+	testutil.TPMSimulatorTestBase
+}
+
+var _ = Suite(&keydataSuite{})
+
+type mockKeyDataWriter struct {
+	tmp   *bytes.Buffer
+	final *bytes.Buffer
+}
+
+func (w *mockKeyDataWriter) Write(data []byte) (int, error) {
+	if w.tmp == nil {
+		return 0, errors.New("cancelled")
+	}
+	return w.tmp.Write(data)
+}
+
+func (w *mockKeyDataWriter) Commit() error {
+	if w.tmp == nil {
+		return errors.New("cancelled or already committed")
+	}
+	w.final = w.tmp
+	w.tmp = nil
+	return nil
+}
+
+func (w *mockKeyDataWriter) Reader() io.Reader {
+	return w.final
+}
+
+func newMockKeyDataWriter() *mockKeyDataWriter {
+	return &mockKeyDataWriter{tmp: new(bytes.Buffer)}
+}
+
+func (s *keydataSuite) TestFileReadAndWrite(c *C) {
+	c.Assert(s.TPM.EnsureProvisioned(ProvisionModeFull, nil), IsNil)
+
+	key := make([]byte, 32)
+	rand.Read(key)
+	keyFile := filepath.Join(c.MkDir(), "keydata")
+
+	authPrivateKey, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, IsNil)
+
+	var st1 unix.Stat_t
+	c.Check(unix.Stat(keyFile, &st1), IsNil)
+
+	k, err := ReadSealedKeyObjectFromFile(keyFile)
+	c.Assert(err, IsNil)
+	c.Check(k.Validate(s.TPM.TPMContext, authPrivateKey, s.TPM.HmacSession()), IsNil)
+
+	w := NewFileSealedKeyObjectWriter(keyFile)
+	c.Check(k.WriteAtomic(w), IsNil)
+
+	var st2 unix.Stat_t
+	c.Check(unix.Stat(keyFile, &st2), IsNil)
+	c.Check(st1.Ino, Not(Equals), st2.Ino)
+
+	k, err = ReadSealedKeyObjectFromFile(keyFile)
+	c.Assert(err, IsNil)
+	c.Check(k.Validate(s.TPM.TPMContext, authPrivateKey, s.TPM.HmacSession()), IsNil)
+}
+
+func (s *keydataSuite) TestReadAndWrite(c *C) {
+	c.Assert(s.TPM.EnsureProvisioned(ProvisionModeFull, nil), IsNil)
+
+	key := make([]byte, 32)
+	rand.Read(key)
+	keyFile := filepath.Join(c.MkDir(), "keydata")
+
+	authPrivateKey, err := SealKeyToTPM(s.TPM, key, keyFile, &KeyCreationParams{PCRProfile: getTestPCRProfile(), PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, IsNil)
+
+	k, err := ReadSealedKeyObjectFromFile(keyFile)
+	c.Assert(err, IsNil)
+
+	w := newMockKeyDataWriter()
+	c.Check(k.WriteAtomic(w), IsNil)
+
+	k, err = ReadSealedKeyObject(w.Reader())
+	c.Assert(err, IsNil)
+	c.Check(k.Validate(s.TPM.TPMContext, authPrivateKey, s.TPM.HmacSession()), IsNil)
+}

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -162,10 +162,6 @@ type KeyCreationParams struct {
 //
 // The tpmKey argument must correspond to the storage primary key on the target TPM, persisted at the standard handle.
 //
-// This function expects there to be no file at the specified path. If keyPath references a file that already exists, a wrapped
-// *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be returned if
-// the file cannot be created and opened for writing.
-//
 // This function cannot create a sealed key that uses a PCR policy counter. The PCRPolicyCounterHandle field of the params argument
 // must be tpm2.HandleNull.
 //
@@ -193,8 +189,6 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath str
 	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
 		return nil, errors.New("PCRPolicyCounter must be tpm2.HandleNull when creating an importable sealed key")
 	}
-
-	succeeded := false
 
 	// Compute metadata.
 
@@ -235,22 +229,7 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath str
 		return nil, xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}
 
-	// Clean up files on failure.
-	defer func() {
-		if succeeded {
-			return
-		}
-		os.Remove(keyPath)
-	}()
-
 	// Seal key
-
-	// Create the destination file
-	f, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create key data file: %w", err)
-	}
-	defer f.Close()
 
 	// Create the sensitive data
 	sealedData, err := mu.MarshalToBytes(sealedData{Key: key, AuthPrivateKey: authKey})
@@ -280,20 +259,20 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath str
 		return nil, xerrors.Errorf("cannot create duplication object: %w", err)
 	}
 
+	w := NewFileSealedKeyObjectWriter(keyPath)
+
 	// Marshal the entire object (sealed key object and auxiliary data) to disk
-	data := keyData{
+	sko := &SealedKeyObject{&keyData{
 		version:           currentMetadataVersion,
 		keyPrivate:        priv,
 		keyPublic:         pub,
 		importSymSeed:     importSymSeed,
 		staticPolicyData:  staticPolicyData,
-		dynamicPolicyData: dynamicPolicyData}
-
-	if err := data.write(f); err != nil {
+		dynamicPolicyData: dynamicPolicyData}}
+	if err := sko.WriteAtomic(w); err != nil {
 		return nil, xerrors.Errorf("cannot write key data file: %w", err)
 	}
 
-	succeeded = true
 	return authKey, nil
 }
 
@@ -312,10 +291,6 @@ type SealKeyRequest struct {
 // This function requires knowledge of the authorization value for the storage hierarchy, which must be provided by calling
 // Connection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the provided authorization value is incorrect,
 // a AuthFailError error will be returned.
-//
-// This function expects there to be no files at the specified paths. If the keys argument references a file that already exists, a
-// wrapped *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be
-// returned if any file cannot be created and opened for writing.
 //
 // This function will create a NV index at the handle specified by the PCRPolicyCounterHandle field of the params argument if it is
 // not tpm2.HandleNull. If the handle is already in use, a TPMResourceExistsError error will be returned. In this case, the caller
@@ -450,15 +425,6 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 
 	// Seal each key.
 	for _, key := range keys {
-		// Create the destination file
-		f, err := os.OpenFile(key.Path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-		if err != nil {
-			return nil, xerrors.Errorf("cannot create key data file %s: %w", key.Path, err)
-		}
-		// We'll close this at the end of this loop, but make sure it is closed if the function
-		// returns early
-		defer f.Close()
-
 		// Create the sensitive data
 		sealedData, err := mu.MarshalToBytes(sealedData{Key: key.Key, AuthPrivateKey: authKey})
 		if err != nil {
@@ -474,19 +440,19 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 			return nil, xerrors.Errorf("cannot create sealed data object for key: %w", err)
 		}
 
+		w := NewFileSealedKeyObjectWriter(key.Path)
+
 		// Marshal the entire object (sealed key object and auxiliary data) to disk
-		data := keyData{
+		sko := &SealedKeyObject{&keyData{
 			version:           currentMetadataVersion,
 			keyPrivate:        priv,
 			keyPublic:         pub,
 			staticPolicyData:  staticPolicyData,
-			dynamicPolicyData: dynamicPolicyData}
+			dynamicPolicyData: dynamicPolicyData}}
 
-		if err := data.write(f); err != nil {
+		if err := sko.WriteAtomic(w); err != nil {
 			return nil, xerrors.Errorf("cannot write key data file: %w", err)
 		}
-
-		f.Close()
 	}
 
 	succeeded = true
@@ -503,10 +469,6 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 //
 // If the TPM is not correctly provisioned, a ErrTPMProvisioning error will be returned. In this case, ProvisionTPM must be called
 // before proceeding.
-//
-// This function expects there to be no file at the specified path. If keyPath references a file that already exists, a wrapped
-// *os.PathError error will be returned with an underlying error of syscall.EEXIST. A wrapped *os.PathError error will be returned if
-// the file cannot be created and opened for writing.
 //
 // This function will create a NV index at the handle specified by the PCRPolicyCounterHandle field of the params argument if it is not
 // tpm2.HandleNull. If the handle is already in use, a TPMResourceExistsError error will be returned. In this case, the caller will
@@ -535,8 +497,8 @@ func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keys []*SealedKeyO
 	// Validate the primary key object
 	pcrPolicyCounterPub, err := primaryData.validate(tpm, authKey, session)
 	if err != nil {
-		if isKeyFileError(err) {
-			return InvalidKeyFileError{err.Error()}
+		if isKeyDataError(err) {
+			return InvalidKeyDataError{err.Error()}
 		}
 		// FIXME: Turn the missing lock NV index in to ErrTPMProvisioning
 		return xerrors.Errorf("cannot validate key data: %w", err)
@@ -545,8 +507,8 @@ func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keys []*SealedKeyO
 	// Validate secondary key objects and make sure they are related
 	for i, k := range keys[1:] {
 		if _, err := k.data.validate(tpm, nil, session); err != nil {
-			if isKeyFileError(err) {
-				return InvalidKeyFileError{fmt.Sprintf("%v (%d)", err.Error(), i)}
+			if isKeyDataError(err) {
+				return InvalidKeyDataError{fmt.Sprintf("%v (%d)", err.Error(), i)}
 			}
 			// FIXME: Turn the missing lock NV index in to ErrTPMProvisioning
 			return xerrors.Errorf("cannot validate related key data: %w", err)
@@ -557,7 +519,7 @@ func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keys []*SealedKeyO
 		// and dynamic authorization policy signing key, so this is the only check required to determine
 		// if 2 keys are related.
 		if !bytes.Equal(k.data.keyPublic.AuthPolicy, primaryData.keyPublic.AuthPolicy) {
-			return InvalidKeyFileError{fmt.Sprintf("key data at index %d is not related to the primary key data", i)}
+			return InvalidKeyDataError{fmt.Sprintf("key data at index %d is not related to the primary key data", i)}
 		}
 	}
 
@@ -574,13 +536,8 @@ func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keys []*SealedKeyO
 		return xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}
 
-	// Atomically update the key data files
 	for _, k := range keys {
 		k.data.dynamicPolicyData = policyData
-
-		if err := k.data.writeToFileAtomic(k.path); err != nil {
-			return xerrors.Errorf("cannot write key data file: %v", err)
-		}
 	}
 
 	return nil
@@ -596,10 +553,10 @@ func updateKeyPCRProtectionPolicyCommon(tpm *tpm2.TPMContext, keys []*SealedKeyO
 
 // If the policy update data file cannot be opened, a wrapped *os.PathError error will be returned.
 //
-// If validation of the sealed key data fails, a InvalidKeyFileError error will be returned.
+// If validation of the sealed key data fails, a InvalidKeyDataError error will be returned.
 //
-// On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
-// computed from the supplied PCRProtectionProfile.
+// On success, this SealedKeyObject will have an updated authorization policy that includes a PCR policy computed
+// from the supplied PCRProtectionProfile. It must be persisted using SealedKeyObject.WriteAtomic.
 func (k *SealedKeyObject) UpdatePCRProtectionPolicyV0(tpm *Connection, policyUpdatePath string, pcrProfile *PCRProtectionProfile) error {
 	policyUpdateFile, err := os.Open(policyUpdatePath)
 	if err != nil {
@@ -609,10 +566,10 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicyV0(tpm *Connection, policyUpd
 
 	policyUpdateData, err := decodeKeyPolicyUpdateData(policyUpdateFile)
 	if err != nil {
-		return InvalidKeyFileError{fmt.Sprintf("cannot read dynamic policy update data: %v", err)}
+		return InvalidKeyDataError{fmt.Sprintf("cannot read dynamic policy update data: %v", err)}
 	}
 	if policyUpdateData.version != k.data.version {
-		return InvalidKeyFileError{"mismatched metadata versions"}
+		return InvalidKeyDataError{"mismatched metadata versions"}
 	}
 
 	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, []*SealedKeyObject{k}, policyUpdateData.authKey, pcrProfile, tpm.HmacSession())
@@ -630,7 +587,7 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicyV0(tpm *Connection, policyUpd
 // to RevokeOldPCRProtectionPoliciesV0. As TPMs may apply rate-limiting to NV writes, this should be called
 // after each call to UpdatePCRProtectionPolicyV0 that removes some PCR policy branches.
 //
-// If validation of the key data fails, a InvalidKeyFileError error will be returned.
+// If validation of the key data fails, a InvalidKeyDataError error will be returned.
 func (k *SealedKeyObject) RevokeOldPCRProtectionPoliciesV0(tpm *Connection, policyUpdatePath string) error {
 	policyUpdateFile, err := os.Open(policyUpdatePath)
 	if err != nil {
@@ -640,16 +597,16 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPoliciesV0(tpm *Connection, poli
 
 	policyUpdateData, err := decodeKeyPolicyUpdateData(policyUpdateFile)
 	if err != nil {
-		return InvalidKeyFileError{fmt.Sprintf("cannot read dynamic policy update data: %v", err)}
+		return InvalidKeyDataError{fmt.Sprintf("cannot read dynamic policy update data: %v", err)}
 	}
 	if policyUpdateData.version != k.data.version {
-		return InvalidKeyFileError{"mismatched metadata versions"}
+		return InvalidKeyDataError{"mismatched metadata versions"}
 	}
 
 	pcrPolicyCounterPub, err := k.data.validate(tpm.TPMContext, policyUpdateData.authKey, tpm.HmacSession())
 	if err != nil {
-		if isKeyFileError(err) {
-			return InvalidKeyFileError{err.Error()}
+		if isKeyDataError(err) {
+			return InvalidKeyDataError{err.Error()}
 		}
 		return xerrors.Errorf("cannot validate key data: %w", err)
 	}
@@ -677,14 +634,12 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPoliciesV0(tpm *Connection, poli
 // incremented by 1 compared with the value associated with the current PCR policy. This does not increment the NV
 // counter on the TPM - this can be done with a subsequent call to RevokeOldPCRProtectionPolicies.
 //
-// If validation of the sealed key data fails, a InvalidKeyFileError error will be returned.
-//
-// On success, the sealed key data file is updated atomically with an updated authorization policy that includes a PCR policy
-// computed from the supplied PCRProtectionProfile.
+// On success, this SealedKeyObject will have an updated authorization policy that includes a PCR policy computed
+// from the supplied PCRProtectionProfile. It must be persisted using SealedKeyObject.WriteAtomic.
 func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey PolicyAuthKey, pcrProfile *PCRProtectionProfile) error {
 	ecdsaAuthKey, err := createECDSAPrivateKeyFromTPM(k.data.staticPolicyData.authPublicKey, tpm2.ECCParameter(authKey))
 	if err != nil {
-		return InvalidKeyFileError{fmt.Sprintf("cannot create auth key: %v", err)}
+		return InvalidKeyDataError{fmt.Sprintf("cannot create auth key: %v", err)}
 	}
 	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, []*SealedKeyObject{k}, ecdsaAuthKey, pcrProfile, tpm.HmacSession())
 }
@@ -702,17 +657,17 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey Pol
 // to RevokeOldPCRProtectionPolicies. As TPMs may apply rate-limiting to NV writes, this should be called
 // after each call to UpdatePCRProtectionPolicy that removes some PCR policy branches.
 //
-// If validation of the key data fails, a InvalidKeyFileError error will be returned.
+// If validation of the key data fails, a InvalidKeyDataError error will be returned.
 func (k *SealedKeyObject) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey PolicyAuthKey) error {
 	ecdsaAuthKey, err := createECDSAPrivateKeyFromTPM(k.data.staticPolicyData.authPublicKey, tpm2.ECCParameter(authKey))
 	if err != nil {
-		return InvalidKeyFileError{fmt.Sprintf("cannot create auth key: %v", err)}
+		return InvalidKeyDataError{fmt.Sprintf("cannot create auth key: %v", err)}
 	}
 
 	pcrPolicyCounterPub, err := k.data.validate(tpm.TPMContext, nil, tpm.HmacSession())
 	if err != nil {
-		if isKeyFileError(err) {
-			return InvalidKeyFileError{err.Error()}
+		if isKeyDataError(err) {
+			return InvalidKeyDataError{err.Error()}
 		}
 		return xerrors.Errorf("cannot validate key data: %w", err)
 	}
@@ -738,10 +693,11 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPolicies(tpm *Connection, authKe
 // profile defined by the pcrProfile argument. The keys must all be related (ie, they were created using
 // SealKeyToTPMMultiple). If any key in the supplied set is not related, an error will be returned.
 //
-// If validation of any sealed key object fails, a InvalidKeyFileError error will be returned.
+// If validation of any sealed key object fails, a InvalidKeyDataError error will be returned.
 //
-// On success, each sealed key data file is updated atomically with an updated authorization policy that includes a PCR
-// policy computed from the supplied PCRProtectionProfile.
+// On success, each of the supplied SealedKeyObjects will have an updated authorization policy that includes a
+// PCR policy computed from the supplied PCRProtectionProfile. They must be persisted using
+// SealedKeyObject.WriteAtomic.
 func UpdateKeyPCRProtectionPolicyMultiple(tpm *Connection, keys []*SealedKeyObject, authKey PolicyAuthKey, pcrProfile *PCRProtectionProfile) error {
 	if len(keys) == 0 {
 		return errors.New("no sealed keys supplied")
@@ -749,7 +705,7 @@ func UpdateKeyPCRProtectionPolicyMultiple(tpm *Connection, keys []*SealedKeyObje
 
 	ecdsaAuthKey, err := createECDSAPrivateKeyFromTPM(keys[0].data.staticPolicyData.authPublicKey, tpm2.ECCParameter(authKey))
 	if err != nil {
-		return InvalidKeyFileError{fmt.Sprintf("cannot create auth key: %v", err)}
+		return InvalidKeyDataError{fmt.Sprintf("cannot create auth key: %v", err)}
 	}
 
 	return updateKeyPCRProtectionPolicyCommon(tpm.TPMContext, keys, ecdsaAuthKey, pcrProfile, tpm.HmacSession())

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -111,7 +111,7 @@ func undefineNVSpace(t *testing.T, tpm *Connection, context, authHandle tpm2.Res
 }
 
 func undefineKeyNVSpace(t *testing.T, tpm *Connection, path string) {
-	k, err := ReadSealedKeyObject(path)
+	k, err := ReadSealedKeyObjectFromFile(path)
 	if err != nil {
 		t.Fatalf("ReadSealedKeyObject failed: %v", err)
 	}

--- a/tpm2/unseal_test.go
+++ b/tpm2/unseal_test.go
@@ -60,7 +60,7 @@ func TestUnsealWithNo2FA(t *testing.T) {
 		}
 		defer undefineKeyNVSpace(t, tpm, keyFile)
 
-		k, err := ReadSealedKeyObject(keyFile)
+		k, err := ReadSealedKeyObjectFromFile(keyFile)
 		if err != nil {
 			t.Fatalf("ReadSealedKeyObject failed: %v", err)
 		}
@@ -134,7 +134,7 @@ func TestUnsealImportable(t *testing.T) {
 			t.Fatalf("SealKeyToExternalTPMStorageKey failed: %v", err)
 		}
 
-		k, err := ReadSealedKeyObject(keyFile)
+		k, err := ReadSealedKeyObjectFromFile(keyFile)
 		if err != nil {
 			t.Fatalf("ReadSealedKeyObject failed: %v", err)
 		}
@@ -189,7 +189,7 @@ func TestUnsealRelated(t *testing.T) {
 	defer undefineKeyNVSpace(t, tpm, keys[0].Path)
 
 	for _, key := range keys {
-		k, err := ReadSealedKeyObject(key.Path)
+		k, err := ReadSealedKeyObjectFromFile(key.Path)
 		if err != nil {
 			t.Fatalf("ReadSealedKeyObject failed: %v", err)
 		}
@@ -238,7 +238,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 
 		fn(tpm, keyFile, authKey)
 
-		k, err := ReadSealedKeyObject(keyFile)
+		k, err := ReadSealedKeyObjectFromFile(keyFile)
 		if err != nil {
 			t.Fatalf("ReadSealedKeyObject failed: %v", err)
 		}
@@ -294,7 +294,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 				t.Errorf("EvictControl failed: %v", err)
 			}
 		})
-		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot load sealed key object in to TPM: bad "+
+		if _, ok := err.(InvalidKeyDataError); !ok || err.Error() != "invalid key data: cannot load sealed key object in to TPM: bad "+
 			"sealed key object or TPM owner changed" {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -309,7 +309,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expected an error")
 		}
-		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot complete authorization policy "+
+		if _, ok := err.(InvalidKeyDataError); !ok || err.Error() != "invalid key data: cannot complete authorization policy "+
 			"assertions: cannot complete OR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -332,7 +332,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 
 			io.Copy(dst, src)
 
-			k, err := ReadSealedKeyObject(newKeyFile)
+			k, err := ReadSealedKeyObjectFromFile(newKeyFile)
 			if err != nil {
 				t.Fatalf("ReadSealedKeyObject failed: %v", err)
 			}
@@ -344,7 +344,7 @@ func TestUnsealErrorHandling(t *testing.T) {
 				t.Fatalf("RevokeOldPCRProtectionPolicies failed: %v", err)
 			}
 		})
-		if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: cannot complete authorization policy "+
+		if _, ok := err.(InvalidKeyDataError); !ok || err.Error() != "invalid key data: cannot complete authorization policy "+
 			"assertions: the PCR policy has been revoked" {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -356,8 +356,8 @@ func TestUnsealErrorHandling(t *testing.T) {
 				t.Errorf("BlockPCRProtectionPolicies failed: %v", err)
 			}
 		})
-		if _, ok := err.(InvalidKeyFileError); !ok ||
-			err.Error() != "invalid key data file: cannot complete authorization policy assertions: cannot complete OR assertions: current "+
+		if _, ok := err.(InvalidKeyDataError); !ok ||
+			err.Error() != "invalid key data: cannot complete authorization policy assertions: cannot complete OR assertions: current "+
 				"session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}


### PR DESCRIPTION
In order to create a tpm2 platform implementation for KeyData,
SealedKeyObject needs to be storage agnostic instead of having
a hard dependency on file paths.

This makes ReadSealedKeyObject take an io.Reader.

SealedKeyObject.UpdatePCRProtectionPolicy now only modifies the
in-memory SealedKeyObject. SealedKeyObject.WriteAtomic has been
introduced for persisting changes to some storage mechanism.

Two additional APIs have been introduced to work with existing
sealed key files - ReadSealedKeyObjectFromFile and
NewFileSealedKeyObjectWriter.

Existing sealed key files use a AF-splitter. This has limited use
on solid state drives and was introduced to make PIN changes more
secure with key data that is stored inside a filesystem. For that
reason, the generic ReadSealedKeyObject and
SealedKeyObject.WriteAtomic do not use the AF-splitter - this is
implemented only for the file reader / writer. Note that PIN support
is removed in a previous PR anyway.

The key data metadata needs to be versioned regardless of how it
is stored. One challenge here is that this metadata version is
stored before the metadata for the AF-slitter, which is specific
to key data files. To work around this, the file reader does some
gymnastics to ensure that the stream read by ReadSealedKeyObject
contains this version. Similarly, the file writer performs the
reverse gymnastics to ensure that the version gets written to the
correct place.

This doesn't modify the existing SealKeyToTPM API yet - this API
will continue to only create files for now. I did consider making
SealKeyToTPM return a SealedKeyObject that then has to be written
somewhere persistent, but this API is going to look different when
creating new style sealed keys compatible with the secboot.KeyData
API - it will return a secboot.KeyCreationData that can be passed
to secboot.NewKeyData. I didn't see the point in changing this API
twice.