### PR TITLE
Add AuthRequestor interface

### DIFF
--- a/auth_requestor.go
+++ b/auth_requestor.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+// AuthRequestor is an interface for requesting credentials.
+type AuthRequestor interface {
+	// RequestPassphrase is used to request the passphrase for a platform
+	// protected key that is being used to unlock the container at the
+	// specified sourceDevicePath.
+	RequestPassphrase(volumeName, sourceDevicePath string) (string, error)
+
+	// RequestRecoveryKey is used to request the recovery key to unlock the
+	// container at the specified sourceDevicePath.
+	RequestRecoveryKey(volumeName, sourceDevicePath string) (RecoveryKey, error)
+}

--- a/auth_requestor_systemd.go
+++ b/auth_requestor_systemd.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"golang.org/x/xerrors"
+)
+
+type askPasswordMsgParams struct {
+	VolumeName       string
+	SourceDevicePath string
+	// PartLabel string
+	// LUKS2Label string
+}
+
+type systemdAuthRequestor struct {
+	passphraseTmpl  *template.Template
+	recoveryKeyTmpl *template.Template
+}
+
+func (r *systemdAuthRequestor) askPassword(sourceDevicePath, msg string) (string, error) {
+	cmd := exec.Command(
+		"systemd-ask-password",
+		"--icon", "drive-harddisk",
+		"--id", filepath.Base(os.Args[0])+":"+sourceDevicePath,
+		msg)
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	result, err := out.ReadString('\n')
+	if err != nil {
+		// The only error returned from bytes.Buffer.ReadString is io.EOF.
+		return "", errors.New("systemd-ask-password output is missing terminating newline")
+	}
+	return strings.TrimRight(result, "\n"), nil
+}
+
+func (r *systemdAuthRequestor) RequestPassphrase(volumeName, sourceDevicePath string) (string, error) {
+	params := askPasswordMsgParams{
+		VolumeName:       volumeName,
+		SourceDevicePath: sourceDevicePath}
+
+	msg := new(bytes.Buffer)
+	if err := r.passphraseTmpl.Execute(msg, params); err != nil {
+		return "", xerrors.Errorf("cannot execute message template: %w", err)
+	}
+
+	return r.askPassword(sourceDevicePath, msg.String())
+}
+
+func (r *systemdAuthRequestor) RequestRecoveryKey(volumeName, sourceDevicePath string) (RecoveryKey, error) {
+	params := askPasswordMsgParams{
+		VolumeName:       volumeName,
+		SourceDevicePath: sourceDevicePath}
+
+	msg := new(bytes.Buffer)
+	if err := r.recoveryKeyTmpl.Execute(msg, params); err != nil {
+		return RecoveryKey{}, xerrors.Errorf("cannot execute message template: %w", err)
+	}
+
+	passphrase, err := r.askPassword(sourceDevicePath, msg.String())
+	if err != nil {
+		return RecoveryKey{}, err
+	}
+
+	key, err := ParseRecoveryKey(passphrase)
+	if err != nil {
+		return RecoveryKey{}, xerrors.Errorf("cannot parse recovery key: %w", err)
+	}
+
+	return key, nil
+}
+
+// NewSystemdAuthRequestor creates an implementation of AuthRequestor that
+// delegates to the systemd-ask-password binary. The supplied templates are
+// used to compose the messages that will be displayed when requesting a
+// credential. The template will be executed with the following parameters:
+// - .VolumeName: The name that the LUKS container will be mapped to.
+// - .SourceDevicePath: The device path of the LUKS container.
+func NewSystemdAuthRequestor(passphraseTmpl, recoveryKeyTmpl string) (AuthRequestor, error) {
+	pt, err := template.New("passphraseMsg").Parse(passphraseTmpl)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot parse passphrase message template: %w", err)
+	}
+
+	rkt, err := template.New("recoveryKeyMsg").Parse(recoveryKeyTmpl)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot parse recovery key message template: %w", err)
+	}
+
+	return &systemdAuthRequestor{
+		passphraseTmpl:  pt,
+		recoveryKeyTmpl: rkt}, nil
+}

