### PR TITLE
tpm2: split the tree used for PolicyOR assertions

### DIFF
--- a/internal/compattest/v0_test.go
+++ b/internal/compattest/v0_test.go
@@ -130,5 +130,5 @@ func (s *compatTestV0Suite) TestUnsealAfterLock(c *C) {
 	// but keep this here just to make sure.
 	s.replayPCRSequenceFromFile(c, s.absPath("pcrSequence.1"))
 	c.Assert(secboot_tpm2.BlockPCRProtectionPolicies(s.TPM(), []int{12}), IsNil)
-	s.testUnsealErrorMatchesCommon(c, "invalid key data: cannot complete authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data")
+	s.testUnsealErrorMatchesCommon(c, "invalid key data: cannot complete authorization policy assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
 }

--- a/internal/compattest/v1_test.go
+++ b/internal/compattest/v1_test.go
@@ -116,5 +116,5 @@ func (s *compatTestV1Suite) TestUpdateKeyPCRProtectionPolicyAfterLock(c *C) {
 func (s *compatTestV1Suite) TestUnsealAfterLock(c *C) {
 	s.replayPCRSequenceFromFile(c, s.absPath("pcrSequence.1"))
 	c.Assert(secboot_tpm2.BlockPCRProtectionPolicies(s.TPM(), []int{12}), IsNil)
-	s.testUnsealErrorMatchesCommon(c, "invalid key data: cannot complete authorization policy assertions: cannot complete OR assertions: current session digest not found in policy data")
+	s.testUnsealErrorMatchesCommon(c, "invalid key data: cannot complete authorization policy assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
 }

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -40,15 +40,17 @@ var (
 	ComputeV1PcrPolicyCounterAuthPolicies   = computeV1PcrPolicyCounterAuthPolicies
 	ComputeV1PcrPolicyRefFromCounterContext = computeV1PcrPolicyRefFromCounterContext
 	ComputeV1PcrPolicyRefFromCounterName    = computeV1PcrPolicyRefFromCounterName
-	ComputePolicyORData                     = computePolicyORData
 	ComputeSnapModelDigest                  = computeSnapModelDigest
 	ComputeStaticPolicy                     = computeStaticPolicy
 	CreateTPMPublicAreaForECDSAKey          = createTPMPublicAreaForECDSAKey
+	ErrSessionDigestNotFound                = errSessionDigestNotFound
 	ExecutePolicySession                    = executePolicySession
 	IncrementPcrPolicyCounterTo             = incrementPcrPolicyCounterTo
 	IsDynamicPolicyDataError                = isDynamicPolicyDataError
 	IsStaticPolicyDataError                 = isStaticPolicyDataError
 	NewPcrPolicyCounterHandleV1             = newPcrPolicyCounterHandleV1
+	NewPolicyOrDataV0                       = newPolicyOrDataV0
+	NewPolicyOrTree                         = newPolicyOrTree
 	ReadKeyDataV0                           = readKeyDataV0
 	ReadKeyDataV1                           = readKeyDataV1
 	ReadKeyDataV2                           = readKeyDataV2
@@ -62,7 +64,7 @@ func (d *DynamicPolicyData) PCRSelection() tpm2.PCRSelectionList {
 	return d.pcrSelection
 }
 
-func (d *DynamicPolicyData) PCROrData() policyOrDataTree {
+func (d *DynamicPolicyData) PCROrData() PolicyOrData_v0 {
 	return d.pcrOrData
 }
 
@@ -90,7 +92,39 @@ type KeyData_v1 = keyData_v1
 type KeyData_v2 = keyData_v2
 type KeyDataError = keyDataError
 type PcrPolicyCounterHandle = pcrPolicyCounterHandle
-type PolicyOrDataTree = policyOrDataTree
+
+type PolicyOrData_v0 = policyOrData_v0
+
+func (t PolicyOrData_v0) Resolve() (out *PolicyOrTree, err error) {
+	return t.resolve()
+}
+
+type PolicyOrDataNode_v0 = policyOrDataNode_v0
+
+type PolicyOrNode = policyOrNode
+
+func (n *PolicyOrNode) Parent() *PolicyOrNode {
+	return n.parent
+}
+
+func (n *PolicyOrNode) Digests() tpm2.DigestList {
+	return n.digests
+}
+
+func (n *PolicyOrNode) Contains(digest tpm2.Digest) bool {
+	return n.contains(digest)
+}
+
+type PolicyOrTree = policyOrTree
+
+func (t *PolicyOrTree) LeafNodes() []*PolicyOrNode {
+	return t.leafNodes
+}
+
+func (t *PolicyOrTree) ExecuteAssertions(tpm *tpm2.TPMContext, session tpm2.SessionContext) error {
+	return t.executeAssertions(tpm, session)
+}
+
 type SnapModelHasher = snapModelHasher
 
 type StaticPolicyData = staticPolicyData

--- a/tpm2/keydata_v0_test.go
+++ b/tpm2/keydata_v0_test.go
@@ -124,7 +124,7 @@ func (s *keyDataV0Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 			PinIndexAuthPolicies: counterPolicies},
 		DynamicPolicyData: &DynamicPolicyDataRaw_v0{
 			PCRSelection:     tpm2.PCRSelectionList{},
-			PCROrData:        PolicyOrDataTree{},
+			PCROrData:        PolicyOrData_v0{},
 			AuthorizedPolicy: make(tpm2.Digest, 32),
 			AuthorizedPolicySignature: &tpm2.Signature{
 				SigAlg: tpm2.SigSchemeAlgRSAPSS,

--- a/tpm2/keydata_v1_test.go
+++ b/tpm2/keydata_v1_test.go
@@ -99,7 +99,7 @@ func (s *keyDataV1Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 			PCRPolicyCounterHandle: pcrPolicyCounterHandle},
 		DynamicPolicyData: &DynamicPolicyDataRaw_v0{
 			PCRSelection:     tpm2.PCRSelectionList{},
-			PCROrData:        PolicyOrDataTree{},
+			PCROrData:        PolicyOrData_v0{},
 			PolicyCount:      count,
 			AuthorizedPolicy: make(tpm2.Digest, 32),
 			AuthorizedPolicySignature: &tpm2.Signature{

--- a/tpm2/keydata_v2_test.go
+++ b/tpm2/keydata_v2_test.go
@@ -100,7 +100,7 @@ func (s *keyDataV2Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 			PCRPolicyCounterHandle: pcrPolicyCounterHandle},
 		DynamicPolicyData: &DynamicPolicyDataRaw_v0{
 			PCRSelection:     tpm2.PCRSelectionList{},
-			PCROrData:        PolicyOrDataTree{},
+			PCROrData:        PolicyOrData_v0{},
 			PolicyCount:      count,
 			AuthorizedPolicy: make(tpm2.Digest, 32),
 			AuthorizedPolicySignature: &tpm2.Signature{
@@ -149,7 +149,7 @@ func (s *keyDataV2Suite) newMockImportableKeyData(c *C) KeyData {
 			PCRPolicyCounterHandle: tpm2.HandleNull},
 		DynamicPolicyData: &DynamicPolicyDataRaw_v0{
 			PCRSelection:     tpm2.PCRSelectionList{},
-			PCROrData:        PolicyOrDataTree{},
+			PCROrData:        PolicyOrData_v0{},
 			AuthorizedPolicy: make(tpm2.Digest, 32),
 			AuthorizedPolicySignature: &tpm2.Signature{
 				SigAlg: tpm2.SigSchemeAlgECDSA,

--- a/tpm2/platform_legacy_test.go
+++ b/tpm2/platform_legacy_test.go
@@ -114,7 +114,7 @@ func (s *platformLegacySuite) TestRecoverKeysInvalidPCRPolicy(c *C) {
 
 	_, _, err = k.RecoverKeys()
 	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-		"cannot complete OR assertions: current session digest not found in policy data")
+		"cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
 
 func (s *platformLegacySuite) TestRecoverKeysTPMLockout(c *C) {

--- a/tpm2/policy_test.go
+++ b/tpm2/policy_test.go
@@ -21,12 +21,14 @@ package tpm2_test
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
 	"encoding/pem"
+	"io"
 	"math/big"
-	"sort"
+	"strconv"
 	"testing"
 	"unsafe"
 
@@ -39,6 +41,47 @@ import (
 	"github.com/snapcore/secboot/internal/tpm2test"
 	. "github.com/snapcore/secboot/tpm2"
 )
+
+type policyOrTreeMixin struct{}
+
+func (_ policyOrTreeMixin) checkPolicyOrTree(c *C, alg tpm2.HashAlgorithmId, digests tpm2.DigestList, tree *PolicyOrTree) (policy tpm2.Digest, depth int) {
+	// Try a manual walk of the tree for every input digest
+	for i, digest := range digests {
+		trial := util.ComputeAuthPolicy(alg)
+
+		var node *PolicyOrNode
+		for _, n := range tree.LeafNodes() {
+			if n.Contains(digest) {
+				node = n
+				break
+			}
+		}
+
+		c.Assert(node, NotNil)
+
+		d := 0
+		for node != nil {
+			d += 1
+
+			digests := node.Digests()
+			if len(digests) == 1 {
+				digests = tpm2.DigestList{digests[0], digests[0]}
+			}
+			trial.PolicyOR(digests)
+			node = node.Parent()
+		}
+
+		if i == 0 {
+			policy = trial.GetDigest()
+			depth = d
+		} else {
+			c.Assert(trial.GetDigest(), DeepEquals, policy)
+			c.Assert(d, Equals, depth)
+		}
+	}
+
+	return policy, depth
+}
 
 func TestPcrPolicyCounterHandleSet(t *testing.T) {
 	tpm, _, closeTPM := tpm2test.OpenTPMConnectionT(t,
@@ -192,285 +235,6 @@ AwEHoUQDQgAEkxoOhf6oe3ZE91Kl97qMH/WndK1B0gD7nuqXzPnwtxBBWhTF6pbw
 
 			if !bytes.Equal(policy, data.policy) {
 				t.Errorf("Wrong policy digest: %x", policy)
-			}
-		})
-	}
-}
-
-type pcrDigestBuilder struct {
-	t           *testing.T
-	alg         tpm2.HashAlgorithmId
-	pcrs        tpm2.PCRSelectionList
-	pcrsCurrent tpm2.PCRSelectionList
-	values      tpm2.PCRValues
-}
-
-func (b *pcrDigestBuilder) addDigest(digest tpm2.Digest) *pcrDigestBuilder {
-	for {
-		if len(b.pcrsCurrent) == 0 {
-			b.t.Fatalf("No more digests required")
-		}
-		if len(b.pcrsCurrent[0].Select) > 0 {
-			break
-		}
-		b.pcrsCurrent = b.pcrsCurrent[1:]
-	}
-
-	b.values.SetValue(b.pcrsCurrent[0].Hash, b.pcrsCurrent[0].Select[0], digest)
-
-	b.pcrsCurrent[0].Select = b.pcrsCurrent[0].Select[1:]
-	return b
-}
-
-func (b *pcrDigestBuilder) end() tpm2.Digest {
-	digest, err := util.ComputePCRDigest(b.alg, b.pcrs, b.values)
-	if err != nil {
-		b.t.Fatalf("ComputePCRDigest failed: %v", err)
-	}
-	return digest
-}
-
-func buildPCRDigest(t *testing.T, alg tpm2.HashAlgorithmId, pcrs tpm2.PCRSelectionList) *pcrDigestBuilder {
-	var pcrs2 tpm2.PCRSelectionList
-	for _, p := range pcrs {
-		p2 := tpm2.PCRSelection{Hash: p.Hash}
-		p2.Select = make([]int, len(p.Select))
-		copy(p2.Select, p.Select)
-		sort.Ints(p2.Select)
-		pcrs2 = append(pcrs2, p2)
-	}
-	return &pcrDigestBuilder{t: t, alg: alg, pcrs: pcrs, pcrsCurrent: pcrs2, values: make(tpm2.PCRValues)}
-}
-
-func TestComputePolicyORData(t *testing.T) {
-	for _, data := range []struct {
-		desc         string
-		alg          tpm2.HashAlgorithmId
-		inputDigests tpm2.DigestList
-		outputPolicy tpm2.Digest
-	}{
-		{
-			desc: "SingleDigest",
-			alg:  tpm2.HashAlgorithmSHA256,
-			inputDigests: tpm2.DigestList{
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo")).end(),
-			},
-			outputPolicy: testutil.DecodeHexStringT(t, "fd7451c024bafe5f117cab2841c2dd81f5304350bd8b17ef1f667bceda1ffcf9"),
-		},
-		{
-			desc: "MultipleDigests",
-			alg:  tpm2.HashAlgorithmSHA256,
-			inputDigests: tpm2.DigestList{
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "1234")).end(),
-			},
-			outputPolicy: testutil.DecodeHexStringT(t, "4088de0181ede03662fabce88ba4385b16448a981f6b399da861dfe6cc955b68"),
-		},
-		{
-			desc: "2Rows",
-			alg:  tpm2.HashAlgorithmSHA256,
-			inputDigests: tpm2.DigestList{
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-			},
-			outputPolicy: testutil.DecodeHexStringT(t, "0a023c5b9182d2456407c39bf0ab62f6b86f90a4cec61e594c026a087c43e84c"),
-		},
-		{
-			desc: "3Rows",
-			alg:  tpm2.HashAlgorithmSHA256,
-			inputDigests: tpm2.DigestList{
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc1")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc2")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc3")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc4")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar1")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar2")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar3")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar4")).end(),
-				buildPCRDigest(t, tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 8, 12}}}).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "abc5")).addDigest(tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar5")).end(),
-			},
-			outputPolicy: testutil.DecodeHexStringT(t, "447f411c3cedd453e53e9b95958774413bea32267a75db8545cd258ed4968575"),
-		},
-	} {
-		t.Run(data.desc, func(t *testing.T) {
-			trial := util.ComputeAuthPolicy(data.alg)
-			orData := ComputePolicyORData(data.alg, trial, data.inputDigests)
-			if !bytes.Equal(trial.GetDigest(), data.outputPolicy) {
-				t.Errorf("Unexpected policy digest (got %x, expected %x)", trial.GetDigest(), data.outputPolicy)
-			}
-
-			// Verify we can walk the tree correctly from each input digest and that we get to the root node each time
-			for i, d := range data.inputDigests {
-				for n := i / 8; n < len(orData); n += int(orData[n].Next) {
-					found := false
-					for _, digest := range orData[n].Digests {
-						if bytes.Equal(digest, d) {
-							found = true
-							break
-						}
-					}
-					if !found {
-						t.Errorf("Digest %x not found in expected node %d", d, n)
-						break
-					}
-
-					trial := util.ComputeAuthPolicy(data.alg)
-					if len(orData[n].Digests) == 1 {
-						trial.PolicyOR(tpm2.DigestList{orData[n].Digests[0], orData[n].Digests[0]})
-					} else {
-						trial.PolicyOR(orData[n].Digests)
-					}
-					d = trial.GetDigest()
-
-					if orData[n].Next == 0 {
-						break
-					}
-				}
-				if !bytes.Equal(d, data.outputPolicy) {
-					t.Errorf("Unexpected final digest after tree walk from digest %x, node %d (got %x, expected %x)", data.inputDigests[i], i/8, d, data.outputPolicy)
-				}
-
 			}
 		})
 	}
@@ -1033,7 +797,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, nil)
-		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot execute PolicyOR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1075,7 +839,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "xxx",
 				},
 			}}, nil)
