### PR TITLE
tpm2: use DiskUnlockKey and AuxiliaryKey types

### DIFF
--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -36,6 +36,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/tpm2test"
 	secboot_tpm2 "github.com/snapcore/secboot/tpm2"
 )
@@ -156,9 +157,9 @@ func (s *compatTestSuiteBase) testUnsealCommon(c *C) {
 
 	expectedKey, err := ioutil.ReadFile(s.absPath("clearKey"))
 	c.Assert(err, IsNil)
-	c.Check(key, DeepEquals, expectedKey)
+	c.Check(key, DeepEquals, secboot.DiskUnlockKey(expectedKey))
 
-	var expectedAuthPrivateKey secboot_tpm2.PolicyAuthKey
+	var expectedAuthPrivateKey secboot.AuxiliaryKey
 	authKeyPath := s.absPath("authKey")
 	if _, err := os.Stat(authKeyPath); err == nil {
 		expectedAuthPrivateKey, err = ioutil.ReadFile(authKeyPath)

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -21,6 +21,8 @@ package tpm2
 
 import (
 	"github.com/canonical/go-tpm2"
+
+	"github.com/snapcore/secboot"
 )
 
 // Export constants for testing
@@ -57,6 +59,7 @@ type KeyDataPolicy = keyDataPolicy
 type KeyDataPolicy_v0 = keyDataPolicy_v0
 type KeyDataPolicy_v1 = keyDataPolicy_v1
 type KeyDataPolicy_v2 = keyDataPolicy_v2
+
 type PolicyDataError = policyDataError
 type PolicyOrData_v0 = policyOrData_v0
 
@@ -96,7 +99,7 @@ type PcrPolicyData_v2 = pcrPolicyData_v2
 
 type PcrPolicyParams = pcrPolicyParams
 
-func NewPcrPolicyParams(key PolicyAuthKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name) *PcrPolicyParams {
+func NewPcrPolicyParams(key secboot.AuxiliaryKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name) *PcrPolicyParams {
 	return &PcrPolicyParams{
 		key:               key,
 		pcrs:              pcrs,
@@ -150,7 +153,7 @@ func MakeMockPolicyPCRValuesFull(params []MockPolicyPCRParam) (out []tpm2.PCRVal
 	return
 }
 
-func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authKey PolicyAuthKey, session tpm2.SessionContext) error {
+func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {
 	if _, err := k.validateData(tpm, session); err != nil {
 		return err
 	}
@@ -158,7 +161,7 @@ func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authKey PolicyAuthKey, 
 	return k.data.Policy().ValidateAuthKey(authKey)
 }
 
-func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authKey PolicyAuthKey, session tpm2.SessionContext) error {
+func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {
 	k, err := ReadSealedKeyObjectFromFile(keyFile)
 	if err != nil {
 		return err

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -45,12 +45,9 @@ const (
 	keyDataHeader uint32 = 0x55534b24
 )
 
-// PolicyAuthKey corresponds to the private part of the key used for signing updates to the authorization policy for a sealed key.
-type PolicyAuthKey []byte
-
 type sealedData struct {
-	Key            []byte
-	AuthPrivateKey PolicyAuthKey
+	Key            secboot.DiskUnlockKey
+	AuthPrivateKey secboot.AuxiliaryKey
 }
 
 type keyDataError struct {

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -86,7 +86,7 @@ func (h *legacyPlatformKeyDataHandler) RecoverKeys(data *secboot.PlatformKeyData
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
 	}
 
-	return secboot.MarshalKeys(key, secboot.AuxiliaryKey(authKey)), nil
+	return secboot.MarshalKeys(key, authKey), nil
 }
 
 func (h *legacyPlatformKeyDataHandler) RecoverKeysWithAuthKey(data *secboot.PlatformKeyData, key []byte) (secboot.KeyPayload, error) {

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -27,6 +27,8 @@ import (
 	"github.com/canonical/go-tpm2/util"
 
 	"golang.org/x/xerrors"
+
+	"github.com/snapcore/secboot"
 )
 
 const (
@@ -39,7 +41,7 @@ const (
 
 // pcrPolicyParams provides the parameters to keyDataPolicy.updatePcrPolicy.
 type pcrPolicyParams struct {
-	key PolicyAuthKey // Key used to authorize the generated dynamic authorization policy
+	key secboot.AuxiliaryKey // Key used to authorize the generated dynamic authorization policy
 
 	pcrs       tpm2.PCRSelectionList // PCR selection
 	pcrDigests tpm2.DigestList       // Approved PCR digests
@@ -87,8 +89,8 @@ type policyOrTree struct {
 
 // pcrPolicyCounterContext corresponds to a PCR policy counter.
 type pcrPolicyCounterContext interface {
-	Get() (uint64, error)              // Return the current counter value
-	Increment(key PolicyAuthKey) error // Increment the counter value using the supplied key for authorization
+	Get() (uint64, error)                     // Return the current counter value
+	Increment(key secboot.AuxiliaryKey) error // Increment the counter value using the supplied key for authorization
 }
 
 // keyDataPolicy corresponds to the authorization policy for keyData.
@@ -118,7 +120,7 @@ type keyDataPolicy interface {
 
 	// ValidateAuthKey verifies that the supplied key is associated with this
 	// keyDataPolicy.
-	ValidateAuthKey(key PolicyAuthKey) error
+	ValidateAuthKey(key secboot.AuxiliaryKey) error
 }
 
 // createPcrPolicyCounter creates and initializes a NV counter that is associated with a sealed key object

--- a/tpm2/policy_v0.go
+++ b/tpm2/policy_v0.go
@@ -31,6 +31,8 @@ import (
 	"github.com/canonical/go-tpm2/util"
 
 	"golang.org/x/xerrors"
+
+	"github.com/snapcore/secboot"
 )
 
 type policyOrDataNode_v0 struct {
@@ -536,7 +538,7 @@ func (c *pcrPolicyCounterContext_v0) Get() (uint64, error) {
 	return c.tpm.NVReadCounter(c.index, c.index, authSession, c.session.IncludeAttrs(tpm2.AttrAudit))
 }
 
-func (c *pcrPolicyCounterContext_v0) Increment(key PolicyAuthKey) error {
+func (c *pcrPolicyCounterContext_v0) Increment(key secboot.AuxiliaryKey) error {
 	rsaKey, err := x509.ParsePKCS1PrivateKey(key)
 	if err != nil {
 		return xerrors.Errorf("cannot parse auth key: %w", err)
@@ -606,7 +608,7 @@ func (p *keyDataPolicy_v0) PCRPolicyCounterContext(tpm *tpm2.TPMContext, pub *tp
 		authPolicies: p.StaticData.PCRPolicyCounterAuthPolicies}, nil
 }
 
-func (p *keyDataPolicy_v0) ValidateAuthKey(key PolicyAuthKey) error {
+func (p *keyDataPolicy_v0) ValidateAuthKey(key secboot.AuxiliaryKey) error {
 	rsaKey, err := x509.ParsePKCS1PrivateKey(key)
 	if err != nil {
 		return xerrors.Errorf("cannot parse auth key: %w", err)

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -29,6 +29,8 @@ import (
 	"github.com/canonical/go-tpm2/util"
 
 	"golang.org/x/xerrors"
+
+	"github.com/snapcore/secboot"
 )
 
 // computeV1PcrPolicyCounterAuthPolicies computes the authorization policy digests passed to
@@ -246,7 +248,7 @@ func (c *pcrPolicyCounterContext_v1) Get() (uint64, error) {
 	return c.tpm.NVReadCounter(c.index, c.index, c.session)
 }
 
-func (c *pcrPolicyCounterContext_v1) Increment(key PolicyAuthKey) error {
+func (c *pcrPolicyCounterContext_v1) Increment(key secboot.AuxiliaryKey) error {
 	ecdsaKey, err := createECDSAPrivateKeyFromTPM(c.updateKey, tpm2.ECCParameter(key))
 	if err != nil {
 		return xerrors.Errorf("cannot create auth key: %w", err)
@@ -313,7 +315,7 @@ func (p *keyDataPolicy_v1) PCRPolicyCounterContext(tpm *tpm2.TPMContext, pub *tp
 		updateKey: p.StaticData.AuthPublicKey}, nil
 }
 
-func (p *keyDataPolicy_v1) ValidateAuthKey(key PolicyAuthKey) error {
+func (p *keyDataPolicy_v1) ValidateAuthKey(key secboot.AuxiliaryKey) error {
 	pub, ok := p.StaticData.AuthPublicKey.Public().(*ecdsa.PublicKey)
 	if !ok {
 		return policyDataError{errors.New("unexpected dynamic authorization policy public key type")}

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -33,6 +33,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/tcg"
 	"github.com/snapcore/secboot/internal/testutil"
 	"github.com/snapcore/secboot/internal/tpm2test"
@@ -63,7 +64,7 @@ func (s *sealSuite) SetUpTest(c *C) {
 var _ = Suite(&sealSuite{})
 
 func (s *sealSuite) testSealKeyToTPM(c *C, params *KeyCreationParams) {
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -80,7 +81,7 @@ func (s *sealSuite) testSealKeyToTPM(c *C, params *KeyCreationParams) {
 	c.Check(k.PCRPolicyCounterHandle(), Equals, params.PCRPolicyCounterHandle)
 
 	if params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, PolicyAuthKey(params.AuthKey.D.Bytes()))
+		c.Check(authKey, DeepEquals, secboot.AuxiliaryKey(params.AuthKey.D.Bytes()))
 	}
 
 	keyUnsealed, authKeyUnsealed, err := k.UnsealFromTPM(s.TPM())
@@ -245,7 +246,7 @@ type testSealKeyToTPMMultipleData struct {
 }
 
 func (s *sealSuite) testSealKeyToTPMMultiple(c *C, data *testSealKeyToTPMMultipleData) {
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -273,7 +274,7 @@ func (s *sealSuite) testSealKeyToTPMMultiple(c *C, data *testSealKeyToTPMMultipl
 	}
 
 	if data.params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, PolicyAuthKey(data.params.AuthKey.D.Bytes()))
+		c.Check(authKey, DeepEquals, secboot.AuxiliaryKey(data.params.AuthKey.D.Bytes()))
 	}
 
 	if data.params.PCRProfile != nil {
@@ -384,7 +385,7 @@ func (s *sealSuite) testSealKeyToTPMErrorHandling(c *C, params *KeyCreationParam
 		c.Check(err, IsNil)
 	}
 
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -482,7 +483,7 @@ func (s *sealSuite) testSealKeyToExternalTPMStorageKey(c *C, params *KeyCreation
 	srkPub, _, _, err := s.TPM().ReadPublic(srk)
 	c.Assert(err, IsNil)
 
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -499,7 +500,7 @@ func (s *sealSuite) testSealKeyToExternalTPMStorageKey(c *C, params *KeyCreation
 	c.Check(k.PCRPolicyCounterHandle(), Equals, params.PCRPolicyCounterHandle)
 
 	if params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, PolicyAuthKey(params.AuthKey.D.Bytes()))
+		c.Check(authKey, DeepEquals, secboot.AuxiliaryKey(params.AuthKey.D.Bytes()))
 	}
 
 	keyUnsealed, authKeyUnsealed, err := k.UnsealFromTPM(s.TPM())
@@ -546,7 +547,7 @@ func (s *sealSuite) testSealKeyToExternalTPMStorageKeyErrorHandling(c *C, params
 	srkPub, _, _, err := s.TPM().ReadPublic(srk)
 	c.Assert(err, IsNil)
 
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -598,7 +599,7 @@ func (s *sealSuite) TestSealKeyToExternalTPMStorageKeyErrorHandlingWithPCRPolicy
 }
 
 func (s *sealSuite) testUpdatePCRProtectionPolicy(c *C, params *KeyCreationParams) {
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -640,7 +641,7 @@ func (s *sealSuite) TestUpdatePCRProtectionPolicyWithProvidedAuthKey(c *C) {
 }
 
 func (s *sealSuite) testRevokeOldPCRProtectionPolicies(c *C, params *KeyCreationParams) error {
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -692,7 +693,7 @@ func (s *sealSuite) TestRevokeOldPCRProtectionPoliciesWithoutPCRPolicyCounter(c 
 }
 
 func (s *sealSuite) TestUpdateKeyPCRProtectionPolicyMultiple(c *C) {
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()
@@ -733,7 +734,7 @@ func (s *sealSuite) TestUpdateKeyPCRProtectionPolicyMultipleUnrelated1(c *C) {
 	// Test that UpdateKeyPCRProtectionPolicyMultiple rejects keys that have the
 	// same auth key, but different policies because they use independent PCR policy
 	// counters.
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
@@ -764,7 +765,7 @@ func (s *sealSuite) TestUpdateKeyPCRProtectionPolicyMultipleUnrelated1(c *C) {
 func (s *sealSuite) TestUpdateKeyPCRProtectionPolicyMultipleUnrelated2(c *C) {
 	// Test that UpdateKeyPCRProtectionPolicyMultiple rejects keys that use different
 	// auth keys.
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	dir := c.MkDir()

--- a/tpm2/unseal.go
+++ b/tpm2/unseal.go
@@ -27,6 +27,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/tcg"
 )
 
@@ -136,7 +137,7 @@ func (k *SealedKeyObject) loadForUnseal(tpm *tpm2.TPMContext, session tpm2.Sessi
 //
 // On success, the unsealed cleartext key is returned as the first return value, and the private part of the key used for
 // authorizing PCR policy updates with UpdateKeyPCRProtectionPolicy is returned as the second return value.
-func (k *SealedKeyObject) UnsealFromTPM(tpm *Connection) (key []byte, authKey PolicyAuthKey, err error) {
+func (k *SealedKeyObject) UnsealFromTPM(tpm *Connection) (key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, err error) {
 	// Check if the TPM is in lockout mode
 	props, err := tpm.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1)
 	if err != nil {
@@ -184,7 +185,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *Connection) (key []byte, authKey Po
 	}
 
 	if k.data.Version() == 0 {
-		return keyData, nil, nil
+		return secboot.DiskUnlockKey(keyData), nil, nil
 	}
 
 	var sealedData sealedData

--- a/tpm2/unseal_test.go
+++ b/tpm2/unseal_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/tcg"
 	"github.com/snapcore/secboot/internal/tpm2test"
 	. "github.com/snapcore/secboot/tpm2"
@@ -54,7 +55,7 @@ func (s *unsealSuite) SetUpTest(c *C) {
 var _ = Suite(&unsealSuite{})
 
 func (s *unsealSuite) testUnsealFromTPM(c *C, params *KeyCreationParams) {
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	path := filepath.Join(c.MkDir(), "key")
@@ -89,7 +90,7 @@ func (s *unsealSuite) TestUnsealFromTPMNoPCRPolicyCounter(c *C) {
 }
 
 func (s *unsealSuite) testUnsealFromTPMNoValidSRK(c *C, prepareSrk func()) {
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	path := filepath.Join(c.MkDir(), "key")
@@ -139,7 +140,7 @@ func (s *unsealSuite) testUnsealImportableFromTPM(c *C, params *KeyCreationParam
 	srkPub, _, _, err := s.TPM().ReadPublic(srk)
 	c.Assert(err, IsNil)
 
-	key := make([]byte, 32)
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	path := filepath.Join(c.MkDir(), "key")
@@ -166,8 +167,8 @@ func (s *unsealSuite) TestUnsealImportableFromTPMNilPCRProfile(c *C) {
 	s.testUnsealImportableFromTPM(c, &KeyCreationParams{PCRPolicyCounterHandle: tpm2.HandleNull})
 }
 
-func (s *unsealSuite) testUnsealFromTPMErrorHandling(c *C, prepare func(string, PolicyAuthKey)) error {
-	key := make([]byte, 32)
+func (s *unsealSuite) testUnsealFromTPMErrorHandling(c *C, prepare func(string, secboot.AuxiliaryKey)) error {
+	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
 	path := filepath.Join(c.MkDir(), "key")
@@ -188,7 +189,7 @@ func (s *unsealSuite) testUnsealFromTPMErrorHandling(c *C, prepare func(string, 
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingLockout(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ PolicyAuthKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.AuxiliaryKey) {
 		// Put the TPM in DA lockout mode
 		c.Check(s.TPM().DictionaryAttackParameters(s.TPM().LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	})
@@ -196,7 +197,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingLockout(c *C) {
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingInvalidPCRProfile(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ PolicyAuthKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.AuxiliaryKey) {
 		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
 		c.Check(err, IsNil)
 	})
@@ -206,7 +207,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingInvalidPCRProfile(c *C) {
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingRevokedPolicy(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(path string, authKey PolicyAuthKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(path string, authKey secboot.AuxiliaryKey) {
 		k, err := ReadSealedKeyObjectFromFile(path)
 		c.Assert(err, IsNil)
 		c.Check(k.UpdatePCRProtectionPolicy(s.TPM(), authKey, nil), IsNil)
@@ -218,7 +219,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingRevokedPolicy(c *C) {
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingSealedKeyAccessLocked(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ PolicyAuthKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.AuxiliaryKey) {
 		c.Check(BlockPCRProtectionPolicies(s.TPM(), []int{23}), IsNil)
 	})
 	c.Check(err, tpm2_testutil.ConvertibleTo, InvalidKeyDataError{})


### PR DESCRIPTION
This removes the PolicyAuthKey type and aligns the
tpm2 code with the platform agnostic code, in preparation
for adding a proper tpm2 platform.