### PR TITLE
Add internal/luksview package

### DIFF
--- a/internal/luksview/export_test.go
+++ b/internal/luksview/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luksview
+
+type OrphanedToken = orphanedToken

--- a/internal/luksview/luksview_test.go
+++ b/internal/luksview/luksview_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luksview_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }

--- a/internal/luksview/tokens.go
+++ b/internal/luksview/tokens.go
@@ -124,16 +124,6 @@ type tokenBaseRaw struct {
 	Name     string          `json:"ubuntu_fde_name"`
 }
 
-type recoveryTokenRaw struct {
-	tokenBaseRaw
-}
-
-type keyDataTokenRaw struct {
-	tokenBaseRaw
-	Priority int             `json:"ubuntu_fde_priority"`
-	Data     json.RawMessage `json:"ubuntu_fde_data,omitempty"`
-}
-
 // TokenBase provides the fields that are common to all tokens created by secboot.
 type TokenBase struct {
 	TokenKeyslot int    // The ID of the keyslot associated with this token
@@ -146,6 +136,10 @@ func (t *TokenBase) Keyslots() []int {
 
 func (t *TokenBase) Name() string {
 	return t.TokenName
+}
+
+type recoveryTokenRaw struct {
+	tokenBaseRaw
 }
 
 // RecoveryToken represents a token with the type "ubuntu-fde-recovery",
@@ -188,6 +182,12 @@ func (t *RecoveryToken) UnmarshalJSON(data []byte) error {
 			TokenKeyslot: int(raw.Keyslots[0]),
 			TokenName:    raw.Name}}
 	return nil
+}
+
+type keyDataTokenRaw struct {
+	tokenBaseRaw
+	Priority int             `json:"ubuntu_fde_priority"`
+	Data     json.RawMessage `json:"ubuntu_fde_data,omitempty"`
 }
 
 // KeyDataToken represents a token with the "ubuntu-fde" type, associated

--- a/internal/luksview/tokens.go
+++ b/internal/luksview/tokens.go
@@ -266,9 +266,9 @@ func (t *orphanedToken) Name() string {
 	return t.raw.Name
 }
 
-// NewOrphanedTokenForTesting returns a new orphaned named token with the
+// MockOrphanedToken returns a new orphaned named token with the
 // supplied type and name, which is useful for testing.