-		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot execute PolicyOR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1217,7 +981,7 @@ func TestExecutePolicy(t *testing.T) {
 					data:  "foo",
 				},
 			}}, nil)
-		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot complete OR assertions: current session digest not found in policy data" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot execute PolicyOR assertions: current session digest not found in policy data" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1702,9 +1466,7 @@ func TestExecutePolicy(t *testing.T) {
 	})
 
 	t.Run("InvalidDynamicMetadata/PCROrDigests/1", func(t *testing.T) {
-		// Test handling of a corrupted OR digest tree with a PCR policy that only has one condition (execution should succeed - the
-		// corrupted value causes executeOrPolicyAssertions to bail at the right time but for the wrong reason, so the resulting
-		// session digest ends up correct)
+		// Test handling of a corrupted OR digest tree with a PCR policy that only has one condition
 		expected, digest, err := run(t, &testData{
 			alg:  tpm2.HashAlgorithmSHA256,
 			pcrs: tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7, 12}}},
@@ -1738,11 +1500,11 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			d.PCROrData()[0].Next = 1000
 		})
-		if err != nil {
-			t.Errorf("Failed to execute policy session: %v", err)
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot resolve PolicyOR tree: too many leaf nodes (1000)" {
+			t.Errorf("Unexpected error: %v", err)
 		}
