### PR TITLE
Bump go-tpm2 version

### DIFF
--- a/efi/bootmanager_policy_test.go
+++ b/efi/bootmanager_policy_test.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -59,7 +60,7 @@ func (s *bootManagerPolicySuite) testAddBootManagerProfile(c *C, data *testAddBo
 	expectedPcrs = expectedPcrs.Merge(tpm2.PCRSelectionList{{Hash: data.params.PCRAlgorithm, Select: []int{4}}})
 	var expectedDigests tpm2.DigestList
 	for _, v := range data.values {
-		d, _ := tpm2.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
+		d, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
 		expectedDigests = append(expectedDigests, d)
 	}
 

--- a/efi/sdstub_policy_test.go
+++ b/efi/sdstub_policy_test.go
@@ -21,6 +21,7 @@ package efi_test
 
 import (
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -48,7 +49,7 @@ func (s *sdstubPolicySuite) testAddSystemdStubProfile(c *C, data *testAddSystemd
 	expectedPcrs = expectedPcrs.Merge(tpm2.PCRSelectionList{{Hash: data.params.PCRAlgorithm, Select: []int{data.params.PCRIndex}}})
 	var expectedDigests tpm2.DigestList
 	for _, v := range data.values {
-		d, _ := tpm2.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
+		d, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
 		expectedDigests = append(expectedDigests, d)
 	}
 

--- a/efi/secureboot_policy_test.go
+++ b/efi/secureboot_policy_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/canonical/go-efilib"
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -270,7 +271,7 @@ func (s *securebootPolicySuite) testAddSecureBootPolicyProfile(c *C, data *testA
 	expectedPcrs = expectedPcrs.Merge(tpm2.PCRSelectionList{{Hash: data.params.PCRAlgorithm, Select: []int{7}}})
 	var expectedDigests tpm2.DigestList
 	for _, v := range data.values {
-		d, _ := tpm2.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
+		d, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
 		expectedDigests = append(expectedDigests, d)
 	}
 

--- a/internal/tcti/tcti.go
+++ b/internal/tcti/tcti.go
@@ -21,6 +21,7 @@ package tcti
 
 import (
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/linux"
 )
 
 const (
@@ -30,5 +31,5 @@ const (
 
 // OpenDefaultTcti connects to the default TPM character device. This can be overridden for tests to connect to a simulator device.
 var OpenDefault = func() (tpm2.TCTI, error) {
-	return tpm2.OpenTPMDevice(tpmPath)
+	return linux.OpenDevice(tpmPath)
 }

--- a/internal/testutil/suites.go
+++ b/internal/testutil/suites.go
@@ -21,6 +21,7 @@ package testutil
 
 import (
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mssim"
 	"github.com/snapcore/snapd/testutil"
 
 	"golang.org/x/sys/unix"
@@ -117,7 +118,7 @@ func (b *TPMTestBase) SetHierarchyAuth(c *C, hierarchy tpm2.Handle) {
 
 type TPMSimulatorTestBase struct {
 	TPMTestBase
-	tcti *tpm2.TctiMssim
+	tcti *mssim.Tcti
 }
 
 func (b *TPMSimulatorTestBase) SetUpTest(c *C) {

--- a/tpm2/pcr_profile.go
+++ b/tpm2/pcr_profile.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/util"
 
 	"golang.org/x/xerrors"
 )
@@ -364,7 +365,10 @@ func (p *PCRProtectionProfile) ComputePCRDigests(tpm *tpm2.TPMContext, alg tpm2.
 	// Compute the PCR digests for all branches, making sure that they all contain values for the same sets of PCRs.
 	var pcrDigests tpm2.DigestList
 	for _, v := range values {
-		p, digest, _ := tpm2.ComputePCRDigestSimple(alg, v)
+		p, digest, err := util.ComputePCRDigestFromAllValues(alg, v)
+		if err != nil {
+			return nil, nil, xerrors.Errorf("cannot compute PCR digest: %w", err)
+		}
 		if !p.Equal(pcrs) {
 			return nil, nil, errors.New("not all branches contain values for the same sets of PCRs")
 		}

--- a/tpm2/pcr_profile_test.go
+++ b/tpm2/pcr_profile_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/util"
 
 	"github.com/snapcore/secboot/internal/testutil"
 	. "github.com/snapcore/secboot/tpm2"
@@ -327,7 +328,7 @@ func TestPCRProtectionProfile(t *testing.T) {
 			expectedPcrs := data.values[0].SelectionList()
 			var expectedDigests tpm2.DigestList
 			for _, v := range data.values {
-				d, _ := tpm2.ComputePCRDigest(data.alg, expectedPcrs, v)
+				d, _ := util.ComputePCRDigest(data.alg, expectedPcrs, v)
 				expectedDigests = append(expectedDigests, d)
 			}
 
@@ -409,7 +410,7 @@ func TestPCRProtectionProfileAddValueFromTPM(t *testing.T) {
 	if len(digests) != 1 {
 		t.Fatalf("ComputePCRDigests returned the wrong number of digests")
 	}
-	expectedDigest, _ := tpm2.ComputePCRDigest(tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}, tpmValues)
+	expectedDigest, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}, tpmValues)
 	if !bytes.Equal(digests[0], expectedDigest) {
 		t.Errorf("ComputePCRDigests returned unexpected values")
 	}

--- a/tpm2/provisioning.go
+++ b/tpm2/provisioning.go
@@ -119,7 +119,7 @@ func selectSrkTemplate(tpm *tpm2.TPMContext, session tpm2.SessionContext) *tpm2.
 		return tcg.SRKTemplate
 	}
 
-	if !tmpl.IsParent() {
+	if !tmpl.IsStorageParent() {
 		return tcg.SRKTemplate
 	}
 
@@ -357,7 +357,7 @@ func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAut
 // completed without using the lockout hierarchy, but the function should be called again either with mode set to ProvisionModeFull
 // (if the authorization value for the lockout hierarchy is known), or ProvisionModeClear.
 func (t *Connection) EnsureProvisionedWithCustomSRK(mode ProvisionMode, newLockoutAuth []byte, srkTemplate *tpm2.Public) error {
-	if srkTemplate != nil && !srkTemplate.IsParent() {
+	if srkTemplate != nil && !srkTemplate.IsStorageParent() {
 		return errors.New("supplied SRK template is not valid for a parent key")
 	}
 

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
+	"github.com/canonical/go-tpm2/util"
 
 	"golang.org/x/xerrors"
 )
@@ -269,7 +270,7 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath str
 		panic(fmt.Sprintf("cannot marshal sensitive data: %v", err))
 	}
 	// Define the actual sensitive area. The initial auth value is empty - note
-	// that tpm2.CreateDuplicationObjectFromSensitive pads this to the length of
+	// that util.CreateDuplicationObjectFromSensitive pads this to the length of
 	// the name algorithm for us so we don't define it here.
 	sensitive := tpm2.Sensitive{
 		Type:      pub.Type,
@@ -286,7 +287,7 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key []byte, keyPath str
 	pub.Unique = &tpm2.PublicIDU{KeyedHash: h.Sum(nil)}
 
 	// Now create the importable sealed key object (duplication object).
-	_, priv, importSymSeed, err := tpm2.CreateDuplicationObjectFromSensitive(&sensitive, pub, tpmKey, nil, nil)
+	_, priv, importSymSeed, err := util.CreateDuplicationObjectFromSensitive(&sensitive, pub, tpmKey, nil, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create duplication object: %w", err)
 	}

--- a/tpm2/snapmodel_policy.go
+++ b/tpm2/snapmodel_policy.go
@@ -139,7 +139,7 @@ func measureSnapPropertyToTPM(tpm *Connection, pcrIndex int, computeDigest func(
 
 	var digests tpm2.TaggedHashList
 	for _, s := range pcrSelection {
-		if !s.Hash.Supported() {
+		if !s.Hash.Available() {
 			// We can't compute a digest for this algorithm, which is unfortunate. It's unlikely that we'll come across a TPM that supports a
 			// digest algorithm that go doesn't have an implementation of, so just skip it to avoid a panic - we can't generate a PCR profile
 			// bound to any PCRs in this bank anyway.

--- a/tpm2/snapmodel_policy_test.go
+++ b/tpm2/snapmodel_policy_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
@@ -50,7 +51,7 @@ func (s *snapModelProfileSuite) testAddSnapModelProfile(c *C, data *testAddSnapM
 	expectedPcrs = expectedPcrs.Merge(tpm2.PCRSelectionList{{Hash: data.params.PCRAlgorithm, Select: []int{data.params.PCRIndex}}})
 	var expectedDigests tpm2.DigestList
 	for _, v := range data.values {
-		d, _ := tpm2.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
+		d, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, expectedPcrs, v)
 		expectedDigests = append(expectedDigests, d)
 	}
 

--- a/tpm2/tpm.go
+++ b/tpm2/tpm.go
@@ -350,13 +350,8 @@ func connectToDefaultTPM() (*tpm2.TPMContext, error) {
 		return nil, xerrors.Errorf("cannot open TPM device: %w", err)
 	}
 
-	tpm, _ := tpm2.NewTPMContext(tcti)
-	isTpm2, err := tpm.IsTPM2()
-	if err != nil {
-		tpm.Close()
-		return nil, xerrors.Errorf("cannot determine if TPM is a TPM2 device: %w", err)
-	}
-	if !isTpm2 {
+	tpm := tpm2.NewTPMContext(tcti)
+	if !tpm.IsTPM2() {
 		tpm.Close()
 		return nil, ErrNoTPM2Device
 	}

--- a/tpm2/tpm2_test.go
+++ b/tpm2/tpm2_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mssim"
 
 	"golang.org/x/xerrors"
 
@@ -51,7 +52,7 @@ func Test(t *testing.T) { TestingT(t) }
 
 // resetTPMSimulator executes reset sequence of the TPM (Shutdown(CLEAR) -> reset -> Startup(CLEAR)) and the re-initializes the
 // Connection.
-func resetTPMSimulator(t *testing.T, tpm *Connection, tcti *tpm2.TctiMssim) (*Connection, *tpm2.TctiMssim) {
+func resetTPMSimulator(t *testing.T, tpm *Connection, tcti *mssim.Tcti) (*Connection, *mssim.Tcti) {
 	tpm, tcti, err := testutil.ResetTPMSimulator(tpm, tcti)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -59,7 +60,7 @@ func resetTPMSimulator(t *testing.T, tpm *Connection, tcti *tpm2.TctiMssim) (*Co
 	return tpm, tcti
 }
 
-func openTPMSimulatorForTesting(t *testing.T) (*Connection, *tpm2.TctiMssim) {
+func openTPMSimulatorForTesting(t *testing.T) (*Connection, *mssim.Tcti) {
 	tpm, tcti, err := testutil.OpenTPMSimulatorForTesting()
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/tpm2/tpm_test.go
+++ b/tpm2/tpm_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mssim"
 
 	"github.com/snapcore/secboot/internal/tcg"
 	"github.com/snapcore/secboot/internal/testutil"
@@ -69,7 +70,7 @@ func TestConnectionIsEnabled(t *testing.T) {
 
 func TestConnectToDefaultTPM(t *testing.T) {
 	restore := testutil.MockOpenDefaultTctiFn(func() (tpm2.TCTI, error) {
-		return tpm2.OpenMssim("", testutil.MssimPort, testutil.MssimPort+1)
+		return mssim.OpenConnection("", testutil.MssimPort)
 	})
 	defer restore()
 
@@ -214,7 +215,7 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 	}
 
 	restore := testutil.MockOpenDefaultTctiFn(func() (tpm2.TCTI, error) {
-		return tpm2.OpenMssim("", testutil.MssimPort, testutil.MssimPort+1)
+		return mssim.OpenConnection("", testutil.MssimPort)
 	})
 	defer restore()
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -41,28 +41,46 @@
 			"revisionTime": "2021-03-12T20:55:53Z"
 		},
 		{
-			"checksumSHA1": "UYqZjF/41DZxSoSdAOnYlL1yrKQ=",
+			"checksumSHA1": "+FSFqGmrjmYyWJhJlL5C42jWPyU=",
 			"path": "github.com/canonical/go-tpm2",
-			"revision": "3926e4dcfeedab70d07ebd55425f8283b18f4a20",
-			"revisionTime": "2021-04-29T19:17:09Z"
+			"revision": "09737a6617acced3befb8084e63dd6084b8f0d8a",
+			"revisionTime": "2021-08-24T19:02:25Z"
 		},
 		{
-			"checksumSHA1": "bT/rC7K8St3lNRXf/XJGpB4wNJU=",
+			"checksumSHA1": "0wuA3btHc67a/DaiXem7zlpPRw4=",
 			"path": "github.com/canonical/go-tpm2/internal",
-			"revision": "16307201a54dc51583440f9416cfa836bcf0b3fc",
-			"revisionTime": "2020-04-16T00:17:14Z"
+			"revision": "3e2b334e4aa6bc83175ebe0d0cc9524140737632",
+			"revisionTime": "2021-08-24T13:09:21Z"
 		},
 		{
-			"checksumSHA1": "e9330VKxSBvGRJ7jSl2wNYKiBms=",
+			"checksumSHA1": "hcs0X8rKQni3LBBPquw7GZ7KF4A=",
+			"path": "github.com/canonical/go-tpm2/linux",
+			"revision": "09737a6617acced3befb8084e63dd6084b8f0d8a",
+			"revisionTime": "2021-08-24T19:02:25Z"
+		},
+		{
+			"checksumSHA1": "CaogwrlaFaf5AHOunuxYZbMhE2o=",
+			"path": "github.com/canonical/go-tpm2/mssim",
+			"revision": "09737a6617acced3befb8084e63dd6084b8f0d8a",
+			"revisionTime": "2021-08-24T19:02:25Z"
+		},
+		{
+			"checksumSHA1": "XhX0jJCdJOvsn4pIOL0H8J9YV54=",
 			"path": "github.com/canonical/go-tpm2/mu",
-			"revision": "14cc20cfdf983fc6894fce8659c40acf3e6d3a73",
-			"revisionTime": "2021-01-29T14:51:58Z"
+			"revision": "09737a6617acced3befb8084e63dd6084b8f0d8a",
+			"revisionTime": "2021-08-24T19:02:25Z"
 		},
 		{
-			"checksumSHA1": "43QtCy2oPFC9FSVmVpfJvaZvkL8=",
+			"checksumSHA1": "xPM3ZG13qidGvsK3teP0JhrKX4I=",
+			"path": "github.com/canonical/go-tpm2/util",
+			"revision": "09737a6617acced3befb8084e63dd6084b8f0d8a",
+			"revisionTime": "2021-08-24T19:02:25Z"
+		},
+		{
+			"checksumSHA1": "pjpC3gtdvLblTbmFOnvc8MzbaLs=",
 			"path": "github.com/canonical/tcglog-parser",
-			"revision": "143e5990fece56ae5ccf77271d6e2ebe49878e7a",
-			"revisionTime": "2021-07-11T17:09:48Z"
+			"revision": "69fa1e9f0ad25c043447972330d66337cb1e9a57",
+			"revisionTime": "2021-08-24T13:18:05Z"
 		},
 		{
 			"checksumSHA1": "r6hlCzWoD5bpQ9a4CY2QORjFjHY=",


### PR DESCRIPTION
This bumps the go-tpm2 version to the latest master. This includes
https://github.com/canonical/go-tpm2/commit/96eb110220ece5922dc7b691422fff12735f1880
which makes it possible to decode TPM responses containing TPML_DIGEST_VALUES
structures with SM3 digests.

Some functionality that is not required by the core tpm2 library but was
previously part of the go-tpm2 package has been split out into separate
subpackages.