-func NewOrphanedTokenForTesting(t luks2.TokenType, name string) NamedToken {
+func MockOrphanedToken(t luks2.TokenType, name string) NamedToken {
 	return &orphanedToken{
 		raw: tokenBaseRaw{
 			Type: t,

--- a/internal/luksview/tokens.go
+++ b/internal/luksview/tokens.go
@@ -1,0 +1,276 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luksview
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+
+	"golang.org/x/xerrors"
+
+	"github.com/snapcore/secboot/internal/luks2"
+)
+
+const (
+	KeyDataTokenType  luks2.TokenType = "ubuntu-fde"
+	RecoveryTokenType luks2.TokenType = "ubuntu-fde-recovery"
+)
+
+var (
+	errInvalidNamedToken  = errors.New("invalid named token")
+	errOrphanedNamedToken = errors.New("orphaned named token")
+)
+
+func fallbackDecodeTokenHelper(data []byte, origErr error) (luks2.Token, error) {
+	switch {
+	case origErr == nil:
+		panic("asked to decode fallback token without an error")
+	case xerrors.Is(origErr, errOrphanedNamedToken):
+		var token *orphanedToken
+		if err := json.Unmarshal(data, &token); err != nil {
+			return nil, err
+		}
+		return token, nil
+	case xerrors.Is(origErr, errInvalidNamedToken):
+		var token *luks2.GenericToken
+		if err := json.Unmarshal(data, &token); err != nil {
+			return nil, err
+		}
+		return token, nil
+	default:
+		return nil, origErr
+	}
+}
+
+func init() {
+	luks2.RegisterTokenDecoder(KeyDataTokenType, func(data []byte) (luks2.Token, error) {
+		var token *KeyDataToken
+		if err := json.Unmarshal(data, &token); err != nil {
+			return fallbackDecodeTokenHelper(data, err)
+		}
+		return token, nil
+	})
+
+	luks2.RegisterTokenDecoder(RecoveryTokenType, func(data []byte) (luks2.Token, error) {
+		var token *RecoveryToken
+		if err := json.Unmarshal(data, &token); err != nil {
+			return fallbackDecodeTokenHelper(data, err)
+		}
+		return token, nil
+	})
+}
+
+// NamedToken corresponds to a token created by secboot, which identifies
+// the associated keyslot with a name and may contain data required to
+// activate a volume using the associated keyslot.
+type NamedToken interface {
+	luks2.Token
+
+	// Name returns the name of this token. A name is an arbitrary
+	// string used to identify the associated keyslot, and the name is
+	// intended to be unique between keyslots.
+	Name() string
+}
+
+type tokenKeyslots []int
+
+func (k tokenKeyslots) MarshalJSON() ([]byte, error) {
+	var keyslots []luks2.JsonNumber
+	for _, slot := range k {
+		keyslots = append(keyslots, luks2.JsonNumber(strconv.Itoa(slot)))
+	}
+	return json.Marshal(keyslots)
+}
+
+func (k *tokenKeyslots) UnmarshalJSON(data []byte) error {
+	var rawslots []luks2.JsonNumber
+	if err := json.Unmarshal(data, &rawslots); err != nil {
+		return err
+	}
+
+	var keyslots tokenKeyslots
+	for _, v := range rawslots {
+		slot, err := v.Int()
+		if err != nil {
+			return xerrors.Errorf("invalid keyslot ID: %w", err)
+		}
+		keyslots = append(keyslots, slot)
+	}
+	*k = keyslots
+	return nil
+}
+
+type tokenBaseRaw struct {
+	Type     luks2.TokenType `json:"type"`
+	Keyslots tokenKeyslots   `json:"keyslots"`
+	Name     string          `json:"ubuntu_fde_name"`
+}
+
+type recoveryTokenRaw struct {
+	tokenBaseRaw
+}
+
+type keyDataTokenRaw struct {
+	tokenBaseRaw
+	Priority int             `json:"ubuntu_fde_priority"`
+	Data     json.RawMessage `json:"ubuntu_fde_data,omitempty"`
+}
+
+// TokenBase provides the fields that are common to all tokens created by secboot.
+type TokenBase struct {
+	TokenKeyslot int    // The ID of the keyslot associated with this token
+	TokenName    string // The name of the keyslot that this token is associated with
+}
+
+func (t *TokenBase) Keyslots() []int {
+	return []int{t.TokenKeyslot}
+}
+
+func (t *TokenBase) Name() string {
+	return t.TokenName
+}
+
+// RecoveryToken represents a token with the type "ubuntu-fde-recovery",
+// associated with a recovery keyslot
+type RecoveryToken struct {
+	TokenBase
+}
+
+func (t *RecoveryToken) Type() luks2.TokenType {
+	return RecoveryTokenType
+}
+
+func (t *RecoveryToken) MarshalJSON() ([]byte, error) {
+	raw := &recoveryTokenRaw{
+		tokenBaseRaw: tokenBaseRaw{
+			Type:     RecoveryTokenType,
+			Keyslots: tokenKeyslots{t.TokenKeyslot},
+			Name:     t.TokenName}}
+	return json.Marshal(raw)
+}
+
+func (t *RecoveryToken) UnmarshalJSON(data []byte) error {
+	var raw *recoveryTokenRaw
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	switch {
+	case raw.Name == "" || len(raw.Keyslots) > 1:
+		return errInvalidNamedToken
+	case len(raw.Keyslots) == 0:
+		// Cryptsetup removes the keyslot ID from associated tokens
+		// when the slot is deleted, so a token with no associated
+		// keyslots is orphaned.
+		return errOrphanedNamedToken
+	}
+
+	*t = RecoveryToken{
+		TokenBase: TokenBase{
+			TokenKeyslot: int(raw.Keyslots[0]),
+			TokenName:    raw.Name}}
+	return nil
+}
+
+// KeyDataToken represents a token with the "ubuntu-fde" type, associated
+// with a platform protected keyslot. It is created as a placeholder when
+// a keyslot is created, and then is subsequently updated to contain an
+// encoded KeyData.
+type KeyDataToken struct {
+	TokenBase
+
+	// Priority is the priority of the keyslot associated with
+	// this token. 0 is the default, with higher numbers indicating a
+	// higher priority. A negative priority means that the associated
+	// keyslot shouldn't be used unless requested explicitly by name.
+	Priority int
+
+	Data json.RawMessage // The raw KeyData JSON payload
+}
+
+func (t *KeyDataToken) Type() luks2.TokenType {
+	return KeyDataTokenType
+}
+
+func (t *KeyDataToken) MarshalJSON() ([]byte, error) {
+	raw := &keyDataTokenRaw{
+		tokenBaseRaw: tokenBaseRaw{
+			Type:     KeyDataTokenType,
+			Keyslots: tokenKeyslots{t.TokenKeyslot},
+			Name:     t.TokenName},
+		Priority: t.Priority,
+		Data:     t.Data}
+	return json.Marshal(raw)
+}
+
+func (t *KeyDataToken) UnmarshalJSON(data []byte) error {
+	var raw *keyDataTokenRaw
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	switch {
+	case raw.Name == "" || len(raw.Keyslots) > 1:
+		return errInvalidNamedToken
+	case len(raw.Keyslots) == 0:
+		// Cryptsetup removes the keyslot ID from associated tokens
+		// when the slot is deleted, so a token with no associated
+		// keyslots is orphaned.
+		return errOrphanedNamedToken
+	}
+
+	*t = KeyDataToken{
+		TokenBase: TokenBase{
+			TokenKeyslot: int(raw.Keyslots[0]),
+			TokenName:    raw.Name},
+		Priority: raw.Priority,
+		Data:     raw.Data}
+	return nil
+}
+
+type orphanedToken struct {
+	raw tokenBaseRaw
+}
+
+func (t *orphanedToken) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &t.raw)
+}
+
+func (t *orphanedToken) Type() luks2.TokenType {
+	return t.raw.Type
+}
+
+func (t *orphanedToken) Keyslots() []int {
+	return nil
+}
+
+func (t *orphanedToken) Name() string {
+	return t.raw.Name
+}
+
+// NewOrphanedTokenForTesting returns a new orphaned named token with the
+// supplied type and name, which is useful for testing.
+func NewOrphanedTokenForTesting(t luks2.TokenType, name string) NamedToken {
+	return &orphanedToken{
+		raw: tokenBaseRaw{
+			Type: t,
+			Name: name}}
+}

--- a/internal/luksview/tokens_test.go
+++ b/internal/luksview/tokens_test.go
@@ -1,0 +1,346 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luksview_test
+
+import (
+	"encoding/json"
+	"strconv"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luks2/luks2test"
+	. "github.com/snapcore/secboot/internal/luksview"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+type tokenSuite struct{}
+
+var _ = Suite(&tokenSuite{})
+
+func (s *tokenSuite) checkTokenBaseJSON(c *C, j map[string]interface{}, token *TokenBase, typ luks2.TokenType) {
+	t, ok := j["type"].(string)
+	c.Check(ok, testutil.IsTrue)
+	c.Check(t, Equals, string(typ))
+
+	keyslots, ok := j["keyslots"].([]interface{})
+	c.Check(ok, testutil.IsTrue)
+	for i, v := range keyslots {
+		slot, ok := v.(string)
+		c.Check(ok, testutil.IsTrue)
+		c.Check(slot, Equals, strconv.Itoa(token.Keyslots()[i]))
+	}
+
+	name, ok := j["ubuntu_fde_name"].(string)
+	c.Check(ok, testutil.IsTrue)
+	c.Check(name, Equals, token.Name())
+}
+
+func (s *tokenSuite) checkRecoveryTokenJSON(c *C, data []byte, token *RecoveryToken) {
+	var j map[string]interface{}
+	c.Assert(json.Unmarshal(data, &j), IsNil)
+
+	s.checkTokenBaseJSON(c, j, &token.TokenBase, RecoveryTokenType)
+}
+
+func (s *tokenSuite) TestMarshalRecoveryToken1(c *C) {
+	token := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "foo-recovery",
+			TokenKeyslot: 1}}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	s.checkRecoveryTokenJSON(c, data, token)
+}
+
+func (s *tokenSuite) TestMarshalRecoveryToken2(c *C) {
+	token := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "recovery-bar",
+			TokenKeyslot: 7}}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	s.checkRecoveryTokenJSON(c, data, token)
+}
+
+func (s *tokenSuite) TestUnmarshalRecoveryToken1(c *C) {
+	token := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "foo-recovery",
+			TokenKeyslot: 1}}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	var token2 *RecoveryToken
+	c.Check(json.Unmarshal(data, &token2), IsNil)
+	c.Check(token2, DeepEquals, token)
+}
+
+func (s *tokenSuite) TestUnmarshalRecoveryToken2(c *C) {
+	token := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "recovery-bar",
+			TokenKeyslot: 7}}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	var token2 *RecoveryToken
+	c.Check(json.Unmarshal(data, &token2), IsNil)
+	c.Check(token2, DeepEquals, token)
+}
+
+func (s *tokenSuite) TestDecodeRecoveryToken(c *C) {
+	if luks2.DetectCryptsetupFeatures()&luks2.FeatureTokenImport == 0 {
+		c.Skip("cryptsetup doesn't support token import")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.FormatOptions{KDFOptions: luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &options), IsNil)
+
+	createToken := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "recovery",
+			TokenKeyslot: 0}}
+	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
+
+	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	token, ok := header.Metadata.Tokens[0].(*RecoveryToken)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(token, DeepEquals, createToken)
+}
+
+func (s *tokenSuite) TestDecodeOrphanedRecoveryToken(c *C) {
+	if luks2.DetectCryptsetupFeatures()&luks2.FeatureTokenImport == 0 {
+		c.Skip("cryptsetup doesn't support token import")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.FormatOptions{KDFOptions: luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &options), IsNil)
+
+	createToken := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "recovery",
+			TokenKeyslot: 0}}
+	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
+	c.Check(luks2.KillSlot(path, 0, make([]byte, 32)), IsNil)
+
+	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	token, ok := header.Metadata.Tokens[0].(*OrphanedToken)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(token.Type(), Equals, RecoveryTokenType)
+	c.Check(token.Keyslots(), DeepEquals, []int(nil))
+	c.Check(token.Name(), Equals, "recovery")
+}
+
+func (s *tokenSuite) TestDecodeInvalidRecoveryToken(c *C) {
+	if luks2.DetectCryptsetupFeatures()&luks2.FeatureTokenImport == 0 {
+		c.Skip("cryptsetup doesn't support token import")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.FormatOptions{KDFOptions: luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &options), IsNil)
+
+	createToken := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenKeyslot: 0}}
+	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
+
+	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	token, ok := header.Metadata.Tokens[0].(*luks2.GenericToken)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(token, DeepEquals, &luks2.GenericToken{
+		TokenType:     RecoveryTokenType,
+		TokenKeyslots: []int{0},
+		Params: map[string]interface{}{
+			"ubuntu_fde_name": "",
+		},
+	})
+}
+func (s *tokenSuite) checkKeyDataTokenJSON(c *C, data []byte, token *KeyDataToken) {
+	var j map[string]interface{}
+	c.Assert(json.Unmarshal(data, &j), IsNil)
+
+	s.checkTokenBaseJSON(c, j, &token.TokenBase, KeyDataTokenType)
+
+	priority, ok := j["ubuntu_fde_priority"].(float64)
+	c.Check(ok, testutil.IsTrue)
+	c.Check(priority, Equals, float64(token.Priority))
+
+	if len(token.Data) == 0 {
+		c.Check(j, Not(testutil.HasKey), "ubuntu_fde_data")
+	} else {
+		var expectedData map[string]interface{}
+		c.Assert(json.Unmarshal(token.Data, &expectedData), IsNil)
+
+		d, ok := j["ubuntu_fde_data"]
+		c.Check(ok, testutil.IsTrue)
+		c.Check(d, DeepEquals, expectedData)
+	}
+}
+
+func (s *tokenSuite) TestMarshalKeyDataToken1(c *C) {
+	token := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "foo",
+			TokenKeyslot: 0}}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	s.checkKeyDataTokenJSON(c, data, token)
+}
+
+func (s *tokenSuite) TestMarshalKeyDataToken2(c *C) {
+	token := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "bar",
+			TokenKeyslot: 3},
+		Priority: 1,
+		Data:     json.RawMessage(`{"key1":"foo","key2":542}`)}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	s.checkKeyDataTokenJSON(c, data, token)
+}
+
+func (s *tokenSuite) TestUnmarshalKeyDataToken1(c *C) {
+	token := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "foo",
+			TokenKeyslot: 0}}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	var token2 *KeyDataToken
+	c.Check(json.Unmarshal(data, &token2), IsNil)
+	c.Check(token2, DeepEquals, token)
+}
+
+func (s *tokenSuite) TestUnmarshalKeyDataToken2(c *C) {
+	token := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "bar",
+			TokenKeyslot: 3},
+		Priority: 1,
+		Data:     json.RawMessage(`{"key1":"foo","key2":542}`)}
+	data, err := json.Marshal(token)
+	c.Check(err, IsNil)
+
+	var token2 *KeyDataToken
+	c.Check(json.Unmarshal(data, &token2), IsNil)
+	c.Check(token2, DeepEquals, token)
+	c.Logf("%s\n", token2.Data)
+}
+
+func (s *tokenSuite) TestDecodeKeyDataToken(c *C) {
+	if luks2.DetectCryptsetupFeatures()&luks2.FeatureTokenImport == 0 {
+		c.Skip("cryptsetup doesn't support token import")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.FormatOptions{KDFOptions: luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &options), IsNil)
+
+	createToken := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "bar",
+			TokenKeyslot: 0},
+		Priority: 1,
+		Data:     json.RawMessage(`{"key1":"foo","key2":542}`)}
+	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
+
+	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	token, ok := header.Metadata.Tokens[0].(*KeyDataToken)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(token, DeepEquals, createToken)
+}
+
+func (s *tokenSuite) TestDecodeOrphanedKeyDataToken(c *C) {
+	if luks2.DetectCryptsetupFeatures()&luks2.FeatureTokenImport == 0 {
+		c.Skip("cryptsetup doesn't support token import")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.FormatOptions{KDFOptions: luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &options), IsNil)
+
+	createToken := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "bar",
+			TokenKeyslot: 0}}
+	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
+	c.Check(luks2.KillSlot(path, 0, make([]byte, 32)), IsNil)
+
+	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	token, ok := header.Metadata.Tokens[0].(*OrphanedToken)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(token.Type(), Equals, KeyDataTokenType)
+	c.Check(token.Keyslots(), DeepEquals, []int(nil))
+	c.Check(token.Name(), Equals, "bar")
+}
+
+func (s *tokenSuite) TestDecodeInvalidKeyDataToken(c *C) {
+	if luks2.DetectCryptsetupFeatures()&luks2.FeatureTokenImport == 0 {
+		c.Skip("cryptsetup doesn't support token import")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.FormatOptions{KDFOptions: luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &options), IsNil)
+
+	createToken := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenKeyslot: 0}}
+	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
+
+	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	token, ok := header.Metadata.Tokens[0].(*luks2.GenericToken)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(token, DeepEquals, &luks2.GenericToken{
+		TokenType:     KeyDataTokenType,
+		TokenKeyslots: []int{0},
+		Params: map[string]interface{}{
+			"ubuntu_fde_name":     "",
+			"ubuntu_fde_priority": float64(0),
+		},
+	})
+}

