### PR TITLE
move Snap model authorization to ActivateVolumeWith*KeyData

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -342,7 +342,7 @@ type ActivateVolumeOptions struct {
 	// kernel keys created during activation.
 	KeyringPrefix string
 
-	// SnapModel is the snap device model that will access the data
+	// Model is the snap device model that will access the data
 	// on the encrypted container. The ActivateVolumeWith* functions
 	// will check that this model is authorized via the KeyData
 	// binding before unlocking the encrypted container.
@@ -350,10 +350,12 @@ type ActivateVolumeOptions struct {
 	// The caller of the ActivateVolumeWith* API is responsible for
 	// validating the associated model assertion and snaps.
 	//
-	// Set this to SkipSnapModelCheck to skip the check.
+	// Set this to SkipSnapModelCheck to skip the check. It cannot
+	// be left set as nil.
 	//
-	// It is ignored by ActivateVolumeWithRecoveryKey.
-	SnapModel SnapModel
+	// It is ignored by ActivateVolumeWithRecoveryKey, and it is
+	// ok to leave it set as nil in this case.
+	Model SnapModel
 }
 
 type activateVolumeWithKeyDataError struct {
@@ -391,7 +393,7 @@ var ErrRecoveryKeyUsed = errors.New("cannot activate with platform protected key
 // 0, then no attempts will be made to request and use the fallback recovery key.
 //
 // If either the PassphraseTries or RecoveryKeyTries fields of options are less
-// than zero, an error will be returned. If the SnapModel field of options is nil,
+// than zero, an error will be returned. If the Model field of options is nil,
 // an error will be returned.
 //
 // If the fallback recovery key is used for successfully for activation, an
@@ -412,8 +414,8 @@ func ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath string, keys
 	if options.RecoveryKeyTries < 0 {
 		return errors.New("invalid RecoveryKeyTries")
 	}
-	if options.SnapModel == nil {
-		return errors.New("nil SnapModel")
+	if options.Model == nil {
+		return errors.New("nil Model")
 	}
 
 	if (options.PassphraseTries > 0 || options.RecoveryKeyTries > 0) && authRequestor == nil {
@@ -423,7 +425,7 @@ func ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath string, keys
 		return errors.New("nil kdf")
 	}
 
-	s := newActivateWithKeyDataState(volumeName, sourceDevicePath, options.KeyringPrefix, options.SnapModel, keys, authRequestor, kdf, options.PassphraseTries)
+	s := newActivateWithKeyDataState(volumeName, sourceDevicePath, options.KeyringPrefix, options.Model, keys, authRequestor, kdf, options.PassphraseTries)
 	success, err := s.run()
 	switch {
 	case success:
@@ -459,7 +461,7 @@ func ActivateVolumeWithMultipleKeyData(volumeName, sourceDevicePath string, keys
 // will be made to request and use the fallback recovery key.
 //
 // If either the PassphraseTries or RecoveryKeyTries fields of options are less
-// than zero, an error will be returned. If the SnapModel field of options is nil,
+// than zero, an error will be returned. If the Model field of options is nil,
 // an error will be returned.
 //
 // If the fallback recovery key is used for successfully for activation, an

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -667,7 +667,7 @@ func (s *cryptSuite) testActivateVolumeWithKeyData(c *C, data *testActivateVolum
 	options := &ActivateVolumeOptions{
 		PassphraseTries: data.passphraseTries,
 		KeyringPrefix:   data.keyringPrefix,
-		SnapModel:       data.model}
+		Model:           data.model}
 	err := ActivateVolumeWithKeyData(data.volumeName, data.sourceDevicePath, keyData, authRequestor, &kdf, options)
 	c.Assert(err, IsNil)
 
@@ -833,7 +833,7 @@ func (s *cryptSuite) testActivateVolumeWithKeyDataErrorHandling(c *C, data *test
 		PassphraseTries:  data.passphraseTries,
 		RecoveryKeyTries: data.recoveryKeyTries,
 		KeyringPrefix:    data.keyringPrefix,
-		SnapModel:        data.model}
+		Model:            data.model}
 	err := ActivateVolumeWithKeyData("data", "/dev/sda1", data.keyData, authRequestor, data.kdf, options)
 	if data.errChecker != nil {
 		c.Check(err, data.errChecker, data.errCheckerArgs...)
@@ -1102,7 +1102,7 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling14(c *C) {
 	s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
 		keyData:        keyData,
 		errChecker:     ErrorMatches,
-		errCheckerArgs: []interface{}{"nil SnapModel"}})
+		errCheckerArgs: []interface{}{"nil Model"}})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling15(c *C) {
@@ -1159,7 +1159,7 @@ func (s *cryptSuite) testActivateVolumeWithMultipleKeyData(c *C, data *testActiv
 	options := &ActivateVolumeOptions{
 		PassphraseTries: data.passphraseTries,
 		KeyringPrefix:   data.keyringPrefix,
-		SnapModel:       data.model}
+		Model:           data.model}
 	err := ActivateVolumeWithMultipleKeyData(data.volumeName, data.sourceDevicePath, data.keyData, authRequestor, &kdf, options)
 	c.Assert(err, IsNil)
 
@@ -1516,7 +1516,7 @@ func (s *cryptSuite) testActivateVolumeWithMultipleKeyDataErrorHandling(c *C, da
 		PassphraseTries:  data.passphraseTries,
 		RecoveryKeyTries: data.recoveryKeyTries,
 		KeyringPrefix:    data.keyringPrefix,
-		SnapModel:        data.model}
+		Model:            data.model}
 	err := ActivateVolumeWithMultipleKeyData("data", "/dev/sda1", data.keyData, authRequestor, data.kdf, options)
 	if data.errChecker != nil {
 		c.Check(err, data.errChecker, data.errCheckerArgs...)
@@ -1792,7 +1792,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling14(c *C) 
 	s.testActivateVolumeWithMultipleKeyDataErrorHandling(c, &testActivateVolumeWithMultipleKeyDataErrorHandlingData{
 		keyData:        keyData,
 		errChecker:     ErrorMatches,
-		errCheckerArgs: []interface{}{"nil SnapModel"}})
+		errCheckerArgs: []interface{}{"nil Model"}})
 }
 
 func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling15(c *C) {


### PR DESCRIPTION
The ActivateVolumeWith*KeyData functions currently return a
SnapModelChecker to delegate authorization of the Snap model to
snap-bootstrap. This means that authorization of the model is
performed after activation of the container. There are a couple
of issues with this though:
- If multiple KeyData are supplied and the container is activated
with one of these but the model isn't authorized, it requires another
call to ActivateVolumeWithMultipleKeyData in order to try others.
- If the model isn't auhtorized with any KeyData, the container has
to be deactivated again.

The first issue is difficult to solve with the current architecture
when KeyData are loaded from the LUKS metadata rather than being
supplied externally from a file.

This implements a different approach where SnapModelChecker is removed,
and the model authorization is done in ActivateVolumeWith*KeyData before
the container is activated, with a KeyData being rejected before
activation if the model authorization check fails.