### PR TITLE
tpm2: remove methods from keyData

### DIFF
--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -183,7 +183,7 @@ func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authPrivateKey PolicyAu
 		return err
 	}
 
-	_, err = k.data.validate(tpm, authKey, session)
+	_, err = k.validate(tpm, authKey, session)
 	return err
 }
 

--- a/tpm2/unseal.go
+++ b/tpm2/unseal.go
@@ -79,7 +79,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *Connection) (key []byte, authKey Po
 	hmacSession := tpm.HmacSession()
 
 	// Load the key data
-	keyObject, err := k.data.load(tpm.TPMContext, hmacSession)
+	keyObject, err := k.load(tpm.TPMContext, hmacSession)
 	switch {
 	case isKeyDataError(err):
 		// A keyDataError can be as a result of an improperly provisioned TPM - detect if the object at tcg.SRKHandle is a valid primary key


### PR DESCRIPTION
The internal keyData struct has a bunch of methods because
once-upon-a-time, SealedKeyObject was only created for unsealing
and we only created keyData internall for other operations.
Now that's SealedKeyObject is used for everything, just make the
methods of keyData unexported methods of SealedKeyObject, as the
current split appears to be completely arbitrary now.