--- a/internal/luksview/view.go
+++ b/internal/luksview/view.go
@@ -1,0 +1,197 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luksview
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/secboot/internal/luks2"
+)
+
+type namedTokenData struct {
+	id    int
+	token NamedToken
+}
+
+// HeaderSource provides a mechanism to obtain a LUKS2 header.
+type HeaderSource interface {
+	ReadHeader() (*luks2.HeaderInfo, error)
+}
+
+type defaultHeaderSource struct {
+	devicePath string
+	lockMode   luks2.LockMode
+}
+
+func (s *defaultHeaderSource) ReadHeader() (*luks2.HeaderInfo, error) {
+	return luks2.ReadHeader(s.devicePath, s.lockMode)
+}
+
+// View provides a read-only view of a LUKS2 header in a way that is useful
+// to secboot.
+type View struct {
+	source HeaderSource
+
+	hdr *luks2.HeaderInfo
+
+	// namedTokens contains a map of keyslot name to valid named tokens.
+	namedTokens map[string]namedTokenData
+}
+
+// NewView creates a new View from the LUKS2 container at the specified
+// path, using the specified locking mode.
+func NewView(devicePath string, lockMode luks2.LockMode) (*View, error) {
+	view := &View{source: &defaultHeaderSource{
+		devicePath: devicePath,
+		lockMode:   lockMode}}
+
+	if err := view.Refresh(); err != nil {
+		return nil, err
+	}
+
+	return view, nil
+}
+
+// NewViewFromCustomHeaderSource creates a new View from the LUKS2 header
+// obtained from the supplied source. This is useful for mocking the header
+// in unit tests.
+func NewViewFromCustomHeaderSource(source HeaderSource) (*View, error) {
+	view := &View{source: source}
+
+	if err := view.Refresh(); err != nil {
+		return nil, err
+	}
+
+	return view, nil
+}
+
+// Refresh updates this view from the source container.
+func (v *View) Refresh() error {
+	hdr, err := v.source.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	v.hdr = hdr
+	v.namedTokens = make(map[string]namedTokenData)
+
+	for id, token := range hdr.Metadata.Tokens {
+		named, ok := token.(NamedToken)
+		if !ok {
+			continue
+		}
+
+		if _, exists := v.namedTokens[named.Name()]; exists {
+			return fmt.Errorf("multiple tokens with the same name (%s)", named.Name())
+		}
+
+		v.namedTokens[named.Name()] = namedTokenData{id: id, token: named}
+	}
+
+	return nil
+}
+
+// ListNames returns a sorted list of all of the keyslot names from this view.
+func (v *View) ListNames() (names []string) {
+	for name, data := range v.namedTokens {
+		if _, orphaned := data.token.(*orphanedToken); orphaned {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TokenByName returns the token and its ID for the keyslot with the supplied name.
+func (v *View) TokenByName(name string) (token NamedToken, id int, exists bool) {
+	data, exists := v.namedTokens[name]
+	if !exists {
+		return nil, 0, false
+	}
+	if _, orphaned := data.token.(*orphanedToken); orphaned {
+		return nil, 0, false
+	}
+	return data.token, data.id, true
+}
+
+// KeyDataTokensByPriority returns all of the key data tokens in order of priority,
+// from highest to lowest. Tokens with the same priority are returned in the order in
+// which their names are sorted. This omits any with a priority of 0.
+func (v *View) KeyDataTokensByPriority() (tokens []*KeyDataToken) {
+	// Build a map of tokens by priority
+	tokensByPriority := make(map[int][]*KeyDataToken)
+	for _, name := range v.ListNames() {
+		t := v.namedTokens[name].token
+
+		if t.Type() != KeyDataTokenType {
+			continue
+		}
+
+		token := t.(*KeyDataToken)
+
+		if token.Priority < 0 {
+			// Priority -1 tokens are ignored unless called explicitly
+			// by name.
+			continue
+		}
+		tokensByPriority[token.Priority] = append(tokensByPriority[token.Priority], token)
+	}
+
+	// Create a list of priorites, sorted in reverse order (highest to lowest)
+	priorities := make([]int, 0, len(tokensByPriority))
+	for priority := range tokensByPriority {
+		priorities = append(priorities, priority)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(priorities)))
+
+	// Build the list of tokens in priority order (highest to lowest)
+	for _, priority := range priorities {
+		tokens = append(tokens, tokensByPriority[priority]...)
+	}
+
+	return tokens
+}
+
+// OrphanedTokenIds returns a list of ids for tokens that have been orphaned
+// and can be removed. Orphaned tokens are those where the associated keyslot
+// doesn't has been deleted and can occur if the process of removing a keyslot
+// and its tokens is interrupted.
+func (v *View) OrphanedTokenIds() (ids []int) {
+	for _, data := range v.namedTokens {
+		if _, orphaned := data.token.(*orphanedToken); !orphaned {
+			continue
+		}
+		ids = append(ids, data.id)
+	}
+
+	sort.Ints(ids)
+	return ids
+}
+
+// UsedKeyslots returns a list of ids for currently active keyslots.
+func (v *View) UsedKeyslots() (slots []int) {
+	for slot := range v.hdr.Metadata.Keyslots {
+		slots = append(slots, slot)
+	}
+	sort.Ints(slots)
+	return slots
+}

--- a/internal/luksview/view_test.go
+++ b/internal/luksview/view_test.go
@@ -1,0 +1,270 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luksview_test
+
+import (
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luks2/luks2test"
+	. "github.com/snapcore/secboot/internal/luksview"
+	"github.com/snapcore/secboot/internal/paths/pathstest"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+type viewSuite struct {
+	snapd_testutil.BaseTest
+}
+
+func (s *viewSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(pathstest.MockRunDir(c.MkDir()))
+	s.AddCleanup(luks2test.WrapCryptsetup(c))
+}
+
+var _ = Suite(&viewSuite{})
+
+type mockHeaderSource luks2.HeaderInfo
+
+func (s mockHeaderSource) ReadHeader() (*luks2.HeaderInfo, error) {
+	return (*luks2.HeaderInfo)(&s), nil
+}
+
+var testHeader = mockHeaderSource(luks2.HeaderInfo{
+	Metadata: luks2.Metadata{
+		Keyslots: map[int]*luks2.Keyslot{
+			0: new(luks2.Keyslot),
+			1: new(luks2.Keyslot),
+			2: new(luks2.Keyslot),
+			3: new(luks2.Keyslot),
+			4: new(luks2.Keyslot),
+			5: new(luks2.Keyslot)},
+		Tokens: map[int]luks2.Token{
+			0: &KeyDataToken{
+				TokenBase: TokenBase{
+					TokenKeyslot: 0,
+					TokenName:    "foo"},
+				Priority: 1},
+			1: &RecoveryToken{
+				TokenBase: TokenBase{
+					TokenKeyslot: 1,
+					TokenName:    "recovery"}},
+			2: &KeyDataToken{
+				TokenBase: TokenBase{
+					TokenKeyslot: 2,
+					TokenName:    "bar"}},
+			// Test that this token type is ignored.
+			3: &luks2.GenericToken{
+				TokenType:     "luks2-keyring",
+				TokenKeyslots: []int{3}},
+			// Add another token with the same priority as
+			// an existing one to check that the behaviour of
+			// TokensByPriority is well defined.
+			4: &KeyDataToken{
+				TokenBase: TokenBase{
+					TokenKeyslot: 4,
+					TokenName:    "abc"},
+				Priority: 1},
+			// Add a token with priority -1 to test that it
+			// is omitted from TokensByPriority.
+			5: &KeyDataToken{
+				TokenBase: TokenBase{
+					TokenKeyslot: 5,
+					TokenName:    "xyz"},
+				Priority: -1},
+			// Add a token without a corresponding keyslot
+			// to test OrphanedTokenIds, and to ensure that
+			// it is omitted from ListNames and TokenByName.
+			6: NewOrphanedTokenForTesting(KeyDataTokenType, "orphaned")}}})
+
+func (s *viewSuite) TestViewListNames(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+	c.Check(view.ListNames(), DeepEquals, []string{"abc", "bar", "foo", "recovery", "xyz"})
+}
+
+func (s *viewSuite) TestViewTokenByName1(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+
+	token, id, exists := view.TokenByName("foo")
+	c.Check(exists, testutil.IsTrue)
+	c.Check(token, DeepEquals, testHeader.Metadata.Tokens[0])
+	c.Check(id, Equals, 0)
+}
+
+func (s *viewSuite) TestViewTokenByName2(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+
+	token, id, exists := view.TokenByName("bar")
+	c.Check(exists, testutil.IsTrue)
+	c.Check(token, DeepEquals, testHeader.Metadata.Tokens[2])
+	c.Check(id, Equals, 2)
+}
+
+func (s *viewSuite) TestViewTokenByNameNonExistant(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+
+	token, _, exists := view.TokenByName("zzz")
+	c.Check(exists, Not(testutil.IsTrue))
+	c.Check(token, IsNil)
+}
+
+func (s *viewSuite) TestViewTokenByNameOrphaned(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+
+	token, _, exists := view.TokenByName("orphaned")
+	c.Check(exists, Not(testutil.IsTrue))
+	c.Check(token, IsNil)
+}
+
+func (s *viewSuite) TestViewKeyDataTokensByPriority(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+
+	tokens := view.KeyDataTokensByPriority()
+	c.Assert(tokens, HasLen, 3)
+	c.Check(tokens[0], DeepEquals, testHeader.Metadata.Tokens[4])
+	c.Check(tokens[1], DeepEquals, testHeader.Metadata.Tokens[0])
+	c.Check(tokens[2], DeepEquals, testHeader.Metadata.Tokens[2])
+}
+
+func (s *viewSuite) TestViewOrphanedTokenIds(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+	c.Check(view.OrphanedTokenIds(), DeepEquals, []int{6})
+}
+
+func (s *viewSuite) TestViewUsedKeyslots(c *C) {
+	view, err := NewViewFromCustomHeaderSource(testHeader)
+	c.Assert(err, IsNil)
+	c.Check(view.UsedKeyslots(), DeepEquals, []int{0, 1, 2, 3, 4, 5})
+}
+
+func (s *viewSuite) TestNewView(c *C) {
+	if luks2.DetectCryptsetupFeatures()&luks2.FeatureTokenImport == 0 {
+		c.Skip("cryptsetup doesn't support token import")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.FormatOptions{KDFOptions: luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &options), IsNil)
+
+	token := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "default",
+			TokenKeyslot: 0},
+		Priority: 1}
+	c.Check(luks2.ImportToken(path, token, nil), IsNil)
+
+	recoveryToken := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "recovery",
+			TokenKeyslot: 0}}
+	c.Check(luks2.ImportToken(path, recoveryToken, nil), IsNil)
+
+	view, err := NewView(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	c.Check(view.ListNames(), DeepEquals, []string{"default", "recovery"})
+
+	t, id, exists := view.TokenByName("default")
+	c.Check(t, DeepEquals, token)
+	c.Check(id, Equals, 0)
+	c.Check(exists, testutil.IsTrue)
+
+	t, id, exists = view.TokenByName("recovery")
+	c.Check(t, DeepEquals, recoveryToken)
+	c.Check(id, Equals, 1)
+	c.Check(exists, testutil.IsTrue)
+
+	c.Check(view.UsedKeyslots(), DeepEquals, []int{0})
+}
+
+func (s *viewSuite) TestViewRefresh(c *C) {
+	if luks2.DetectCryptsetupFeatures()&(luks2.FeatureTokenImport|luks2.FeatureTokenReplace) != (luks2.FeatureTokenImport | luks2.FeatureTokenReplace) {
+		c.Skip("cryptsetup doesn't support token import or replace")
+	}
+
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	options := luks2.KDFOptions{MemoryKiB: 32, ForceIterations: 4}
+	c.Check(luks2.Format(path, "", make([]byte, 32), &luks2.FormatOptions{KDFOptions: options}), IsNil)
+
+	token := &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "default",
+			TokenKeyslot: 0},
+		Priority: 1}
+	c.Check(luks2.ImportToken(path, token, nil), IsNil)
+
+	view, err := NewView(path, luks2.LockModeNonBlocking)
+	c.Assert(err, IsNil)
+
+	c.Check(view.ListNames(), DeepEquals, []string{"default"})
+
+	token = &KeyDataToken{
+		TokenBase: TokenBase{
+			TokenName:    "default",
+			TokenKeyslot: 0},
+		Priority: 2}
+	c.Check(luks2.ImportToken(path, token, &luks2.ImportTokenOptions{Replace: true, Id: 0}), IsNil)
+
+	c.Check(luks2.AddKey(path, make([]byte, 32), make([]byte, 32), &luks2.AddKeyOptions{KDFOptions: options, Slot: luks2.AnySlot}), IsNil)
+	recoveryToken := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "recovery",
+			TokenKeyslot: 1}}
+	c.Check(luks2.ImportToken(path, recoveryToken, nil), IsNil)
+
+	c.Check(luks2.AddKey(path, make([]byte, 32), make([]byte, 32), &luks2.AddKeyOptions{KDFOptions: options, Slot: luks2.AnySlot}), IsNil)
+	token2 := &RecoveryToken{
+		TokenBase: TokenBase{
+			TokenName:    "foo",
+			TokenKeyslot: 2}}
+	c.Check(luks2.ImportToken(path, token2, nil), IsNil)
+	c.Check(luks2.KillSlot(path, 2, make([]byte, 32)), IsNil)
+
+	c.Check(view.Refresh(), IsNil)
+
+	t, id, exists := view.TokenByName("default")
+	c.Check(t, DeepEquals, token)
+	c.Check(id, Equals, 0)
+	c.Check(exists, testutil.IsTrue)
+
+	t, id, exists = view.TokenByName("recovery")
+	c.Check(t, DeepEquals, recoveryToken)
+	c.Check(id, Equals, 1)
+	c.Check(exists, testutil.IsTrue)
+
+	t, id, exists = view.TokenByName("foo")
+	c.Check(t, IsNil)
+	c.Check(id, Equals, 0)
+	c.Check(exists, Not(testutil.IsTrue))
+
+	c.Check(view.UsedKeyslots(), DeepEquals, []int{0, 1})
+	c.Check(view.OrphanedTokenIds(), DeepEquals, []int{2})
+}

