### PR TITLE
tpm2: Don't depend on go's crypto packages for measurements

### DIFF
--- a/tpm2/crypt_test.go
+++ b/tpm2/crypt_test.go
@@ -174,7 +174,6 @@ func (s *cryptTPMSimulatorSuite) SetUpTest(c *C) {
 	s.recoveryKey = s.newRecoveryKey()
 	s.addMockKeyslot(c, s.recoveryKey[:])
 
-
 	sdAskPasswordBottom := `
 head -1 %[1]s
 sed -i -e '1,1d' %[1]s

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -83,6 +83,9 @@ func (d *DynamicPolicyData) AuthorizedPolicySignature() *tpm2.Signature {
 	return d.authorizedPolicySignature
 }
 
+type GoSnapModelHasher = goSnapModelHasher
+type SnapModelHasher = snapModelHasher
+
 type StaticPolicyData = staticPolicyData
 
 func (d *StaticPolicyData) AuthPublicKey() *tpm2.Public {

--- a/tpm2/snapmodel_policy_test.go
+++ b/tpm2/snapmodel_policy_test.go
@@ -418,7 +418,9 @@ func (s *snapModelMeasureSuite) testMeasureSnapModelToTPMTest(c *C, data *testMe
 	c.Assert(err, IsNil)
 
 	for _, s := range pcrSelection {
-		snapModelDigest, err := ComputeSnapModelDigest(s.Hash, data.model)
+		snapModelDigest, err := ComputeSnapModelDigest(func() (SnapModelHasher, error) {
+			return &GoSnapModelHasher{s.Hash.NewHash()}, nil
+		}, data.model)
 		c.Assert(err, IsNil)
 
 		h := s.Hash.NewHash()


### PR DESCRIPTION
BlockPCRProtectionPolicies makes use of an event sequence which
means that the TPM computes the measurement digest for each PCR
bank based on the data supplied to the sequence. Neither
MeasureSnapSystemEpochToTPM or MeasureSnapModelToTPM use this -
they instead rely on go for computing a digest for each PCR bank,
which is then measured to the TPM using TPM2_PCR_Extend.

The issue is that the TPM may support a digest algorithm which is
not part of go's standard library (such as sha3), and in the case of
SM3, not even part of golang.org/x/crypto and without a corresponding
crypto.Hash. And I'm not sure we'd want to pull in every possible
crypto package just for this anyway.

The code skips unsupported algorithms as a workaround by checking
tpm2.HashAlgorithmId.Supported(), although this is wrong -
Supported() indicates whether there is a corresponding crypto.Hash,
not whether the algorithm can actually be used -
tpm2.HashAlgorithmId.Available() is for that. I suspect that this
code will panic on newer TPMs that support sha3 if
golang.org/x/crypto/sha3 is not linked into snap-bootstrap. When
we update go-tpm2 to support the SM3 algorithm ID, this code will
definitely panic because there won't be a way to actually construct
a SM3 digest.

MeasureSnapSystemEpochToTPM can make use of an event sequence like
BlockPCRProtectionPolicies already does, so I've converted it to
do so.

MeasureSnapModelToTPM is a bit trickier because it computes the
digest in multiple steps and cannot use an event sequence. Instead,
I've converted it to computing the digests for each PCR bank using
individual hash sequences and then measuring the digests to the TPM
using TPM2_PCR_Extend like it currently does.