-		if !bytes.Equal(digest, expected) {
-			t.Errorf("Session digest didn't match policy digest")
+		if bytes.Equal(digest, expected) {
+			t.Errorf("Session digest shouldn't match policy digest")
 		}
 	})
 
@@ -1789,7 +1551,7 @@ func TestExecutePolicy(t *testing.T) {
 			}}, func(s *StaticPolicyData, d *DynamicPolicyData) {
 			d.PCROrData()[0].Next = 1000
 		})
-		if !IsDynamicPolicyDataError(err) || err.Error() != "the PCR policy is invalid" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot resolve PolicyOR tree: too many leaf nodes (1000)" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1841,7 +1603,7 @@ func TestExecutePolicy(t *testing.T) {
 			x := int32(-10)
 			d.PCROrData()[0].Next = *(*uint32)(unsafe.Pointer(&x))
 		})
-		if !IsDynamicPolicyDataError(err) || err.Error() != "the PCR policy is invalid" {
+		if !IsDynamicPolicyDataError(err) || err.Error() != "cannot resolve PolicyOR tree: too many leaf nodes (4294967286)" {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if bytes.Equal(digest, expected) {
@@ -1932,6 +1694,10 @@ func TestExecutePolicy(t *testing.T) {
 	})
 }
 
+type policySuiteNoTPM struct {
+	policyOrTreeMixin
+}
+
 type policySuite struct {
 	tpm2test.TPMTest
 }
@@ -1940,7 +1706,157 @@ func (s *policySuite) SetUpSuite(c *C) {
 	s.TPMFeatures = tpm2test.TPMFeaturePCR | tpm2test.TPMFeatureNV
 }
 
+var _ = Suite(&policySuiteNoTPM{})
 var _ = Suite(&policySuite{})
+
+func hash(alg crypto.Hash, data string) []byte {
+	h := alg.New()
+	io.WriteString(h, data)
+	return h.Sum(nil)
+}
+
+type testNewPolicyOrTreeData struct {
+	alg     tpm2.HashAlgorithmId
+	digests tpm2.DigestList
+
+	depth    int
+	expected tpm2.Digest
+}
+
+func (s *policySuiteNoTPM) testNewPolicyOrTree(c *C, data *testNewPolicyOrTreeData) {
+	trial := util.ComputeAuthPolicy(data.alg)
+
+	tree, err := NewPolicyOrTree(data.alg, trial, data.digests)
+	c.Assert(err, IsNil)
+
+	c.Assert(trial.GetDigest(), DeepEquals, data.expected)
+
+	policy, depth := s.checkPolicyOrTree(c, data.alg, data.digests, tree)
+	c.Check(policy, DeepEquals, data.expected)
+	c.Check(depth, Equals, data.depth)
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeSingleDigest(c *C) {
+	s.testNewPolicyOrTree(c, &testNewPolicyOrTreeData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  tpm2.DigestList{hash(crypto.SHA256, "foo")},
+		depth:    1,
+		expected: testutil.DecodeHexString(c, "51d05afe8c2bbc42a2c1f540d7390b0228cd0d59d417a8e765c28af6f43f024c")})
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeDepth1(c *C) {
+	s.testNewPolicyOrTree(c, &testNewPolicyOrTreeData{
+		alg: tpm2.HashAlgorithmSHA256,
+		digests: tpm2.DigestList{
+			hash(crypto.SHA256, "1"),
+			hash(crypto.SHA256, "2"),
+			hash(crypto.SHA256, "3"),
+			hash(crypto.SHA256, "4"),
+			hash(crypto.SHA256, "5")},
+		depth:    1,
+		expected: testutil.DecodeHexString(c, "5e5a5c8790bd34336f2df51c216e072ca52bd9c0c2dc67e249d5952aa81aecfa")})
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeDepth2(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 26; i++ {
+		digests = append(digests, hash(crypto.SHA256, strconv.Itoa(i)))
+	}
+	s.testNewPolicyOrTree(c, &testNewPolicyOrTreeData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  digests,
+		depth:    2,
+		expected: testutil.DecodeHexString(c, "84be2df61f929c0afca3bcec125f7365fd825b410a150019e250b0dfb25110cf")})
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeSHA1(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 26; i++ {
+		digests = append(digests, hash(crypto.SHA1, strconv.Itoa(i)))
+	}
+	s.testNewPolicyOrTree(c, &testNewPolicyOrTreeData{
+		alg:      tpm2.HashAlgorithmSHA1,
+		digests:  digests,
+		depth:    2,
+		expected: testutil.DecodeHexString(c, "dddd1fd38995710c4aa703599b9741e729ac9ceb")})
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeDepth3(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 201; i++ {
+		digests = append(digests, hash(crypto.SHA256, strconv.Itoa(i)))
+	}
+	s.testNewPolicyOrTree(c, &testNewPolicyOrTreeData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  digests,
+		depth:    3,
+		expected: testutil.DecodeHexString(c, "9c1cb2f1722a0a06f5e6774a9628cabce76572b0f2201bf66002a9eb2dfd6f11")})
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeDepth4(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 1601; i++ {
+		digests = append(digests, hash(crypto.SHA256, strconv.Itoa(i)))
+	}
+	s.testNewPolicyOrTree(c, &testNewPolicyOrTreeData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  digests,
+		depth:    4,
+		expected: testutil.DecodeHexString(c, "6f2ccbe268c9b3324c0922fcc2ccd760f6a7d264b7f61dccd3fba21f98412f85")})
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeNoDigests(c *C) {
+	_, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256), nil)
+	c.Check(err, ErrorMatches, "no digests supplied")
+}
+
+func (s *policySuiteNoTPM) TestNewPolicyOrTreeTooManyDigests(c *C) {
+	_, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256), make(tpm2.DigestList, 5000))
+	c.Check(err, ErrorMatches, "too many digests")
+}
+
+func (s *policySuite) TestPolicyOrTreeExecuteAssertions(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 201; i++ {
+		trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+		trial.PolicyPCR(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
+		digests = append(digests, trial.GetDigest())
+	}
+
+	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	c.Assert(err, IsNil)
+	expectedDigest := trial.GetDigest()
+
+	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeTrial, nil, tpm2.HashAlgorithmSHA256)
+
+	for i := 1; i < 201; i++ {
+		c.Assert(s.TPM().PolicyRestart(session), IsNil)
+		c.Assert(s.TPM().PolicyPCR(session, hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}), IsNil)
+		c.Assert(tree.ExecuteAssertions(s.TPM().TPMContext, session), IsNil)
+
+		digest, err := s.TPM().PolicyGetDigest(session)
+		c.Assert(err, IsNil)
+		c.Assert(digest, DeepEquals, expectedDigest)
+	}
+}
+
+func (s *policySuite) TestPolicyOrTreeExecuteAssertionsDigestNotFound(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 201; i++ {
+		trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+		trial.PolicyPCR(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
+		digests = append(digests, trial.GetDigest())
+	}
+
+	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	c.Assert(err, IsNil)
+
+	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeTrial, nil, tpm2.HashAlgorithmSHA256)
+	c.Check(s.TPM().PolicyPCR(session, hash(crypto.SHA256, "500"), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}), IsNil)
+	c.Check(tree.ExecuteAssertions(s.TPM().TPMContext, session), Equals, ErrSessionDigestNotFound)
+}
 
 func (s *policySuite) testBlockPCRProtectionPolicies(c *C, n []int) {
 	pcrs := tpm2.PCRSelectionList{

--- a/tpm2/policy_v0.go
+++ b/tpm2/policy_v0.go
@@ -33,42 +33,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// computeV0PinNVIndexPostInitAuthPolicies computes the authorization policy digests associated with the post-initialization
-// actions on a NV index created with the removed createPinNVIndex for version 0 key files. These are:
-// - A policy for updating the index to revoke old dynamic authorization policies, requiring an assertion signed by the key
-//   associated with updateKeyName.
-// - A policy for updating the authorization value (PIN / passphrase), requiring knowledge of the current authorization value.
-// - A policy for reading the counter value without knowing the authorization value, as the value isn't secret.
-// - A policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
-func computeV0PinNVIndexPostInitAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) tpm2.DigestList {
-	var out tpm2.DigestList
-	// Compute a policy for incrementing the index to revoke dynamic authorization policies, requiring an assertion signed by the
-	// key associated with updateKeyName.
-	trial := util.ComputeAuthPolicy(alg)
-	trial.PolicyCommandCode(tpm2.CommandNVIncrement)
-	trial.PolicyNvWritten(true)
-	trial.PolicySigned(updateKeyName, nil)
-	out = append(out, trial.GetDigest())
-
-	// Compute a policy for updating the authorization value of the index, requiring knowledge of the current authorization value.
-	trial = util.ComputeAuthPolicy(alg)
-	trial.PolicyCommandCode(tpm2.CommandNVChangeAuth)
-	trial.PolicyAuthValue()
-	out = append(out, trial.GetDigest())
-
-	// Compute a policy for reading the counter value without knowing the authorization value.
-	trial = util.ComputeAuthPolicy(alg)
-	trial.PolicyCommandCode(tpm2.CommandNVRead)
-	out = append(out, trial.GetDigest())
-
-	// Compute a policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
-	trial = util.ComputeAuthPolicy(alg)
-	trial.PolicyCommandCode(tpm2.CommandPolicyNV)
-	out = append(out, trial.GetDigest())
-
-	return out
-}
-
 type policyOrDataNode_v0 struct {
 	Next    uint32 // Index of the parent node in the containing slice, relative to this node. Zero indicates that this is the root node
 	Digests tpm2.DigestList
@@ -174,20 +138,9 @@ func (t policyOrData_v0) resolve() (out *policyOrTree, err error) {
 	return out, nil
 }
 
-// newPolicyOrDataV0 creates a new flattened tree from the supplied digests
-// for creating a policy that can be satisified by multiple conditions. It also
-// extends the supplied trial policy.
-//
-// It works by turning the supplied list of digests (each corresponding to some
-// condition) into a tree of nodes, with each node containing no more than 8 digests
-// that can be used in a single PolicyOR assertion. The leaf nodes contain the
-// supplied digests, and correspond to the first PolicyOR assertion. The root node
-// contains the digests for the final PolicyOR execution, and the policy is executed
-// by finding the leaf node with the current session digest and then walking up the
-// tree to the root node, executing a PolicyOR assertion at each step.
-//
-// It returns an error if no digests are supplied or if too many digests are
-// supplied. The returned tree won't have a depth of more than 4.
+// newPolicyOrDataV0 creates a new flattened tree suitable for serialization
+// from the supplied policyOrTree. The returned data is just a list of nodes,
+// with each node containing an offset in order to index its parent node.
 func newPolicyOrDataV0(tree *policyOrTree) (out policyOrData_v0) {
 	// Track source nodes to index in the flattened tree.
 	srcNodesToIndex := make(map[*policyOrNode]int)
@@ -239,6 +192,42 @@ func newPolicyOrDataV0(tree *policyOrTree) (out policyOrData_v0) {
 		parentIndex := srcNodesToIndex[node.parent]
 		out[index].Next = uint32(parentIndex - index)
 	}
+
+	return out
+}
+
+// computeV0PinNVIndexPostInitAuthPolicies computes the authorization policy digests associated with the post-initialization
+// actions on a NV index created with the removed createPinNVIndex for version 0 key files. These are:
+// - A policy for updating the index to revoke old dynamic authorization policies, requiring an assertion signed by the key
+//   associated with updateKeyName.
+// - A policy for updating the authorization value (PIN / passphrase), requiring knowledge of the current authorization value.
+// - A policy for reading the counter value without knowing the authorization value, as the value isn't secret.
+// - A policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
+func computeV0PinNVIndexPostInitAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) tpm2.DigestList {
+	var out tpm2.DigestList
+	// Compute a policy for incrementing the index to revoke dynamic authorization policies, requiring an assertion signed by the
+	// key associated with updateKeyName.
+	trial := util.ComputeAuthPolicy(alg)
+	trial.PolicyCommandCode(tpm2.CommandNVIncrement)
+	trial.PolicyNvWritten(true)
+	trial.PolicySigned(updateKeyName, nil)
+	out = append(out, trial.GetDigest())
+
+	// Compute a policy for updating the authorization value of the index, requiring knowledge of the current authorization value.
+	trial = util.ComputeAuthPolicy(alg)
+	trial.PolicyCommandCode(tpm2.CommandNVChangeAuth)
+	trial.PolicyAuthValue()
+	out = append(out, trial.GetDigest())
+
+	// Compute a policy for reading the counter value without knowing the authorization value.
+	trial = util.ComputeAuthPolicy(alg)
+	trial.PolicyCommandCode(tpm2.CommandNVRead)
+	out = append(out, trial.GetDigest())
+
+	// Compute a policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
+	trial = util.ComputeAuthPolicy(alg)
+	trial.PolicyCommandCode(tpm2.CommandPolicyNV)
+	out = append(out, trial.GetDigest())
 
 	return out
 }
@@ -316,7 +305,7 @@ func computeDynamicPolicyV0(alg tpm2.HashAlgorithmId, input *dynamicPolicyComput
 	}
 
 	trial := util.ComputeAuthPolicy(alg)
-	pcrOrData, err := newPolicyOrTree(alg, trial, pcrOrDigests)
+	pcrOrTree, err := newPolicyOrTree(alg, trial, pcrOrDigests)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create tree for PolicyOR digests: %w", err)
 	}
