### PR TITLE
luks2: add DetectCryptsetupFeatures

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -40,6 +40,11 @@ import (
 )
 
 var (
+	// ErrMissingCryptsetupFeature is returned from some functions that make
+	// use of the system's cryptsetup binary, if that binary is missing some
+	// required features.
+	ErrMissingCryptsetupFeature = luks2.ErrMissingCryptsetupFeature
+
 	luks2Activate   = luks2.Activate
 	luks2Deactivate = luks2.Deactivate
 )

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -70,7 +70,8 @@ const (
 	FeatureTokenImport
 
 	// FeatureTokenReplace indicates that tokens can be atomically replaced with
-	// ImportToken (yet to be implemented).
+	// ImportToken (yet to be implemented). This was introduced to cryptsetup by:
+	// https://gitlab.com/cryptsetup/cryptsetup/-/commit/98cd52c8d7bddf5b4c1ff775158a48bbb522acb2
 	FeatureTokenReplace
 )
 

--- a/internal/luks2/internal/luks2.go
+++ b/internal/luks2/internal/luks2.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import "sync"
+
+var FeaturesOnce sync.Once

--- a/internal/luks2/luks2test/luks2test.go
+++ b/internal/luks2/luks2test/luks2test.go
@@ -25,10 +25,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 
 	"github.com/snapcore/snapd/testutil"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot/internal/luks2/internal"
 )
 
 func WrapCryptsetup(c *C) (restore func()) {
@@ -60,4 +63,8 @@ func CheckLUKS2Passphrase(c *C, devicePath string, key []byte) {
 	cmd := exec.Command("cryptsetup", "open", "--test-passphrase", "--key-file", "-", devicePath)
 	cmd.Stdin = bytes.NewReader(key)
 	c.Check(cmd.Run(), IsNil)
+}
+
+func ResetCryptsetupFeatures() {
+	internal.FeaturesOnce = sync.Once{}
 }


### PR DESCRIPTION
We depend on some cryptsetup features that aren't in all of the
cryptsetup versions we have in Ubuntu, so add a simple internal
feature detection API for those. This is motivated by the fact
that we're going to depend on --token-replace, which has just been
approved to land upstream and which we'll need to backport.