### PR TITLE
Add KeyDataReader and KeyDataWriter implementations for LUKS

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -574,8 +574,8 @@ func (o *InitializeLUKS2ContainerOptions) formatOpts() *luks2.FormatOptions {
 // InitialKeyslotName field of options. If this is empty, "default" will be used.
 //
 // The initial key should be protected by some platform-specific mechanism in order
-// to create a KeyData object. XXX(chrisccoulson): Add documentation about how to
-// write KeyData to the new slot once a PR lands with that API.
+// to create a KeyData object. The KeyData object can be saved to the
+// keyslot using LUKS2KeyDataWriter.
 //
 // On failure, this will return an error containing the output of the cryptsetup command.
 //
@@ -744,8 +744,8 @@ func listLUKS2ContainerKeyNames(devicePath string, tokenType luks2.TokenType) ([
 // In order to perform this action, an existing key must be supplied.
 //
 // The new key should be protected by some platform-specific mechanism in
-// order to create a KeyData object. XXX(chrisccoulson): Add documentation about
-// how to write KeyData to the new slot once a PR lands with that API.
+// order to create a KeyData object. The KeyData object can be saved to the
+// keyslot using LUKS2KeyDataWriter.
 func AddLUKS2ContainerUnlockKey(devicePath, keyslotName string, existingKey, newKey DiskUnlockKey, options *KDFOptions) error {
 	if len(newKey) < 32 {
 		return fmt.Errorf("expected a key length of at least 256-bits (got %d)", len(newKey)*8)

--- a/keydata_luks.go
+++ b/keydata_luks.go
@@ -1,0 +1,136 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"bytes"
+	"errors"
+
+	"golang.org/x/xerrors"
+
+	"github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luksview"
+)
+
+// LUKS2KeyDataReader provides a mechanism to read a KeyData from a LUKS2 token.
+type LUKS2KeyDataReader struct {
+	name     string
+	slot     int
+	priority int
+	*bytes.Reader
+}
+
+func (r *LUKS2KeyDataReader) ReadableName() string {
+	return r.name
+}
+
+// KeyslotID indicates the keyslot ID associated with the token from which this
+// KeyData is read.
+func (r *LUKS2KeyDataReader) KeyslotID() int {
+	return r.slot
+}
+
+// Priority indicates the priority of the keyslot associated with the token from
+// which this KeyData is read. The default priority is 0 with higher numbers
+// indicating a higher priority.
+func (r *LUKS2KeyDataReader) Priority() int {
+	return r.priority
+}
+
+// NewLUKS2KeyDataReader is used to read a LUKS2 token containing key data with
+// the specified name on the specified LUKS2 container.
+func NewLUKS2KeyDataReader(devicePath, name string) (*LUKS2KeyDataReader, error) {
+	view, err := newLUKSView(devicePath, luks2.LockModeBlocking)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot obtain LUKS2 header view: %w", err)
+	}
+
+	token, _, exists := view.TokenByName(name)
+	if !exists {
+		return nil, errors.New("a keyslot with the specified name does not exist")
+	}
+
+	kdToken, ok := token.(*luksview.KeyDataToken)
+	if !ok {
+		return nil, errors.New("named keyslot is the wrong type")
+	}
+
+	if kdToken.Data == nil {
+		return nil, errors.New("named keyslot does not contain key data yet")
+	}
+
+	return &LUKS2KeyDataReader{
+		name:     devicePath + ":" + name,
+		slot:     token.Keyslots()[0],
+		priority: kdToken.Priority,
+		Reader:   bytes.NewReader(kdToken.Data)}, nil
+}
+
+// LUKS2KeyDataWriter provides a mechanism to write a KeyData to a LUKS2 token.
+type LUKS2KeyDataWriter struct {
+	devicePath string
+	id         int
+	slot       int
+	name       string
+	priority   int
+	*bytes.Buffer
+}
+
+func (w *LUKS2KeyDataWriter) Commit() error {
+	token := &luksview.KeyDataToken{
+		TokenBase: luksview.TokenBase{
+			TokenKeyslot: w.slot,
+			TokenName:    w.name},
+		Priority: w.priority,
+		Data:     w.Bytes()}
+
+	return luks2ImportToken(w.devicePath, token, &luks2.ImportTokenOptions{Id: w.id, Replace: true})
+}
+
+// NewLUKS2KeyDataWriter creates a new LUKS2KeyDataWriter for atomically writing a
+// KeyData to a LUKS2 token with the specicied name and priority on the specified
+// LUKS2 container.
+//
+// The container must already contain a token of the correct type with the supplied
+// name. The initial token is bootstrapped by InitializeLUKS2Container or
+// SetLUKS2ContainerUnlockKey.
+func NewLUKS2KeyDataWriter(devicePath, name string, priority int) (*LUKS2KeyDataWriter, error) {
+	view, err := newLUKSView(devicePath, luks2.LockModeBlocking)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot obtain LUKS2 header view: %w", err)
+	}
+
+	token, id, exists := view.TokenByName(name)
+	if !exists {
+		return nil, errors.New("a keyslot with the specified name does not exist")
+	}
+
+	if token.Type() != luksview.KeyDataTokenType {
+		return nil, errors.New("named keyslot has the wrong type")
+	}
+
+	return &LUKS2KeyDataWriter{
+		devicePath: devicePath,
+		id:         id,
+		slot:       token.Keyslots()[0],
+		name:       name,
+		priority:   priority,
+		Buffer:     new(bytes.Buffer)}, nil
+}

--- a/keydata_luks.go
+++ b/keydata_luks.go
@@ -37,23 +37,6 @@ type LUKS2KeyDataReader struct {
 	*bytes.Reader
 }
 
-func (r *LUKS2KeyDataReader) ReadableName() string {
-	return r.name
-}
-
-// KeyslotID indicates the keyslot ID associated with the token from which this
-// KeyData is read.
-func (r *LUKS2KeyDataReader) KeyslotID() int {
-	return r.slot
-}
-
-// Priority indicates the priority of the keyslot associated with the token from
-// which this KeyData is read. The default priority is 0 with higher numbers
-// indicating a higher priority.
-func (r *LUKS2KeyDataReader) Priority() int {
-	return r.priority
-}
-
 // NewLUKS2KeyDataReader is used to read a LUKS2 token containing key data with
 // the specified name on the specified LUKS2 container.
 func NewLUKS2KeyDataReader(devicePath, name string) (*LUKS2KeyDataReader, error) {
@@ -83,6 +66,23 @@ func NewLUKS2KeyDataReader(devicePath, name string) (*LUKS2KeyDataReader, error)
 		Reader:   bytes.NewReader(kdToken.Data)}, nil
 }
 
+func (r *LUKS2KeyDataReader) ReadableName() string {
+	return r.name
+}
+
+// KeyslotID indicates the keyslot ID associated with the token from which this
+// KeyData is read.
+func (r *LUKS2KeyDataReader) KeyslotID() int {
+	return r.slot
+}
+
+// Priority indicates the priority of the keyslot associated with the token from
+// which this KeyData is read. The default priority is 0 with higher numbers
+// indicating a higher priority.
+func (r *LUKS2KeyDataReader) Priority() int {
+	return r.priority
+}
+
 // LUKS2KeyDataWriter provides a mechanism to write a KeyData to a LUKS2 token.
 type LUKS2KeyDataWriter struct {
 	devicePath string
@@ -91,17 +91,6 @@ type LUKS2KeyDataWriter struct {
 	name       string
 	priority   int
 	*bytes.Buffer
-}
-
-func (w *LUKS2KeyDataWriter) Commit() error {
-	token := &luksview.KeyDataToken{
-		TokenBase: luksview.TokenBase{
-			TokenKeyslot: w.slot,
-			TokenName:    w.name},
-		Priority: w.priority,
-		Data:     w.Bytes()}
-
-	return luks2ImportToken(w.devicePath, token, &luks2.ImportTokenOptions{Id: w.id, Replace: true})
 }
 
 // NewLUKS2KeyDataWriter creates a new LUKS2KeyDataWriter for atomically writing a
@@ -133,4 +122,15 @@ func NewLUKS2KeyDataWriter(devicePath, name string, priority int) (*LUKS2KeyData
 		name:       name,
 		priority:   priority,
 		Buffer:     new(bytes.Buffer)}, nil
+}
+
+func (w *LUKS2KeyDataWriter) Commit() error {
+	token := &luksview.KeyDataToken{
+		TokenBase: luksview.TokenBase{
+			TokenKeyslot: w.slot,
+			TokenName:    w.name},
+		Priority: w.priority,
+		Data:     w.Bytes()}
+
+	return luks2ImportToken(w.devicePath, token, &luks2.ImportTokenOptions{Id: w.id, Replace: true})
 }

--- a/keydata_luks.go
+++ b/keydata_luks.go
@@ -52,7 +52,7 @@ func NewLUKS2KeyDataReader(devicePath, name string) (*LUKS2KeyDataReader, error)
 
 	kdToken, ok := token.(*luksview.KeyDataToken)
 	if !ok {
-		return nil, errors.New("named keyslot is the wrong type")
+		return nil, errors.New("named keyslot has the wrong type")
 	}
 
 	if kdToken.Data == nil {

--- a/keydata_luks_test.go
+++ b/keydata_luks_test.go
@@ -1,0 +1,391 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"crypto"
+	"encoding/json"
+	"fmt"
+
+	snapd_testutil "github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/luks2"
+	"github.com/snapcore/secboot/internal/luks2/luks2test"
+	"github.com/snapcore/secboot/internal/luksview"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+type keyDataLuksSuite struct {
+	snapd_testutil.BaseTest
+	keyDataTestBase
+
+	luks2 *mockLUKS2
+}
+
+func (s *keyDataLuksSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.keyDataTestBase.SetUpTest(c)
+
+	s.luks2 = &mockLUKS2{
+		devices:   make(map[string]*mockLUKS2Container),
+		activated: make(map[string]string)}
+	s.AddCleanup(s.luks2.enableMocks())
+}
+
+var _ = Suite(&keyDataLuksSuite{})
+
+func (s *keyDataLuksSuite) checkKeyDataJSONFromLUKSToken(c *C, path string, id int, keyslot int, name string, priority int, creationData *KeyCreationData, nmodels int) {
+	t, exists := s.luks2.devices[path].tokens[id]
+	c.Assert(exists, testutil.IsTrue)
+
+	data, err := json.Marshal(t)
+	c.Check(err, IsNil)
+
+	var token *luks2.GenericToken
+	c.Check(json.Unmarshal(data, &token), IsNil)
+
+	c.Check(token.Type(), Equals, luksview.KeyDataTokenType)
+	c.Check(token.Keyslots(), DeepEquals, []int{keyslot})
+
+	str, ok := token.Params["ubuntu_fde_name"].(string)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(str, Equals, name)
+
+	n, ok := token.Params["ubuntu_fde_priority"].(float64)
+	c.Assert(ok, testutil.IsTrue)
+	c.Check(n, Equals, float64(priority))
+
+	keyData, ok := token.Params["ubuntu_fde_data"].(map[string]interface{})
+	c.Assert(ok, testutil.IsTrue)
+
+	s.checkKeyDataJSONDecodedAuthModeNone(c, keyData, creationData, nmodels)
+}
+
+type testKeyDataLuksWriterData struct {
+	id       int
+	path     string
+	name     string
+	slot     int
+	priority int
+}
+
+func (s *keyDataLuksSuite) testWriter(c *C, data *testKeyDataLuksWriterData) {
+	key, auxKey := s.newKeyDataKeys(c, 32, 32)
+
+	s.luks2.devices[data.path] = &mockLUKS2Container{
+		tokens: map[int]luks2.Token{
+			data.id: &luksview.KeyDataToken{
+				TokenBase: luksview.TokenBase{
+					TokenName:    data.name,
+					TokenKeyslot: data.slot}},
+		},
+		keyslots: map[int][]byte{data.slot: key}}
+
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	w, err := NewLUKS2KeyDataWriter(data.path, data.name, data.priority)
+	c.Assert(err, IsNil)
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	c.Check(s.luks2.operations, DeepEquals, []string{
+		"newLUKSView(" + data.path + ",0)",
+		fmt.Sprint("ImportToken(", data.path, ",", &luks2.ImportTokenOptions{Id: data.id, Replace: true}, ")"),
+	})
+
+	s.checkKeyDataJSONFromLUKSToken(c, data.path, data.id, data.slot, data.name, data.priority, protected, 0)
+}
+
+func (s *keyDataLuksSuite) TestWriter(c *C) {
+	s.testWriter(c, &testKeyDataLuksWriterData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestWriterDifferentId(c *C) {
+	s.testWriter(c, &testKeyDataLuksWriterData{
+		id:       2,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestWriterDifferentPath(c *C) {
+	s.testWriter(c, &testKeyDataLuksWriterData{
+		id:       0,
+		path:     "/dev/nvme0n1p1",
+		name:     "foo",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestWriterDifferentName(c *C) {
+	s.testWriter(c, &testKeyDataLuksWriterData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "bar",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestWriterDifferentSlot(c *C) {
+	s.testWriter(c, &testKeyDataLuksWriterData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     6,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestWriterDifferentPriority(c *C) {
+	s.testWriter(c, &testKeyDataLuksWriterData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     0,
+		priority: 5,
+	})
+}
+
+func (s *keyDataLuksSuite) TestWriterTokenNotExist(c *C) {
+	s.luks2.devices["/dev/sda1"] = &mockLUKS2Container{
+		tokens:   make(map[int]luks2.Token),
+		keyslots: map[int][]byte{0: nil}}
+	w, err := NewLUKS2KeyDataWriter("/dev/sda1", "foo", 0)
+	c.Assert(w, IsNil)
+	c.Check(err, ErrorMatches, "a keyslot with the specified name does not exist")
+}
+
+func (s *keyDataLuksSuite) TestWriterTokenWrongType(c *C) {
+	s.luks2.devices["/dev/sda1"] = &mockLUKS2Container{
+		tokens: map[int]luks2.Token{
+			0: &luksview.RecoveryToken{
+				TokenBase: luksview.TokenBase{
+					TokenName:    "foo",
+					TokenKeyslot: 0}},
+		},
+		keyslots: map[int][]byte{0: nil}}
+
+	w, err := NewLUKS2KeyDataWriter("/dev/sda1", "foo", 0)
+	c.Assert(w, IsNil)
+	c.Check(err, ErrorMatches, "named keyslot has the wrong type")
+}
+
+type testKeyDataLuksReaderData struct {
+	id       int
+	path     string
+	name     string
+	slot     int
+	priority int
+}
+
+func (s *keyDataLuksSuite) testReader(c *C, data *testKeyDataLuksReaderData) {
+	key, auxKey := s.newKeyDataKeys(c, 32, 32)
+
+	s.luks2.devices[data.path] = &mockLUKS2Container{
+		tokens: map[int]luks2.Token{
+			data.id: &luksview.KeyDataToken{
+				TokenBase: luksview.TokenBase{
+					TokenKeyslot: data.slot,
+					TokenName:    data.name}},
+		},
+		keyslots: map[int][]byte{data.slot: key}}
+
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	models := []SnapModel{
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+
+	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
+
+	expectedId, err := keyData.UniqueID()
+	c.Check(err, IsNil)
+
+	w, err := NewLUKS2KeyDataWriter(data.path, data.name, data.priority)
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	s.luks2.operations = nil
+
+	r, err := NewLUKS2KeyDataReader(data.path, data.name)
+	c.Assert(err, IsNil)
+
+	c.Check(s.luks2.operations, DeepEquals, []string{"newLUKSView(" + data.path + ",0)"})
+
+	c.Check(r.ReadableName(), Equals, data.path+":"+data.name)
+	c.Check(r.KeyslotID(), Equals, data.slot)
+	c.Check(r.Priority(), Equals, data.priority)
+
+	keyData, err = ReadKeyData(r)
+	c.Assert(err, IsNil)
+	c.Check(keyData.ReadableName(), Equals, data.path+":"+data.name)
+
+	id, err := keyData.UniqueID()
+	c.Check(err, IsNil)
+	c.Check(id, DeepEquals, expectedId)
+
+	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(recoveredKey, DeepEquals, key)
+	c.Check(recoveredAuxKey, DeepEquals, auxKey)
+
+	authorized, err := keyData.IsSnapModelAuthorized(recoveredAuxKey, models[0])
+	c.Check(err, IsNil)
+	c.Check(authorized, testutil.IsTrue)
+}
+
+func (s *keyDataLuksSuite) TestReader(c *C) {
+	s.testReader(c, &testKeyDataLuksReaderData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestReaderDifferentPath(c *C) {
+	s.testReader(c, &testKeyDataLuksReaderData{
+		id:       0,
+		path:     "/dev/vdc2",
+		name:     "foo",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestReaderDifferentName(c *C) {
+	s.testReader(c, &testKeyDataLuksReaderData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "bar",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestReaderDifferentSlot(c *C) {
+	s.testReader(c, &testKeyDataLuksReaderData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     5,
+		priority: 1,
+	})
+}
+
+func (s *keyDataLuksSuite) TestReaderDifferentPriority(c *C) {
+	s.testReader(c, &testKeyDataLuksReaderData{
+		id:       0,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     0,
+		priority: 10,
+	})
+}
+
+func (s *keyDataLuksSuite) TestReaderDifferentTokenId(c *C) {
+	s.testReader(c, &testKeyDataLuksReaderData{
+		id:       4,
+		path:     "/dev/sda1",
+		name:     "foo",
+		slot:     0,
+		priority: 1,
+	})
+}
+
+type keyDataLuksUnmockedSuite struct {
+	keyDataTestBase
+}
+
+func (s *keyDataLuksUnmockedSuite) SetUpSuite(c *C) {
+	if luks2.DetectCryptsetupFeatures()&(luks2.FeatureTokenImport|luks2.FeatureTokenReplace) != luks2.FeatureTokenImport|luks2.FeatureTokenReplace {
+		c.Skip("cryptsetup doesn't support token import and replace")
+	}
+	s.keyDataTestBase.SetUpSuite(c)
+}
+
+var _ = Suite(&keyDataLuksUnmockedSuite{})
+
+func (s *keyDataLuksUnmockedSuite) TestReaderAndWriter(c *C) {
+	path := luks2test.CreateEmptyDiskImage(c, 20)
+
+	key, auxKey := s.newKeyDataKeys(c, 32, 32)
+	c.Check(InitializeLUKS2Container(path, "", key, nil), IsNil)
+
+	protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
+
+	keyData, err := NewKeyData(protected)
+	c.Assert(err, IsNil)
+
+	expectedId, err := keyData.UniqueID()
+	c.Check(err, IsNil)
+
+	w, err := NewLUKS2KeyDataWriter(path, "default", 1)
+	c.Assert(err, IsNil)
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	r, err := NewLUKS2KeyDataReader(path, "default")
+	c.Assert(err, IsNil)
+
+	c.Check(r.ReadableName(), Equals, path+":default")
+	c.Check(r.KeyslotID(), Equals, 0)
+	c.Check(r.Priority(), Equals, 1)
+
+	keyData, err = ReadKeyData(r)
+	c.Assert(err, IsNil)
+	c.Check(keyData.ReadableName(), Equals, path+":default")
+
+	id, err := keyData.UniqueID()
+	c.Check(err, IsNil)
+	c.Check(id, DeepEquals, expectedId)
+
+	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(recoveredKey, DeepEquals, key)
+	c.Check(recoveredAuxKey, DeepEquals, auxKey)
+}

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -325,12 +325,7 @@ func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{},
 	}
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Reader, creationData *KeyCreationData, nmodels int) {
-	var j map[string]interface{}
-
-	d := json.NewDecoder(r)
-	c.Check(d.Decode(&j), IsNil)
-
+func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModeNone(c *C, j map[string]interface{}, creationData *KeyCreationData, nmodels int) {
 	s.checkKeyDataJSONCommon(c, j, creationData, nmodels)
 
 	str, ok := j["encrypted_payload"].(string)
@@ -342,7 +337,16 @@ func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Read
 	c.Check(j, Not(testutil.HasKey), "passphrase_protected_payload")
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r io.Reader, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Reader, creationData *KeyCreationData, nmodels int) {
+	var j map[string]interface{}
+
+	d := json.NewDecoder(r)
+	c.Check(d.Decode(&j), IsNil)
+
+	s.checkKeyDataJSONDecodedAuthModeNone(c, j, creationData, nmodels)
+}
+
+func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[string]interface{}, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
 	if kdfOpts == nil {
 		var def KDFOptions
 		kdfOpts = &def
@@ -351,11 +355,6 @@ func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r i
 
 	costParams, err := kdfOpts.DeriveCostParams(0, &kdf)
 	c.Assert(err, IsNil)
-
-	var j map[string]interface{}
-
-	d := json.NewDecoder(r)
-	c.Check(d.Decode(&j), IsNil)
 
 	s.checkKeyDataJSONCommon(c, j, creationData, nmodels)
 
@@ -411,18 +410,13 @@ func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r i
 	c.Check(payload, DeepEquals, creationData.EncryptedPayload)
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONAuthModeNone(c *C, keyData *KeyData, creationData *KeyCreationData, nmodels int) {
-	w := makeMockKeyDataWriter()
-	c.Check(keyData.WriteAtomic(w), IsNil)
+func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r io.Reader, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+	var j map[string]interface{}
 
-	s.checkKeyDataJSONFromReaderAuthModeNone(c, w.Reader(), creationData, nmodels)
-}
+	d := json.NewDecoder(r)
+	c.Check(d.Decode(&j), IsNil)
 
-func (s *keyDataTestBase) checkKeyDataJSONAuthModePassphrase(c *C, keyData *KeyData, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
-	w := makeMockKeyDataWriter()
-	c.Check(keyData.WriteAtomic(w), IsNil)
-
-	s.checkKeyDataJSONFromReaderAuthModePassphrase(c, w.Reader(), creationData, nmodels, passphrase, kdfOpts)
+	s.checkKeyDataJSONDecodedAuthModePassphrase(c, j, creationData, nmodels, passphrase, kdfOpts)
 }
 
 type keyDataSuite struct {
@@ -430,6 +424,20 @@ type keyDataSuite struct {
 }
 
 var _ = Suite(&keyDataSuite{})
+
+func (s *keyDataSuite) checkKeyDataJSONAuthModeNone(c *C, keyData *KeyData, creationData *KeyCreationData, nmodels int) {
+	w := makeMockKeyDataWriter()
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	s.checkKeyDataJSONFromReaderAuthModeNone(c, w.Reader(), creationData, nmodels)
+}
+
+func (s *keyDataSuite) checkKeyDataJSONAuthModePassphrase(c *C, keyData *KeyData, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+	w := makeMockKeyDataWriter()
+	c.Check(keyData.WriteAtomic(w), IsNil)
+
+	s.checkKeyDataJSONFromReaderAuthModePassphrase(c, w.Reader(), creationData, nmodels, passphrase, kdfOpts)
+}
 
 type testKeyPayloadData struct {
 	key    DiskUnlockKey


### PR DESCRIPTION
This adds support for reading and writing KeyData objects to the LUKS
header. A follow up PR will add support for making use of these during
activation.