@@ -349,7 +338,7 @@ func computeDynamicPolicyV0(alg tpm2.HashAlgorithmId, input *dynamicPolicyComput
 
 	return &dynamicPolicyData{
 		pcrSelection:              input.pcrs,
-		pcrOrData:                 newPolicyOrDataV0(pcrOrData),
+		pcrOrData:                 newPolicyOrDataV0(pcrOrTree),
 		policyCount:               input.policyCount,
 		authorizedPolicy:          authorizedPolicy,
 		authorizedPolicySignature: &signature}, nil

--- a/tpm2/policy_v0_test.go
+++ b/tpm2/policy_v0_test.go
@@ -1,0 +1,194 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2_test
+
+import (
+	"crypto"
+	"strconv"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/go-tpm2"
+	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
+	"github.com/canonical/go-tpm2/util"
+
+	"github.com/snapcore/secboot/internal/testutil"
+	"github.com/snapcore/secboot/internal/tpm2test"
+	. "github.com/snapcore/secboot/tpm2"
+)
+
+type policyV0SuiteNoTPM struct {
+	policyOrTreeMixin
+}
+
+type policyV0Suite struct {
+	tpm2test.TPMTest
+}
+
+func (s *policyV0Suite) SetUpSuite(c *C) {
+	s.TPMFeatures = tpm2test.TPMFeatureOwnerHierarchy | tpm2test.TPMFeaturePCR | tpm2test.TPMFeatureNV
+}
+
+var _ = Suite(&policyV0Suite{})
+var _ = Suite(&policyV0SuiteNoTPM{})
+
+type testPolicyOrTreeSerializationData struct {
+	alg      tpm2.HashAlgorithmId
+	digests  tpm2.DigestList
+	numNodes int
+
+	depth    int
+	expected tpm2.Digest
+}
+
+func (s *policyV0SuiteNoTPM) testPolicyOrTreeSerialization(c *C, data *testPolicyOrTreeSerializationData) {
+	trial := util.ComputeAuthPolicy(data.alg)
+	tree, err := NewPolicyOrTree(data.alg, trial, data.digests)
+	c.Assert(err, IsNil)
+
+	serialized := NewPolicyOrDataV0(tree)
+	c.Check(serialized, tpm2_testutil.LenEquals, data.numNodes)
+
+	tree2, err := serialized.Resolve()
+	c.Assert(err, IsNil)
+
+	policy, depth := s.checkPolicyOrTree(c, data.alg, data.digests, tree2)
+	c.Check(policy, DeepEquals, data.expected)
+	c.Check(depth, Equals, data.depth)
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeSerializationSingleDigest(c *C) {
+	s.testPolicyOrTreeSerialization(c, &testPolicyOrTreeSerializationData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  tpm2.DigestList{hash(crypto.SHA256, "foo")},
+		numNodes: 1,
+		depth:    1,
+		expected: testutil.DecodeHexString(c, "51d05afe8c2bbc42a2c1f540d7390b0228cd0d59d417a8e765c28af6f43f024c")})
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeSerializationDepth1(c *C) {
+	s.testPolicyOrTreeSerialization(c, &testPolicyOrTreeSerializationData{
+		alg: tpm2.HashAlgorithmSHA256,
+		digests: tpm2.DigestList{
+			hash(crypto.SHA256, "1"),
+			hash(crypto.SHA256, "2"),
+			hash(crypto.SHA256, "3"),
+			hash(crypto.SHA256, "4"),
+			hash(crypto.SHA256, "5")},
+		numNodes: 1,
+		depth:    1,
+		expected: testutil.DecodeHexString(c, "5e5a5c8790bd34336f2df51c216e072ca52bd9c0c2dc67e249d5952aa81aecfa")})
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeSerializationDepth2(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 26; i++ {
+		digests = append(digests, hash(crypto.SHA256, strconv.Itoa(i)))
+	}
+	s.testPolicyOrTreeSerialization(c, &testPolicyOrTreeSerializationData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  digests,
+		numNodes: 5,
+		depth:    2,
+		expected: testutil.DecodeHexString(c, "84be2df61f929c0afca3bcec125f7365fd825b410a150019e250b0dfb25110cf")})
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeSerializationDepth3(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 201; i++ {
+		digests = append(digests, hash(crypto.SHA256, strconv.Itoa(i)))
+	}
+	s.testPolicyOrTreeSerialization(c, &testPolicyOrTreeSerializationData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  digests,
+		numNodes: 30,
+		depth:    3,
+		expected: testutil.DecodeHexString(c, "9c1cb2f1722a0a06f5e6774a9628cabce76572b0f2201bf66002a9eb2dfd6f11")})
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeSerializationDepth4(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 1601; i++ {
+		digests = append(digests, hash(crypto.SHA256, strconv.Itoa(i)))
+	}
+	s.testPolicyOrTreeSerialization(c, &testPolicyOrTreeSerializationData{
+		alg:      tpm2.HashAlgorithmSHA256,
+		digests:  digests,
+		numNodes: 230,
+		depth:    4,
+		expected: testutil.DecodeHexString(c, "6f2ccbe268c9b3324c0922fcc2ccd760f6a7d264b7f61dccd3fba21f98412f85")})
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeResolveNoNodes(c *C) {
+	_, err := PolicyOrData_v0{}.Resolve()
+	c.Assert(err, ErrorMatches, "no nodes")
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeResolveTooManyNodes(c *C) {
+	_, err := PolicyOrData_v0{&PolicyOrDataNode_v0{Next: 5000}}.Resolve()
+	c.Assert(err, ErrorMatches, "too many leaf nodes \\(5000\\)")
+}
+
+func (s *policyV0SuiteNoTPM) TestPolicyOrTreeResolveError(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 201; i++ {
+		digests = append(digests, make(tpm2.Digest, crypto.SHA256.Size()))
+	}
+
+	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	c.Assert(err, IsNil)
+
+	serialized := NewPolicyOrDataV0(tree)
+	serialized[10].Next = 200
+
+	_, err = serialized.Resolve()
+	c.Check(err, ErrorMatches, "index 210 out of range")
+}
+
+func (s *policyV0Suite) TestPolicyOrTreeExecuteAssertions(c *C) {
+	var digests tpm2.DigestList
+	for i := 1; i < 201; i++ {
+		trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+		trial.PolicyPCR(hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}})
+		digests = append(digests, trial.GetDigest())
+	}
+
+	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	tree, err := NewPolicyOrTree(tpm2.HashAlgorithmSHA256, trial, digests)
+	c.Assert(err, IsNil)
+	expectedDigest := trial.GetDigest()
+
+	serialized := NewPolicyOrDataV0(tree)
+	tree2, err := serialized.Resolve()
+	c.Assert(err, IsNil)
+
+	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeTrial, nil, tpm2.HashAlgorithmSHA256)
+
+	for i := 1; i < 201; i++ {
+		c.Assert(s.TPM().PolicyRestart(session), IsNil)
+		c.Assert(s.TPM().PolicyPCR(session, hash(crypto.SHA256, strconv.Itoa(i)), tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{7}}}), IsNil)
+		c.Assert(tree2.ExecuteAssertions(s.TPM().TPMContext, session), IsNil)
+
+		digest, err := s.TPM().PolicyGetDigest(session)
+		c.Assert(err, IsNil)
+		c.Assert(digest, DeepEquals, expectedDigest)
+	}
+}

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -120,7 +120,7 @@ func computeDynamicPolicyV1(alg tpm2.HashAlgorithmId, input *dynamicPolicyComput
 	}
 
 	trial := util.ComputeAuthPolicy(alg)