--- a/internal/luksview/view_test.go
+++ b/internal/luksview/view_test.go
@@ -93,13 +93,13 @@ var testHeader = mockHeaderSource(luks2.HeaderInfo{
 				Priority: -1},
 			// Add a token without a corresponding keyslot
 			// to test OrphanedTokenIds, and to ensure that
-			// it is omitted from ListNames and TokenByName.
-			6: NewOrphanedTokenForTesting(KeyDataTokenType, "orphaned")}}})
+			// it is omitted from TokenNames and TokenByName.
+			6: MockOrphanedToken(KeyDataTokenType, "orphaned")}}})
 
-func (s *viewSuite) TestViewListNames(c *C) {
+func (s *viewSuite) TestViewTokenNames(c *C) {
 	view, err := NewViewFromCustomHeaderSource(testHeader)
 	c.Assert(err, IsNil)
-	c.Check(view.ListNames(), DeepEquals, []string{"abc", "bar", "foo", "recovery", "xyz"})
+	c.Check(view.TokenNames(), DeepEquals, []string{"abc", "bar", "foo", "recovery", "xyz"})
 }
 
 func (s *viewSuite) TestViewTokenByName1(c *C) {
@@ -189,7 +189,7 @@ func (s *viewSuite) TestNewView(c *C) {
 	view, err := NewView(path, luks2.LockModeNonBlocking)
 	c.Assert(err, IsNil)
 
-	c.Check(view.ListNames(), DeepEquals, []string{"default", "recovery"})
+	c.Check(view.TokenNames(), DeepEquals, []string{"default", "recovery"})
 
 	t, id, exists := view.TokenByName("default")
 	c.Check(t, DeepEquals, token)
@@ -204,7 +204,7 @@ func (s *viewSuite) TestNewView(c *C) {
 	c.Check(view.UsedKeyslots(), DeepEquals, []int{0})
 }
 
-func (s *viewSuite) TestViewRefresh(c *C) {
+func (s *viewSuite) TestViewReread(c *C) {
 	if luks2.DetectCryptsetupFeatures()&(luks2.FeatureTokenImport|luks2.FeatureTokenReplace) != (luks2.FeatureTokenImport | luks2.FeatureTokenReplace) {
 		c.Skip("cryptsetup doesn't support token import or replace")
 	}
@@ -224,7 +224,7 @@ func (s *viewSuite) TestViewRefresh(c *C) {
 	view, err := NewView(path, luks2.LockModeNonBlocking)
 	c.Assert(err, IsNil)
 
-	c.Check(view.ListNames(), DeepEquals, []string{"default"})
+	c.Check(view.TokenNames(), DeepEquals, []string{"default"})
 
 	token = &KeyDataToken{
 		TokenBase: TokenBase{
@@ -248,7 +248,7 @@ func (s *viewSuite) TestViewRefresh(c *C) {
 	c.Check(luks2.ImportToken(path, token2, nil), IsNil)
 	c.Check(luks2.KillSlot(path, 2, make([]byte, 32)), IsNil)
 
-	c.Check(view.Refresh(), IsNil)
+	c.Check(view.Reread(), IsNil)
 
 	t, id, exists := view.TokenByName("default")
 	c.Check(t, DeepEquals, token)

--- a/internal/luksview/view_test.go
+++ b/internal/luksview/view_test.go
@@ -94,7 +94,10 @@ var testHeader = mockHeaderSource(luks2.HeaderInfo{
 			// Add a token without a corresponding keyslot
 			// to test OrphanedTokenIds, and to ensure that
 			// it is omitted from TokenNames and TokenByName.
-			6: MockOrphanedToken(KeyDataTokenType, "orphaned")}}})
+			6: MockOrphanedToken(KeyDataTokenType, "orphaned"),
+			// Test that an orphaned token can't own a name used
+			// by a valid token.
+			7: MockOrphanedToken(KeyDataTokenType, "foo")}}})
 
 func (s *viewSuite) TestViewTokenNames(c *C) {
 	view, err := NewViewFromCustomHeaderSource(testHeader)
@@ -154,7 +157,7 @@ func (s *viewSuite) TestViewKeyDataTokensByPriority(c *C) {
 func (s *viewSuite) TestViewOrphanedTokenIds(c *C) {
 	view, err := NewViewFromCustomHeaderSource(testHeader)
 	c.Assert(err, IsNil)
-	c.Check(view.OrphanedTokenIds(), DeepEquals, []int{6})
+	c.Check(view.OrphanedTokenIds(), DeepEquals, []int{6, 7})
 }
 
 func (s *viewSuite) TestViewUsedKeyslots(c *C) {


### PR DESCRIPTION
This adds a new package containing a view of the LUKS2 metadata
in a way that is most useful to secboot.

It also contains a representation of tokens that will be used by
secboot. Each token has a name, which is an arbitrary string used to
identify its associated keyslot. The name is intended to be unique
between keyslots and secboot will enforce this. All tokens created by
secboot will have a name and will be associated with one keyslot.

Tokens without a name or which are associated by more than one keyslot
are ignored by the View API.

For context, here's some notes about how the View API is intended to be
used:
- View.TokenByName returns the token for the keyslot with the
supplied name, and is intended to be used when performing changes to
the slot (eg, updating the PCR policy in the TPM case or deleting the
slot).
- View.KeyDataTokensByPriority returns a list of key data tokens
in priority order, and is intended to be used internally by the
ActivateVolumeWithKeyData API. There is no priority for recovery slots
as it doesn't make sense - attempting each slot in a defined order
rather than letting cryptsetup pick the order would require repeated
execution of the KDF if more than one recovery keyslot is defined.
- View.OrphanedTokenIds returns a list of IDs associated with
tokens that have been orphaned (ie, their associated keyslot has been
deleted), and can occur if the process of deleting a keyslot and its
associated token is interrupted. This can be used to resume an
interrupted removal.
- View.UsedKeyslots returns a list of the currently used keyslot IDs.
This will be used by secboot to manually pick an ID for new keyslots
rather than letting cryptsetup handle it, as this makes it easier to
subsequently create a token associated with it.