### PR TITLE
Ensure keyring tests are skipped in unsuitable environments

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,10 +10,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-    - name: Set up Go 1.9
+    - name: Set up Go 1.13
       uses: actions/setup-go@v2
       with:
-        go-version: 1.9
+        go-version: 1.13
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -35,6 +35,14 @@ type keyringSuite struct {
 
 var _ = Suite(&keyringSuite{})
 
+func (s *keyringSuite) SetUpSuite(c *C) {
+	s.KeyringTestBase.SetUpSuite(c)
+
+	if !s.ProcessPossessesUserKeyringKeys {
+		c.Skip("Test requires the user keyring to be linked from the process's session keyring")
+	}
+}
+
 type testGetDiskUnlockKeyFromKernelData struct {
 	key        DiskUnlockKey
 	prefix     string


### PR DESCRIPTION
Some tests that touch the keyring are failing since the switch
to github actions. There is a check in other suites to skip
keyring tests in environments that are unsuitable, but not in
the tests that are failing. This adds that check there too.

(We need to figure out how to make these tests work in
github actions, so this is a temporary fix for now just to
get the tests to pass).

Note that I also changed the go version to 1.9 (from 1.10)
when switching to github actions because that was the
minimum required by snapd, but that makes go vet fail.
I've changed the go version to 1.13 now that is the
minimum required by snapd.