-	pcrOrData, err := newPolicyOrTree(alg, trial, pcrOrDigests)
+	pcrOrTree, err := newPolicyOrTree(alg, trial, pcrOrDigests)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create tree for PolicyOR digests: %w", err)
 	}
@@ -154,7 +154,7 @@ func computeDynamicPolicyV1(alg tpm2.HashAlgorithmId, input *dynamicPolicyComput
 
 	return &dynamicPolicyData{
 		pcrSelection:              input.pcrs,
-		pcrOrData:                 newPolicyOrDataV0(pcrOrData),
+		pcrOrData:                 newPolicyOrDataV0(pcrOrTree),
 		policyCount:               input.policyCount,
 		authorizedPolicy:          authorizedPolicy,
 		authorizedPolicySignature: &signature}, nil

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -95,7 +95,7 @@ func (s *sealSuite) testSealKeyToTPM(c *C, params *KeyCreationParams) {
 		c.Check(err, IsNil)
 		_, _, err = k.UnsealFromTPM(s.TPM())
 		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-			"cannot complete OR assertions: current session digest not found in policy data")
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
 	}
 }
 
@@ -288,7 +288,7 @@ func (s *sealSuite) testSealKeyToTPMMultiple(c *C, data *testSealKeyToTPMMultipl
 
 			_, _, err = k.UnsealFromTPM(s.TPM())
 			c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-				"cannot complete OR assertions: current session digest not found in policy data")