--- a/auth_requestor_systemd.go
+++ b/auth_requestor_systemd.go
@@ -53,7 +53,7 @@ func (r *systemdAuthRequestor) askPassword(sourceDevicePath, msg string) (string
 	cmd.Stdout = out
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
-		return "", err
+		return "", xerrors.Errorf("cannot execute systemd-ask-password: %v", err)
 	}
 	result, err := out.ReadString('\n')
 	if err != nil {

--- a/auth_requestor_systemd_test.go
+++ b/auth_requestor_systemd_test.go
@@ -136,6 +136,14 @@ func (s *authRequestorSystemdSuite) TestRequestPassphraseInvalidResponse(c *C) {
 	c.Check(err, ErrorMatches, "systemd-ask-password output is missing terminating newline")
 }
 
+func (s *authRequestorSystemdSuite) TestRequestPassphraseFailure(c *C) {
+	requestor, err := NewSystemdAuthRequestor("", "")
+	c.Assert(err, IsNil)
+
+	_, err = requestor.RequestPassphrase("data", "/dev/sda1")
+	c.Check(err, ErrorMatches, "cannot execute systemd-ask-password: exit status 1")
+}
+
 type testRequestRecoveryKeyData struct {
 	passphrase string
 
@@ -261,4 +269,12 @@ func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyInvalidFormat(c *C) {
 
 	_, err = requestor.RequestRecoveryKey("data", "/dev/sda1")
 	c.Check(err, ErrorMatches, "cannot parse recovery key: incorrectly formatted: insufficient characters")
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyFailure(c *C) {
+	requestor, err := NewSystemdAuthRequestor("", "")
+	c.Assert(err, IsNil)
+
+	_, err = requestor.RequestRecoveryKey("data", "/dev/sda1")
+	c.Check(err, ErrorMatches, "cannot execute systemd-ask-password: exit status 1")
 }

--- a/auth_requestor_systemd_test.go
+++ b/auth_requestor_systemd_test.go
@@ -1,0 +1,264 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+type authRequestorSystemdSuite struct {
+	snapd_testutil.BaseTest
+
+	passwordFile      string
+	mockSdAskPassword *snapd_testutil.MockCmd
+}
+
+func (s *authRequestorSystemdSuite) SetUpTest(c *C) {
+	dir := c.MkDir()
+	s.passwordFile = filepath.Join(dir, "password") // password to be returned by the mock sd-ask-password
+
+	sdAskPasswordBottom := `cat %[1]s`
+	s.mockSdAskPassword = snapd_testutil.MockCommand(c, "systemd-ask-password", fmt.Sprintf(sdAskPasswordBottom, s.passwordFile))
+	s.AddCleanup(s.mockSdAskPassword.Restore)
+}
+
+func (s *authRequestorSystemdSuite) setPassphrase(c *C, passphrase string) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte(passphrase+"\n"), 0600), IsNil)
+}
+
+var _ = Suite(&authRequestorSystemdSuite{})
+
+type testRequestPassphraseData struct {
+	passphrase string
+
+	tmpl string
+
+	volumeName       string
+	sourceDevicePath string
+
+	expectedMsg string
+}
+
+func (s *authRequestorSystemdSuite) testRequestPassphrase(c *C, data *testRequestPassphraseData) {
+	s.setPassphrase(c, data.passphrase)
+
+	requestor, err := NewSystemdAuthRequestor(data.tmpl, "")
+	c.Assert(err, IsNil)
+
+	passphrase, err := requestor.RequestPassphrase(data.volumeName, data.sourceDevicePath)
+	c.Check(err, IsNil)
+	c.Check(passphrase, Equals, data.passphrase)
+
+	c.Check(s.mockSdAskPassword.Calls(), HasLen, 1)
+	c.Check(s.mockSdAskPassword.Calls()[0], DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk",
+		"--id", filepath.Base(os.Args[0]) + ":" + data.sourceDevicePath, data.expectedMsg})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestPassphrase(c *C) {
+	s.testRequestPassphrase(c, &testRequestPassphraseData{
+		passphrase:       "password",
+		tmpl:             "Enter passphrase for {{.SourceDevicePath}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		expectedMsg:      "Enter passphrase for /dev/sda1:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestPassphraseDifferentPassphrase(c *C) {
+	s.testRequestPassphrase(c, &testRequestPassphraseData{
+		passphrase:       "1234",
+		tmpl:             "Enter passphrase for {{.SourceDevicePath}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		expectedMsg:      "Enter passphrase for /dev/sda1:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestPassphraseDifferentSourceDevice(c *C) {
+	s.testRequestPassphrase(c, &testRequestPassphraseData{
+		passphrase:       "password",
+		tmpl:             "Enter passphrase for {{.SourceDevicePath}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/nvme0n1p1",
+		expectedMsg:      "Enter passphrase for /dev/nvme0n1p1:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestPassphraseDifferentMsg(c *C) {
+	s.testRequestPassphrase(c, &testRequestPassphraseData{
+		passphrase:       "password",
+		tmpl:             "Enter passphrase for {{.VolumeName}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		expectedMsg:      "Enter passphrase for data:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestPassphraseDifferentVolumeName(c *C) {
+	s.testRequestPassphrase(c, &testRequestPassphraseData{
+		passphrase:       "password",
+		tmpl:             "Enter passphrase for {{.VolumeName}}:",
+		volumeName:       "foo",
+		sourceDevicePath: "/dev/sda1",
+		expectedMsg:      "Enter passphrase for foo:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestPassphraseInvalidResponse(c *C) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte("foo"), 0600), IsNil)
+
+	requestor, err := NewSystemdAuthRequestor("", "")
+	c.Assert(err, IsNil)
+
+	_, err = requestor.RequestPassphrase("data", "/dev/sda1")
+	c.Check(err, ErrorMatches, "systemd-ask-password output is missing terminating newline")
+}
+
+type testRequestRecoveryKeyData struct {
+	passphrase string
+
+	tmpl string
+
+	volumeName       string
+	sourceDevicePath string
+
+	expectedKey RecoveryKey
+	expectedMsg string
+}
+
+func (s *authRequestorSystemdSuite) testRequestRecoveryKey(c *C, data *testRequestRecoveryKeyData) {
+	s.setPassphrase(c, data.passphrase)
+
+	requestor, err := NewSystemdAuthRequestor("", data.tmpl)
+	c.Assert(err, IsNil)
+
+	key, err := requestor.RequestRecoveryKey(data.volumeName, data.sourceDevicePath)
+	c.Check(err, IsNil)
+	c.Check(key, Equals, data.expectedKey)
+
+	c.Check(s.mockSdAskPassword.Calls(), HasLen, 1)
+	c.Check(s.mockSdAskPassword.Calls()[0], DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk",
+		"--id", filepath.Base(os.Args[0]) + ":" + data.sourceDevicePath, data.expectedMsg})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKey(c *C) {
+	var key RecoveryKey
+	{
+		k := testutil.DecodeHexString(c, "e73232a995f8c96988fbd4b4824e34f4")
+		copy(key[:], k)
+	}
+
+	s.testRequestRecoveryKey(c, &testRequestRecoveryKeyData{
+		passphrase:       key.String(),
+		tmpl:             "Enter recovery key for {{.SourceDevicePath}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		expectedKey:      key,
+		expectedMsg:      "Enter recovery key for /dev/sda1:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyDifferentKey(c *C) {
+	var key RecoveryKey
+	{
+		k := testutil.DecodeHexString(c, "8e67b1865e3d219bab10850cbd2c4dbe")
+		copy(key[:], k)
+	}
+
+	s.testRequestRecoveryKey(c, &testRequestRecoveryKeyData{
+		passphrase:       key.String(),
+		tmpl:             "Enter recovery key for {{.SourceDevicePath}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		expectedKey:      key,
+		expectedMsg:      "Enter recovery key for /dev/sda1:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyDifferentSourceDevice(c *C) {
+	var key RecoveryKey
+	{
+		k := testutil.DecodeHexString(c, "e73232a995f8c96988fbd4b4824e34f4")
+		copy(key[:], k)
+	}
+
+	s.testRequestRecoveryKey(c, &testRequestRecoveryKeyData{
+		passphrase:       key.String(),
+		tmpl:             "Enter recovery key for {{.SourceDevicePath}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/vdb1",
+		expectedKey:      key,
+		expectedMsg:      "Enter recovery key for /dev/vdb1:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyDifferentMsg(c *C) {
+	var key RecoveryKey
+	{
+		k := testutil.DecodeHexString(c, "e73232a995f8c96988fbd4b4824e34f4")
+		copy(key[:], k)
+	}
+
+	s.testRequestRecoveryKey(c, &testRequestRecoveryKeyData{
+		passphrase:       key.String(),
+		tmpl:             "Enter recovery key for {{.VolumeName}}:",
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		expectedKey:      key,
+		expectedMsg:      "Enter recovery key for data:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyDifferentVolumeName(c *C) {
+	var key RecoveryKey
+	{
+		k := testutil.DecodeHexString(c, "e73232a995f8c96988fbd4b4824e34f4")
+		copy(key[:], k)
+	}
+
+	s.testRequestRecoveryKey(c, &testRequestRecoveryKeyData{
+		passphrase:       key.String(),
+		tmpl:             "Enter recovery key for {{.VolumeName}}:",
+		volumeName:       "bar",
+		sourceDevicePath: "/dev/sda1",
+		expectedKey:      key,
+		expectedMsg:      "Enter recovery key for bar:"})
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyInvalidResponse(c *C) {
+	c.Assert(ioutil.WriteFile(s.passwordFile, []byte("foo"), 0600), IsNil)
+
+	requestor, err := NewSystemdAuthRequestor("", "")
+	c.Assert(err, IsNil)
+
+	_, err = requestor.RequestRecoveryKey("data", "/dev/sda1")
+	c.Check(err, ErrorMatches, "systemd-ask-password output is missing terminating newline")
+}
+
+func (s *authRequestorSystemdSuite) TestRequestRecoveryKeyInvalidFormat(c *C) {
+	s.setPassphrase(c, "foo")
+
+	requestor, err := NewSystemdAuthRequestor("", "")
+	c.Assert(err, IsNil)
+
+	_, err = requestor.RequestRecoveryKey("data", "/dev/sda1")
+	c.Check(err, ErrorMatches, "cannot parse recovery key: incorrectly formatted: insufficient characters")
+}

--- a/crypt.go
+++ b/crypt.go
@@ -20,17 +20,12 @@
 package secboot
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -86,58 +81,6 @@ func ParseRecoveryKey(s string) (out RecoveryKey, err error) {
 	}
 
 	return
-}
-
-type execError struct {
-	path string
-	err  error
-}
-
-func (e *execError) Error() string {
-	return fmt.Sprintf("%s failed: %s", e.path, e.err)
-}
-
-func (e *execError) Unwrap() error {
-	return e.err
-}
-
-func wrapExecError(cmd *exec.Cmd, err error) error {
-	if err == nil {
-		return nil
-	}
-	return &execError{path: cmd.Path, err: err}
-}
-
-func askPassword(sourceDevicePath, msg string) (string, error) {
-	cmd := exec.Command(
-		"systemd-ask-password",
-		"--icon", "drive-harddisk",
-		"--id", filepath.Base(os.Args[0])+":"+sourceDevicePath,
-		msg)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stdin = os.Stdin
-	if err := cmd.Run(); err != nil {
-		return "", wrapExecError(cmd, err)
-	}
-	result, err := out.ReadString('\n')
-	if err != nil {
-		return "", xerrors.Errorf("cannot read result from systemd-ask-password: %w", err)
-	}
-	return strings.TrimRight(result, "\n"), nil
-}
-
-func getPassword(sourceDevicePath, description string, reader io.Reader) (string, error) {
-	if reader != nil {
-		scanner := bufio.NewScanner(reader)
-		switch {
-		case scanner.Scan():
-			return scanner.Text(), nil
-		case scanner.Err() != nil:
-			return "", xerrors.Errorf("cannot obtain %s from scanner: %w", description, scanner.Err())
-		}
-	}
-	return askPassword(sourceDevicePath, "Please enter the "+description+" for disk "+sourceDevicePath+":")
 }
 
 type snapModelCheckerImpl struct {
@@ -270,7 +213,7 @@ func newActivateWithKeyDataState(volumeName, sourceDevicePath string, keyringPre
 	return s
 }
 
-func activateWithRecoveryKey(volumeName, sourceDevicePath string, keyReader io.Reader, tries int, keyringPrefix string) error {
+func activateWithRecoveryKey(volumeName, sourceDevicePath string, authRequestor AuthRequestor, tries int, keyringPrefix string) error {
 	if tries == 0 {
 		return errors.New("no recovery key tries permitted")
 	}
@@ -280,17 +223,9 @@ func activateWithRecoveryKey(volumeName, sourceDevicePath string, keyReader io.R
 	for ; tries > 0; tries-- {
 		lastErr = nil
 
-		r := keyReader
-		keyReader = nil
-
-		passphrase, err := getPassword(sourceDevicePath, "recovery key", r)
+		key, err := authRequestor.RequestRecoveryKey(volumeName, sourceDevicePath)
 		if err != nil {
-			return xerrors.Errorf("cannot obtain recovery key: %w", err)
-		}
-
-		key, err := ParseRecoveryKey(passphrase)
-		if err != nil {
-			lastErr = xerrors.Errorf("cannot decode recovery key: %w", err)
+			lastErr = xerrors.Errorf("cannot obtain recovery key: %w", err)
 			continue
 		}
 
@@ -361,25 +296,31 @@ func (e *activateVolumeWithKeyDataError) Error() string {
 // successful.
 var ErrRecoveryKeyUsed = errors.New("cannot activate with platform protected keys but activation with the recovery key was successful")
 
-// ActivateVolumeWithKeyData attempts to activate the LUKS encrypted container at sourceDevicePath and create a
-// mapping with the name volumeName, using the supplied KeyData objects to recover the disk unlock key from the
-// platform's secure device. This makes use of systemd-cryptsetup.
+// ActivateVolumeWithKeyData attempts to activate the LUKS encrypted container at
+// sourceDevicePath and create a mapping with the name volumeName, using the
+// supplied KeyData objects to recover the disk unlock key from the platform's
+// secure device. This makes use of systemd-cryptsetup.
 //
-// If activation with the supplied KeyData objects fails, this function will attempt to activate it with the fallback
-// recovery key instead. The fallback recovery key will be requested using systemd-ask-password. The RecoveryKeyTries
-// field of options specifies how many attempts should be made to activate the volume with the recovery key before
-// failing. If this is set to 0, then no attempts will be made to activate the encrypted volume with the fallback
-// recovery key.
+// If activation with the supplied KeyData objects fails, this function will
+// attempt to activate it with the fallback recovery key instead. The fallback
+// recovery key is requested via the supplied authRequestor. If an AuthRequestor
+// is not supplied, an error will be returned if the fallback recovery key is
+// required. The RecoveryKeyTries field of options specifies how many attemps to
+// request and use the recovery key will be made before failing. If it is set to
+// 0, then no attempts will be made to request and use the fallback recovery key.
 //
-// If either the PassphraseTries or RecoveryKeyTries fields of options are less than zero, an error will be returned.
+// If either the PassphraseTries or RecoveryKeyTries fields of options are less
+// than zero, an error will be returned.
 //
-// If activation with one of the supplied KeyData objects succeeds, a SnapModelChecker will be returned so that the
-// caller can check whether a particular Snap device model has previously been authorized to access the data on this
-// volume. If the fallback recovery key is used for successfully for activation, no SnapModelChecker will be
-// returned and a ErrRecoveryKeyUsed error will be returned.
+// If activation with one of the supplied KeyData objects succeeds, a
+// SnapModelChecker will be returned so that the caller can check whether a
+// particular Snap device model has previously been authorized to access the data
+// on this volume. If the fallback recovery key is used for successfully for
+// activation, no SnapModelChecker will be returned and a ErrRecoveryKeyUsed error
+// will be returned.
 //
 // If activation fails, an error will be returned.
-func ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath string, keys []*KeyData, options *ActivateVolumeOptions) (SnapModelChecker, error) {
+func ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath string, keys []*KeyData, authRequestor AuthRequestor, options *ActivateVolumeOptions) (SnapModelChecker, error) {
 	if len(keys) == 0 {
 		return nil, errors.New("no keys provided")
 	}
@@ -390,12 +331,16 @@ func ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath string, keys
 		return nil, errors.New("invalid RecoveryKeyTries")
 	}
 
+	if options.RecoveryKeyTries > 0 && authRequestor == nil {
+		return nil, errors.New("nil authRequestor")
+	}
+
 	s := newActivateWithKeyDataState(volumeName, sourceDevicePath, options.KeyringPrefix, keys)
 	switch s.run() {
 	case true: // success!
 		return s.snapModelChecker(), nil
 	default: // failed - try recovery key
-		if rErr := activateWithRecoveryKey(volumeName, sourceDevicePath, nil, options.RecoveryKeyTries, options.KeyringPrefix); rErr != nil {
+		if rErr := activateWithRecoveryKey(volumeName, sourceDevicePath, authRequestor, options.RecoveryKeyTries, options.KeyringPrefix); rErr != nil {
 			// failed with recovery key - return errors
 			var kdErrs []error
 			for _, e := range s.errors() {
@@ -408,41 +353,53 @@ func ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath string, keys
 	}
 }
 
-// ActivateVolumeWithKeyData attempts to activate the LUKS encrypted container at sourceDevicePath and create a
-// mapping with the name volumeName, using the supplied KeyData to recover the disk unlock key from the platform's
-// secure device. This makes use of systemd-cryptsetup.
+// ActivateVolumeWithKeyData attempts to activate the LUKS encrypted container at
+// sourceDevicePath and create a mapping with the name volumeName, using the
+// supplied KeyData to recover the disk unlock key from the platform's secure
+// device. This makes use of systemd-cryptsetup.
 //
-// If activation with the supplied KeyData fails, this function will attempt to activate it with the fallback recovery
-// key instead. The fallback recovery key will be requested using systemd-ask-password. The RecoveryKeyTries field of
-// options specifies how many attempts should be made to activate the volume with the recovery key before failing.
-// If this is set to 0, then no attempts will be made to activate the encrypted volume with the fallback recovery key.
+// If activation with the supplied KeyData fails, this function will attempt to
+// activate it with the fallback recovery key instead. The fallback recovery key is
+// requested via the supplied authRequestor. If an AuthRequestor is not supplied,
+// an error will be returned if the fallback recovery key is required. The
+// RecoveryKeyTries field of options specifies how many attemps to request and use
+// the recovery key will be made before failing. If it is set to 0, then no attempts
+// will be made to request and use the fallback recovery key.
 //
-// If either the PassphraseTries or RecoveryKeyTries fields of options are less than zero, an error will be returned.
+// If either the PassphraseTries or RecoveryKeyTries fields of options are less than
+// zero, an error will be returned.
 //
-// If activation with the supplied KeyData succeeds, a SnapModelChecker will be returned so that the caller can check
-// whether a particular Snap device model has previously been authorized to access the data on this volume. If the
-// fallback recovery key is used for successfully for activation, no SnapModelChecker will be returned and a
-// ErrRecoveryKeyUsed error will be returned.
+// If activation with the supplied KeyData succeeds, a SnapModelChecker will be
+// returned so that the caller can check whether a particular Snap device model has
+// previously been authorized to access the data on this volume. If the fallback
+// recovery key is used for successfully for activation, no SnapModelChecker will be
+// returned and a ErrRecoveryKeyUsed error will be returned.
 //
 // If activation fails, an error will be returned.
-func ActivateVolumeWithKeyData(volumeName, sourceDevicePath string, key *KeyData, options *ActivateVolumeOptions) (SnapModelChecker, error) {
-	return ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath, []*KeyData{key}, options)
+func ActivateVolumeWithKeyData(volumeName, sourceDevicePath string, key *KeyData, authRequestor AuthRequestor, options *ActivateVolumeOptions) (SnapModelChecker, error) {
+	return ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath, []*KeyData{key}, authRequestor, options)
 }
 
-// ActivateVolumeWithRecoveryKey attempts to activate the LUKS encrypted volume at sourceDevicePath and create a mapping with the
-// name volumeName, using the fallback recovery key. This makes use of systemd-cryptsetup.
+// ActivateVolumeWithRecoveryKey attempts to activate the LUKS encrypted volume at
+// sourceDevicePath and create a mapping with the name volumeName, using the fallback
+// recovery key. This makes use of systemd-cryptsetup.
 //
-// This function will use systemd-ask-password to request the recovery key. If keyReader is not nil, then an attempt to read the key
-// from this will be made instead by reading all characters until the first newline. The RecoveryKeyTries field of options defines how many
-// attempts should be made to activate the volume with the recovery key before failing.
+// The recovery key is requested via the supplied AuthRequestor. If an AuthRequestor
+// is not supplied, an error will be returned. The RecoveryKeyTries field of options
+// specifies how many attempts to request and use the recovery key will be made before
+// failing.
 //
-// If the RecoveryKeyTries field of options is less than zero, an error will be returned.
-func ActivateVolumeWithRecoveryKey(volumeName, sourceDevicePath string, keyReader io.Reader, options *ActivateVolumeOptions) error {
+// If the RecoveryKeyTries field of options is less than zero, an error will be
+// returned.
+func ActivateVolumeWithRecoveryKey(volumeName, sourceDevicePath string, authRequestor AuthRequestor, options *ActivateVolumeOptions) error {
+	if authRequestor == nil {
+		return errors.New("nil authRequestor")
+	}
 	if options.RecoveryKeyTries < 0 {
 		return errors.New("invalid RecoveryKeyTries")
 	}
 
-	return activateWithRecoveryKey(volumeName, sourceDevicePath, keyReader, options.RecoveryKeyTries, options.KeyringPrefix)
+	return activateWithRecoveryKey(volumeName, sourceDevicePath, authRequestor, options.RecoveryKeyTries, options.KeyringPrefix)
 }
 
 // ActivateVolumeWithKey attempts to activate the LUKS encrypted volume at

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -28,7 +28,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	snapd_testutil "github.com/snapcore/snapd/testutil"
@@ -57,12 +56,47 @@ func (ctb *cryptTestBase) newRecoveryKey() RecoveryKey {
 	return key
 }
 
+type mockAuthRequestor struct {
+	recoveryKeyResponses []interface{}
+	recoveryKeyRequests  []struct {
+		volumeName       string
+		sourceDevicePath string
+	}
+}
+
+func (r *mockAuthRequestor) RequestPassphrase(volumeName, sourceDevicePath string) (string, error) {
+	return "", errors.New("not supported")
+}
+
+func (r *mockAuthRequestor) RequestRecoveryKey(volumeName, sourceDevicePath string) (RecoveryKey, error) {
+	r.recoveryKeyRequests = append(r.recoveryKeyRequests, struct {
+		volumeName       string
+		sourceDevicePath string
+	}{
+		volumeName:       volumeName,
+		sourceDevicePath: sourceDevicePath,
+	})
+
+	if len(r.recoveryKeyResponses) == 0 {
+		return RecoveryKey{}, errors.New("empty response")
+	}
+	response := r.recoveryKeyResponses[0]
+	r.recoveryKeyResponses = r.recoveryKeyResponses[1:]
+
+	switch rsp := response.(type) {
+	case RecoveryKey:
+		return rsp, nil
+	case error:
+		return RecoveryKey{}, rsp
+	default:
+		panic("invalid type")
+	}
+}
+
 type cryptSuite struct {
 	cryptTestBase
 	keyDataTestBase
 	testutil.KeyringTestBase
-
-	passwordFile string // a newline delimited list of passwords for the mock systemd-ask-password to return
 
 	mockKeyslotsDir   string
 	mockKeyslotsCount int
@@ -77,8 +111,7 @@ type cryptSuite struct {
 	cryptsetupKey                string // The file in which the mock cryptsetup dumps the provided key
 	cryptsetupNewkey             string // The file in which the mock cryptsetup dumps the provided new key
 
-	mockCryptsetup    *snapd_testutil.MockCmd
-	mockSdAskPassword *snapd_testutil.MockCmd
+	mockCryptsetup *snapd_testutil.MockCmd
 }
 
 var _ = Suite(&cryptSuite{})
@@ -95,7 +128,6 @@ func (s *cryptSuite) SetUpTest(c *C) {
 	s.AddCleanup(pathstest.MockRunDir(c.MkDir()))
 
 	dir := c.MkDir()
-	s.passwordFile = filepath.Join(dir, "password") // passwords to be returned by the mock sd-ask-password
 
 	s.mockKeyslotsCount = 0
 	s.mockKeyslotsDir = c.MkDir()
@@ -198,28 +230,11 @@ dump_key "$new_keyfile" "%[2]s.$invocation"
 
 	s.mockCryptsetup = snapd_testutil.MockCommand(c, "cryptsetup", fmt.Sprintf(cryptsetupBottom, s.cryptsetupKey, s.cryptsetupNewkey, s.cryptsetupInvocationCountDir))
 	s.AddCleanup(s.mockCryptsetup.Restore)
-
-	sdAskPasswordBottom := `
-head -1 %[1]s
-sed -i -e '1,1d' %[1]s
-`
-	s.mockSdAskPassword = snapd_testutil.MockCommand(c, "systemd-ask-password", fmt.Sprintf(sdAskPasswordBottom, s.passwordFile))
-	s.AddCleanup(s.mockSdAskPassword.Restore)
 }
 
 func (s *cryptSuite) addMockKeyslot(c *C, key []byte) {
 	c.Assert(ioutil.WriteFile(filepath.Join(s.mockKeyslotsDir, fmt.Sprintf("%d", s.mockKeyslotsCount)), key, 0644), IsNil)
 	s.mockKeyslotsCount++
-}
-
-func (s *cryptSuite) addTryPassphrases(c *C, passphrases []string) {
-	for _, passphrase := range passphrases {
-		f, err := os.OpenFile(s.passwordFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
-		c.Assert(err, IsNil)
-		_, err = f.WriteString(passphrase + "\n")
-		c.Check(err, IsNil)
-		f.Close()
-	}
 }
 
 func (s *cryptSuite) checkRecoveryKeyInKeyring(c *C, prefix, path string, expected RecoveryKey) {
@@ -279,26 +294,27 @@ func (s *cryptSuite) newNamedKeyData(c *C, name string) (*KeyData, DiskUnlockKey
 }
 
 type testActivateVolumeWithRecoveryKeyData struct {
-	recoveryKey         RecoveryKey
-	volumeName          string
-	sourceDevicePath    string
-	tries               int
-	keyringPrefix       string
-	recoveryPassphrases []string
-	activateTries       int
+	recoveryKey      RecoveryKey
+	volumeName       string
+	sourceDevicePath string
+	tries            int
+	keyringPrefix    string
+	authResponses    []interface{}
+	activateTries    int
 }
 
 func (s *cryptSuite) testActivateVolumeWithRecoveryKey(c *C, data *testActivateVolumeWithRecoveryKeyData) {
 	s.addMockKeyslot(c, data.recoveryKey[:])
-	s.addTryPassphrases(c, data.recoveryPassphrases)
 
+	authRequestor := &mockAuthRequestor{recoveryKeyResponses: data.authResponses}
 	options := ActivateVolumeOptions{RecoveryKeyTries: data.tries, KeyringPrefix: data.keyringPrefix}
-	c.Assert(ActivateVolumeWithRecoveryKey(data.volumeName, data.sourceDevicePath, nil, &options), IsNil)
 
-	c.Check(len(s.mockSdAskPassword.Calls()), Equals, len(data.recoveryPassphrases))
-	for _, call := range s.mockSdAskPassword.Calls() {
-		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
-			filepath.Base(os.Args[0]) + ":" + data.sourceDevicePath, "Please enter the recovery key for disk " + data.sourceDevicePath + ":"})
+	c.Assert(ActivateVolumeWithRecoveryKey(data.volumeName, data.sourceDevicePath, authRequestor, &options), IsNil)
+
+	c.Check(authRequestor.recoveryKeyRequests, HasLen, len(data.authResponses))
+	for _, rsp := range authRequestor.recoveryKeyRequests {
+		c.Check(rsp.volumeName, Equals, data.volumeName)
+		c.Check(rsp.sourceDevicePath, Equals, data.sourceDevicePath)
 	}
 
 	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
@@ -312,32 +328,19 @@ func (s *cryptSuite) testActivateVolumeWithRecoveryKey(c *C, data *testActivateV
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKey1(c *C) {
-	// Test with a recovery key which is entered with a hyphen between each group of 5 digits.
+	// Test with the correct recovery key.
 	recoveryKey := s.newRecoveryKey()
 	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
-		recoveryKey:         recoveryKey,
-		volumeName:          "data",
-		sourceDevicePath:    "/dev/sda1",
-		tries:               1,
-		recoveryPassphrases: []string{recoveryKey.String()},
-		activateTries:       1,
+		recoveryKey:      recoveryKey,
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		tries:            1,
+		authResponses:    []interface{}{recoveryKey},
+		activateTries:    1,
 	})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKey2(c *C) {
-	// Test with a recovery key which is entered without a hyphen between each group of 5 digits.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
-		recoveryKey:         recoveryKey,
-		volumeName:          "data",
-		sourceDevicePath:    "/dev/sda1",
-		tries:               1,
-		recoveryPassphrases: []string{strings.Replace(recoveryKey.String(), "-", "", -1)},
-		activateTries:       1,
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKey3(c *C) {
 	// Test that activation succeeds when the correct recovery key is provided on the second attempt.
 	recoveryKey := s.newRecoveryKey()
 	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
@@ -345,162 +348,49 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKey3(c *C) {
 		volumeName:       "data",
 		sourceDevicePath: "/dev/sda1",
 		tries:            2,
-		recoveryPassphrases: []string{
-			"00000-00000-00000-00000-00000-00000-00000-00000",
-			recoveryKey.String(),
-		},
-		activateTries: 2,
+		authResponses:    []interface{}{RecoveryKey{}, recoveryKey},
+		activateTries:    2,
 	})
 }
 
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKey4(c *C) {
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey3(c *C) {
 	// Test that activation succeeds when the correct recovery key is provided on the second attempt, and the first
-	// attempt is badly formatted.
+	// attempt is an error.
 	recoveryKey := s.newRecoveryKey()
 	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
 		recoveryKey:      recoveryKey,
 		volumeName:       "data",
 		sourceDevicePath: "/dev/sda1",
 		tries:            2,
-		recoveryPassphrases: []string{
-			"1234",
-			recoveryKey.String(),
-		},
-		activateTries: 1,
+		authResponses:    []interface{}{errors.New(""), recoveryKey},
+		activateTries:    1,
+	})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithRecoveryKey4(c *C) {
+	// Test with a different volume name / device path.
+	recoveryKey := s.newRecoveryKey()
+	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
+		recoveryKey:      recoveryKey,
+		volumeName:       "foo",
+		sourceDevicePath: "/dev/vdb2",
+		tries:            1,
+		authResponses:    []interface{}{recoveryKey},
+		activateTries:    1,
 	})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKey5(c *C) {
-	// Test with a different volume name / device path.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
-		recoveryKey:         recoveryKey,
-		volumeName:          "foo",
-		sourceDevicePath:    "/dev/vdb2",
-		tries:               1,
-		recoveryPassphrases: []string{recoveryKey.String()},
-		activateTries:       1,
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKey6(c *C) {
 	// Test with a different keyring prefix
 	recoveryKey := s.newRecoveryKey()
 	s.testActivateVolumeWithRecoveryKey(c, &testActivateVolumeWithRecoveryKeyData{
-		recoveryKey:         recoveryKey,
-		volumeName:          "data",
-		sourceDevicePath:    "/dev/sda1",
-		tries:               1,
-		keyringPrefix:       "test",
-		recoveryPassphrases: []string{recoveryKey.String()},
-		activateTries:       1,
-	})
-}
-
-type testActivateVolumeWithRecoveryKeyUsingKeyReaderData struct {
-	recoveryKey             RecoveryKey
-	tries                   int
-	recoveryKeyFileContents string
-	recoveryPassphrases     []string
-	activateTries           int
-}
-
-func (s *cryptSuite) testActivateVolumeWithRecoveryKeyUsingKeyReader(c *C, data *testActivateVolumeWithRecoveryKeyUsingKeyReaderData) {
-	s.addMockKeyslot(c, data.recoveryKey[:])
-	s.addTryPassphrases(c, data.recoveryPassphrases)
-
-	dir := c.MkDir()
-	c.Assert(ioutil.WriteFile(filepath.Join(dir, "keyfile"), []byte(data.recoveryKeyFileContents), 0644), IsNil)
-
-	r, err := os.Open(filepath.Join(dir, "keyfile"))
-	c.Assert(err, IsNil)
-	defer r.Close()
-
-	options := ActivateVolumeOptions{RecoveryKeyTries: data.tries}
-	c.Assert(ActivateVolumeWithRecoveryKey("data", "/dev/sda1", r, &options), IsNil)
-
-	c.Check(len(s.mockSdAskPassword.Calls()), Equals, len(data.recoveryPassphrases))
-	for _, call := range s.mockSdAskPassword.Calls() {
-		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
-			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the recovery key for disk /dev/sda1:"})
-	}
-
-	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
-	for _, call := range s.mockLUKS2ActivateCalls {
-		c.Check(call.volumeName, Equals, "data")
-		c.Check(call.sourceDevicePath, Equals, "/dev/sda1")
-	}
-
-	// This should be done last because it may fail in some circumstances.
-	s.checkRecoveryKeyInKeyring(c, "", "/dev/sda1", data.recoveryKey)
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader1(c *C) {
-	// Test with the correct recovery key supplied via a io.Reader, with a hyphen separating each group of 5 digits.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
-		recoveryKey:             recoveryKey,
-		tries:                   1,
-		recoveryKeyFileContents: recoveryKey.String() + "\n",
-		activateTries:           1,
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader2(c *C) {
-	// Test with the correct recovery key supplied via a io.Reader, without a hyphen separating each group of 5 digits.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
-		recoveryKey:             recoveryKey,
-		tries:                   1,
-		recoveryKeyFileContents: strings.Replace(recoveryKey.String(), "-", "", -1) + "\n",
-		activateTries:           1,
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader3(c *C) {
-	// Test with the correct recovery key supplied via a io.Reader when the key doesn't end in a newline.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
-		recoveryKey:             recoveryKey,
-		tries:                   1,
-		recoveryKeyFileContents: recoveryKey.String(),
-		activateTries:           1,
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader4(c *C) {
-	// Test that falling back to requesting a recovery key works if the one provided by the io.Reader is incorrect.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
-		recoveryKey:             recoveryKey,
-		tries:                   2,
-		recoveryKeyFileContents: "00000-00000-00000-00000-00000-00000-00000-00000\n",
-		recoveryPassphrases:     []string{recoveryKey.String()},
-		activateTries:           2,
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader5(c *C) {
-	// Test that falling back to requesting a recovery key works if the one provided by the io.Reader is badly formatted.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
-		recoveryKey:             recoveryKey,
-		tries:                   2,
-		recoveryKeyFileContents: "5678\n",
-		recoveryPassphrases:     []string{recoveryKey.String()},
-		activateTries:           1,
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyUsingKeyReader6(c *C) {
-	// Test that falling back to requesting a recovery key works if the provided io.Reader is backed by an empty buffer,
-	// without using up a try.
-	recoveryKey := s.newRecoveryKey()
-	s.testActivateVolumeWithRecoveryKeyUsingKeyReader(c, &testActivateVolumeWithRecoveryKeyUsingKeyReaderData{
-		recoveryKey:         recoveryKey,
-		tries:               1,
-		recoveryPassphrases: []string{recoveryKey.String()},
-		activateTries:       1,
+		recoveryKey:      recoveryKey,
+		volumeName:       "data",
+		sourceDevicePath: "/dev/sda1",
+		tries:            1,
+		keyringPrefix:    "test",
+		authResponses:    []interface{}{recoveryKey},
+		activateTries:    1,
 	})
 }
 
@@ -612,26 +502,33 @@ func (s *cryptSuite) TestRecoveryKeyStringify2(c *C) {
 }
 
 type testActivateVolumeWithRecoveryKeyErrorHandlingData struct {
-	tries               int
-	recoveryPassphrases []string
-	activateTries       int
-	errChecker          Checker
-	errCheckerArgs      []interface{}
+	tries          int
+	authRequestor  *mockAuthRequestor
+	activateTries  int
+	errChecker     Checker
+	errCheckerArgs []interface{}
 }
 
 func (s *cryptSuite) testActivateVolumeWithRecoveryKeyErrorHandling(c *C, data *testActivateVolumeWithRecoveryKeyErrorHandlingData) {
 	recoveryKey := s.newRecoveryKey()
 	s.addMockKeyslot(c, recoveryKey[:])
 
-	s.addTryPassphrases(c, data.recoveryPassphrases)
+	var authRequestor AuthRequestor
+	var numResponses int
+	if data.authRequestor != nil {
+		authRequestor = data.authRequestor
+		numResponses = len(data.authRequestor.recoveryKeyResponses)
+	}
 
 	options := ActivateVolumeOptions{RecoveryKeyTries: data.tries}
-	c.Check(ActivateVolumeWithRecoveryKey("data", "/dev/sda1", nil, &options), data.errChecker, data.errCheckerArgs...)
+	c.Check(ActivateVolumeWithRecoveryKey("data", "/dev/sda1", authRequestor, &options), data.errChecker, data.errCheckerArgs...)
 
-	c.Check(len(s.mockSdAskPassword.Calls()), Equals, len(data.recoveryPassphrases))
-	for _, call := range s.mockSdAskPassword.Calls() {
-		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
-			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the recovery key for disk /dev/sda1:"})
+	if data.authRequestor != nil {
+		c.Check(data.authRequestor.recoveryKeyRequests, HasLen, numResponses)
+		for _, rsp := range data.authRequestor.recoveryKeyRequests {
+			c.Check(rsp.volumeName, Equals, "data")
+			c.Check(rsp.sourceDevicePath, Equals, "/dev/sda1")
+		}
 	}
 
 	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
@@ -645,6 +542,7 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling1(c *C) {
 	// Test with an invalid RecoveryKeyTries value.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
 		tries:          -1,
+		authRequestor:  &mockAuthRequestor{},
 		errChecker:     ErrorMatches,
 		errCheckerArgs: []interface{}{"invalid RecoveryKeyTries"},
 	})
@@ -654,60 +552,50 @@ func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling2(c *C) {
 	// Test with Tries set to zero.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
 		tries:          0,
+		authRequestor:  &mockAuthRequestor{},
 		errChecker:     ErrorMatches,
 		errCheckerArgs: []interface{}{"no recovery key tries permitted"},
 	})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling3(c *C) {
-	// Test with a badly formatted recovery key.
+	// Test with no auth requestor
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
-		tries:               1,
-		recoveryPassphrases: []string{"00000-1234"},
-		errChecker:          ErrorMatches,
-		errCheckerArgs:      []interface{}{"cannot decode recovery key: incorrectly formatted: insufficient characters"},
+		tries:          1,
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"nil authRequestor"},
 	})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling4(c *C) {
-	// Test with a badly formatted recovery key.
+	// Test with the auth requestor returning an error.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
-		tries:               1,
-		recoveryPassphrases: []string{"00000-123bc"},
-		errChecker:          ErrorMatches,
-		errCheckerArgs:      []interface{}{"cannot decode recovery key: incorrectly formatted: strconv.ParseUint: parsing \"123bc\": invalid syntax"},
+		tries:          1,
+		authRequestor:  &mockAuthRequestor{recoveryKeyResponses: []interface{}{errors.New("some error")}},
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot obtain recovery key: some error"},
 	})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling5(c *C) {
 	// Test with the wrong recovery key.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
-		tries:               1,
-		recoveryPassphrases: []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
-		activateTries:       1,
-		errChecker:          ErrorMatches,
-		errCheckerArgs:      []interface{}{"cannot activate volume: systemd-cryptsetup failed with: exit status 1"},
+		tries:          1,
+		authRequestor:  &mockAuthRequestor{recoveryKeyResponses: []interface{}{RecoveryKey{}}},
+		activateTries:  1,
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot activate volume: systemd-cryptsetup failed with: exit status 1"},
 	})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling6(c *C) {
 	// Test that the last error is returned when there are consecutive failures for different reasons.
 	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
-		tries:               2,
-		recoveryPassphrases: []string{"00000-00000-00000-00000-00000-00000-00000-00000", "1234"},
-		activateTries:       1,
-		errChecker:          ErrorMatches,
-		errCheckerArgs:      []interface{}{"cannot decode recovery key: incorrectly formatted: insufficient characters"},
-	})
-}
-
-func (s *cryptSuite) TestActivateVolumeWithRecoveryKeyErrorHandling7(c *C) {
-	// Test with a badly formatted recovery key.
-	s.testActivateVolumeWithRecoveryKeyErrorHandling(c, &testActivateVolumeWithRecoveryKeyErrorHandlingData{
-		tries:               1,
-		recoveryPassphrases: []string{"00000-00000-00000-00000-00000-00000-00000-00000-00000"},
-		errChecker:          ErrorMatches,
-		errCheckerArgs:      []interface{}{"cannot decode recovery key: incorrectly formatted: too many characters"},
+		tries:          2,
+		authRequestor:  &mockAuthRequestor{recoveryKeyResponses: []interface{}{errors.New("some error"), errors.New("another error")}},
+		activateTries:  0,
+		errChecker:     ErrorMatches,
+		errCheckerArgs: []interface{}{"cannot obtain recovery key: another error"},
 	})
 }
 
@@ -727,14 +615,12 @@ func (s *cryptSuite) testActivateVolumeWithKeyData(c *C, data *testActivateVolum
 	c.Check(keyData.SetAuthorizedSnapModels(auxKey, data.authorizedModels...), IsNil)
 
 	options := &ActivateVolumeOptions{KeyringPrefix: data.keyringPrefix}
-	modelChecker, err := ActivateVolumeWithKeyData(data.volumeName, data.sourceDevicePath, keyData, options)
+	modelChecker, err := ActivateVolumeWithKeyData(data.volumeName, data.sourceDevicePath, keyData, nil, options)
 	c.Assert(err, IsNil)
 
 	authorized, err := modelChecker.IsModelAuthorized(data.model)
 	c.Check(err, IsNil)
 	c.Check(authorized, Equals, data.authorized)
-
-	c.Check(s.mockSdAskPassword.Calls(), HasLen, 0)
 
 	c.Assert(s.mockLUKS2ActivateCalls, HasLen, 1)
 	c.Check(s.mockLUKS2ActivateCalls[0].volumeName, Equals, data.volumeName)
@@ -836,7 +722,7 @@ type testActivateVolumeWithKeyDataErrorHandlingData struct {
 	primaryKey  DiskUnlockKey
 	recoveryKey RecoveryKey
 
-	passphrases []string
+	authRequestor *mockAuthRequestor
 
 	recoveryKeyTries int
 	keyringPrefix    string
@@ -853,12 +739,17 @@ func (s *cryptSuite) testActivateVolumeWithKeyDataErrorHandling(c *C, data *test
 	s.addMockKeyslot(c, data.primaryKey)
 	s.addMockKeyslot(c, data.recoveryKey[:])
 
-	s.addTryPassphrases(c, data.passphrases)
+	var authRequestor AuthRequestor
+	var numResponses int
+	if data.authRequestor != nil {
+		authRequestor = data.authRequestor
+		numResponses = len(data.authRequestor.recoveryKeyResponses)
+	}
 
 	options := &ActivateVolumeOptions{
 		RecoveryKeyTries: data.recoveryKeyTries,
 		KeyringPrefix:    data.keyringPrefix}
-	modelChecker, err := ActivateVolumeWithKeyData("data", "/dev/sda1", data.keyData, options)
+	modelChecker, err := ActivateVolumeWithKeyData("data", "/dev/sda1", data.keyData, authRequestor, options)
 	c.Check(modelChecker, IsNil)
 	if data.errChecker != nil {
 		c.Check(err, data.errChecker, data.errCheckerArgs...)
@@ -866,10 +757,12 @@ func (s *cryptSuite) testActivateVolumeWithKeyDataErrorHandling(c *C, data *test
 		c.Check(err, Equals, ErrRecoveryKeyUsed)
 	}
 
-	c.Check(s.mockSdAskPassword.Calls(), HasLen, len(data.passphrases))
-	for _, call := range s.mockSdAskPassword.Calls() {
-		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
-			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the recovery key for disk /dev/sda1:"})
+	if data.authRequestor != nil {
+		c.Check(data.authRequestor.recoveryKeyRequests, HasLen, numResponses)
+		for _, rsp := range data.authRequestor.recoveryKeyRequests {
+			c.Check(rsp.volumeName, Equals, "data")
+			c.Check(rsp.sourceDevicePath, Equals, "/dev/sda1")
+		}
 	}
 
 	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
@@ -907,7 +800,7 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling2(c *C) {
 	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
 		primaryKey:       key,
 		recoveryKey:      recoveryKey,
-		passphrases:      []string{recoveryKey.String()},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{recoveryKey}},
 		recoveryKeyTries: 1,
 		keyData:          keyData,
 		activateTries:    1})
@@ -923,7 +816,7 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling3(c *C) {
 	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
 		primaryKey:       key,
 		recoveryKey:      recoveryKey,
-		passphrases:      []string{recoveryKey.String()},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{recoveryKey}},
 		recoveryKeyTries: 1,
 		keyData:          keyData,
 		activateTries:    1})
@@ -936,7 +829,7 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling4(c *C) {
 
 	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
 		recoveryKey:      recoveryKey,
-		passphrases:      []string{recoveryKey.String()},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{recoveryKey}},
 		recoveryKeyTries: 1,
 		keyData:          keyData,
 		activateTries:    2})
@@ -972,7 +865,7 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling6(c *C) {
 	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
 		primaryKey:       key,
 		recoveryKey:      recoveryKey,
-		passphrases:      []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{RecoveryKey{}}},
 		recoveryKeyTries: 1,
 		keyData:          keyData,
 		errChecker:       ErrorMatches,
@@ -992,11 +885,9 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling7(c *C) {
 	s.handler.state = mockPlatformDeviceStateUnavailable
 
 	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
-		primaryKey:  key,
-		recoveryKey: recoveryKey,
-		passphrases: []string{
-			"00000-00000-00000-00000-00000-00000-00000-00000",
-			recoveryKey.String()},
+		primaryKey:       key,
+		recoveryKey:      recoveryKey,
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{RecoveryKey{}, recoveryKey}},
 		recoveryKeyTries: 2,
 		keyData:          keyData,
 		activateTries:    2})
@@ -1010,14 +901,23 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling8(c *C) {
 	s.handler.state = mockPlatformDeviceStateUnavailable
 
 	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
-		primaryKey:  key,
-		recoveryKey: recoveryKey,
-		passphrases: []string{
-			"1234",
-			recoveryKey.String()},
+		primaryKey:       key,
+		recoveryKey:      recoveryKey,
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{errors.New("some error"), recoveryKey}},
 		recoveryKeyTries: 2,
 		keyData:          keyData,
 		activateTries:    1})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling9(c *C) {
+	// Test that we get an error if no AuthRequestor is supplied.
+	keyData, _, _ := s.newNamedKeyData(c, "")
+
+	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
+		recoveryKeyTries: 1,
+		keyData:          keyData,
+		errChecker:       ErrorMatches,
+		errCheckerArgs:   []interface{}{"nil authRequestor"}})
 }
 
 type testActivateVolumeWithMultipleKeyDataData struct {
@@ -1043,14 +943,12 @@ func (s *cryptSuite) testActivateVolumeWithMultipleKeyData(c *C, data *testActiv
 	}
 
 	options := &ActivateVolumeOptions{KeyringPrefix: data.keyringPrefix}
-	modelChecker, err := ActivateVolumeWithMultipleKeyData(data.volumeName, data.sourceDevicePath, data.keyData, options)
+	modelChecker, err := ActivateVolumeWithMultipleKeyData(data.volumeName, data.sourceDevicePath, data.keyData, nil, options)
 	c.Assert(err, IsNil)
 
 	authorized, err := modelChecker.IsModelAuthorized(data.model)
 	c.Check(err, IsNil)
 	c.Check(authorized, Equals, data.authorized)
-
-	c.Check(s.mockSdAskPassword.Calls(), HasLen, 0)
 
 	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
 	for _, call := range s.mockLUKS2ActivateCalls {
@@ -1144,7 +1042,7 @@ type testActivateVolumeWithMultipleKeyDataErrorHandlingData struct {
 	recoveryKey RecoveryKey
 	keyData     []*KeyData
 
-	passphrases []string
+	authRequestor *mockAuthRequestor
 
 	recoveryKeyTries int
 	keyringPrefix    string
@@ -1161,12 +1059,17 @@ func (s *cryptSuite) testActivateVolumeWithMultipleKeyDataErrorHandling(c *C, da
 	}
 	s.addMockKeyslot(c, data.recoveryKey[:])
 
-	s.addTryPassphrases(c, data.passphrases)
+	var authRequestor AuthRequestor
+	var numResponses int
+	if data.authRequestor != nil {
+		authRequestor = data.authRequestor
+		numResponses = len(data.authRequestor.recoveryKeyResponses)
+	}
 
 	options := &ActivateVolumeOptions{
 		RecoveryKeyTries: data.recoveryKeyTries,
 		KeyringPrefix:    data.keyringPrefix}
-	modelChecker, err := ActivateVolumeWithMultipleKeyData("data", "/dev/sda1", data.keyData, options)
+	modelChecker, err := ActivateVolumeWithMultipleKeyData("data", "/dev/sda1", data.keyData, authRequestor, options)
 	c.Check(modelChecker, IsNil)
 	if data.errChecker != nil {
 		c.Check(err, data.errChecker, data.errCheckerArgs...)
@@ -1174,10 +1077,12 @@ func (s *cryptSuite) testActivateVolumeWithMultipleKeyDataErrorHandling(c *C, da
 		c.Check(err, Equals, ErrRecoveryKeyUsed)
 	}
 
-	c.Check(s.mockSdAskPassword.Calls(), HasLen, len(data.passphrases))
-	for _, call := range s.mockSdAskPassword.Calls() {
-		c.Check(call, DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk", "--id",
-			filepath.Base(os.Args[0]) + ":/dev/sda1", "Please enter the recovery key for disk /dev/sda1:"})
+	if data.authRequestor != nil {
+		c.Check(data.authRequestor.recoveryKeyRequests, HasLen, numResponses)
+		for _, rsp := range data.authRequestor.recoveryKeyRequests {
+			c.Check(rsp.volumeName, Equals, "data")
+			c.Check(rsp.sourceDevicePath, Equals, "/dev/sda1")
+		}
 	}
 
 	c.Assert(s.mockLUKS2ActivateCalls, HasLen, data.activateTries)
@@ -1216,7 +1121,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling2(c *C) {
 		keys:             keys,
 		recoveryKey:      recoveryKey,
 		keyData:          keyData,
-		passphrases:      []string{recoveryKey.String()},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{recoveryKey}},
 		recoveryKeyTries: 1,
 		activateTries:    1})
 }
@@ -1232,7 +1137,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling3(c *C) {
 		keys:             keys,
 		recoveryKey:      recoveryKey,
 		keyData:          keyData,
-		passphrases:      []string{recoveryKey.String()},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{recoveryKey}},
 		recoveryKeyTries: 1,
 		activateTries:    1})
 }
@@ -1245,7 +1150,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling4(c *C) {
 	s.testActivateVolumeWithMultipleKeyDataErrorHandling(c, &testActivateVolumeWithMultipleKeyDataErrorHandlingData{
 		recoveryKey:      recoveryKey,
 		keyData:          keyData,
-		passphrases:      []string{recoveryKey.String()},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{recoveryKey}},
 		recoveryKeyTries: 1,
 		activateTries:    3})
 }
@@ -1283,7 +1188,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling6(c *C) {
 		keys:             keys,
 		recoveryKey:      recoveryKey,
 		keyData:          keyData,
-		passphrases:      []string{"00000-00000-00000-00000-00000-00000-00000-00000"},
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{RecoveryKey{}}},
 		recoveryKeyTries: 1,
 		errChecker:       ErrorMatches,
 		errCheckerArgs: []interface{}{"cannot activate with platform protected keys:\n" +
@@ -1304,12 +1209,10 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling7(c *C) {
 	s.handler.state = mockPlatformDeviceStateUnavailable
 
 	s.testActivateVolumeWithMultipleKeyDataErrorHandling(c, &testActivateVolumeWithMultipleKeyDataErrorHandlingData{
-		keys:        keys,
-		recoveryKey: recoveryKey,
-		keyData:     keyData,
-		passphrases: []string{
-			"00000-00000-00000-00000-00000-00000-00000-00000",
-			recoveryKey.String()},
+		keys:             keys,
+		recoveryKey:      recoveryKey,
+		keyData:          keyData,
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{RecoveryKey{}, recoveryKey}},
 		recoveryKeyTries: 2,
 		activateTries:    2})
 }
@@ -1322,14 +1225,23 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling8(c *C) {
 	s.handler.state = mockPlatformDeviceStateUnavailable
 
 	s.testActivateVolumeWithMultipleKeyDataErrorHandling(c, &testActivateVolumeWithMultipleKeyDataErrorHandlingData{
-		keys:        keys,
-		recoveryKey: recoveryKey,
-		keyData:     keyData,
-		passphrases: []string{
-			"1234",
-			recoveryKey.String()},
+		keys:             keys,
+		recoveryKey:      recoveryKey,
+		keyData:          keyData,
+		authRequestor:    &mockAuthRequestor{recoveryKeyResponses: []interface{}{errors.New("some error"), recoveryKey}},
 		recoveryKeyTries: 2,
 		activateTries:    1})
+}
+
+func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling9(c *C) {
+	// Test that we get an error if no AuthRequestor is supplied.
+	keyData, _, _ := s.newMultipleNamedKeyData(c, "", "")
+
+	s.testActivateVolumeWithMultipleKeyDataErrorHandling(c, &testActivateVolumeWithMultipleKeyDataErrorHandlingData{
+		keyData:          keyData,
+		recoveryKeyTries: 1,
+		errChecker:       ErrorMatches,
+		errCheckerArgs:   []interface{}{"nil authRequestor"}})
 }
 
 type testActivateVolumeWithKeyData struct {
@@ -1357,13 +1269,10 @@ func (s *cryptSuite) testActivateVolumeWithKey(c *C, data *testActivateVolumeWit
 	}
 
 	if data.cmdCalled {
-		c.Check(len(s.mockSdAskPassword.Calls()), Equals, 0)
-
 		c.Assert(s.mockLUKS2ActivateCalls, HasLen, 1)
 		c.Check(s.mockLUKS2ActivateCalls[0].volumeName, Equals, "luks-volume")
 		c.Check(s.mockLUKS2ActivateCalls[0].sourceDevicePath, Equals, "/dev/sda1")
 	} else {
-		c.Check(len(s.mockSdAskPassword.Calls()), Equals, 0)
 		c.Check(s.mockLUKS2ActivateCalls, HasLen, 0)
 	}
 }


### PR DESCRIPTION
This adds an AuthRequestor interface that is used by the Activate*
APIs to request a credential (passphrase or recovery key) via some
agent.

It also adds an implementation of AuthRequestor that uses
systemd-ask-password. The new API provides a simple template based
way to define the message that is displayed.