+				"cannot execute PolicyOR assertions: current session digest not found in policy data")
 		}
 	}
 }
@@ -515,7 +515,7 @@ func (s *sealSuite) testSealKeyToExternalTPMStorageKey(c *C, params *KeyCreation
 		c.Check(err, IsNil)
 		_, _, err = k.UnsealFromTPM(s.TPM())
 		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-			"cannot complete OR assertions: current session digest not found in policy data")
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
 	}
 }
 
@@ -622,7 +622,7 @@ func (s *sealSuite) testUpdatePCRProtectionPolicy(c *C, params *KeyCreationParam
 	c.Check(err, IsNil)
 	_, _, err = k.UnsealFromTPM(s.TPM())
 	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-		"cannot complete OR assertions: current session digest not found in policy data")
+		"cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
 
 func (s *sealSuite) TestUpdatePCRProtectionPolicyWithPCRPolicyCounter(c *C) {
@@ -728,7 +728,7 @@ func (s *sealSuite) TestUpdateKeyPCRProtectionPolicyMultiple(c *C) {
 	for _, k := range keys {
 		_, _, err = k.UnsealFromTPM(s.TPM())
 		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-			"cannot complete OR assertions: current session digest not found in policy data")
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
 	}
 }
 

--- a/tpm2/unseal_test.go
+++ b/tpm2/unseal_test.go
@@ -202,7 +202,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingInvalidPCRProfile(c *C) {
 	})
 	c.Check(err, tpm2_testutil.ConvertibleTo, InvalidKeyDataError{})
 	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-		"cannot complete OR assertions: current session digest not found in policy data")
+		"cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingRevokedPolicy(c *C) {
@@ -223,5 +223,5 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingSealedKeyAccessLocked(c *C) 
 	})
 	c.Check(err, tpm2_testutil.ConvertibleTo, InvalidKeyDataError{})
 	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
-		"cannot complete OR assertions: current session digest not found in policy data")
+		"cannot execute PolicyOR assertions: current session digest not found in policy data")
 }


### PR DESCRIPTION
This splits the tree structure used for executing PolicyOR assertions
into 2 - there is the existing "flattened" tree on-disk representation,
but this is now converted to an actual tree structure.