### PR TITLE
Allow the platform handle to be any arbitrary JSON value in KeyCreationData

### DIFF
--- a/keydata.go
+++ b/keydata.go
@@ -148,8 +148,16 @@ const (
 // KeyCreationData is the data required to create a new KeyData object.
 // It should be produced by a platform implementation.
 type KeyCreationData struct {
-	PlatformKeyData
-	PlatformName string // Name of the platform that produced this data
+	// Handle contains metadata required by the platform in order to recover
+	// this key. It is opaque to this go package. It should be a value that can
+	// be encoded to JSON using go's encoding/json package, which could be
+	// something as simple as binary data stored in a byte slice or a more complex
+	// JSON object, depending on the requirements of the implementation. A handle
+	// already encoded to JSON can be supplied using the json.RawMessage type.
+	Handle interface{}
+
+	EncryptedPayload []byte // The encrypted payload
+	PlatformName     string // Name of the platform that produced this data
 
 	// AuxiliaryKey is a key used to authorize changes to the key data.
 	// It must match the key protected inside PlatformKeyData.EncryptedPayload.
@@ -720,8 +728,9 @@ func ReadKeyData(r KeyDataReader) (*KeyData, error) {
 // the platform's secure device and the associated handle required for subsequent
 // recovery of the keys.
 func NewKeyData(creationData *KeyCreationData) (*KeyData, error) {
-	if !json.Valid(creationData.Handle) {
-		return nil, errors.New("handle is not valid JSON")
+	handle, err := json.Marshal(creationData.Handle)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot encode platform handle: %w", err)
 	}
 
 	rng, err := drbg.NewCTRWithExternalEntropy(32, creationData.AuxiliaryKey, nil, []byte("SNAP-MODEL-HMAC"), nil)
@@ -737,7 +746,7 @@ func NewKeyData(creationData *KeyCreationData) (*KeyData, error) {
 	return &KeyData{
 		data: keyData{
 			PlatformName:     creationData.PlatformName,
-			PlatformHandle:   json.RawMessage(creationData.Handle),
+			PlatformHandle:   json.RawMessage(handle),
 			EncryptedPayload: creationData.EncryptedPayload,
 			AuthorizedSnapModels: authorizedSnapModels{
 				Alg:       hashAlg{creationData.SnapModelAuthHash},

--- a/keydata.go
+++ b/keydata.go
@@ -728,7 +728,7 @@ func ReadKeyData(r KeyDataReader) (*KeyData, error) {
 // the platform's secure device and the associated handle required for subsequent
 // recovery of the keys.
 func NewKeyData(creationData *KeyCreationData) (*KeyData, error) {
-	handle, err := json.Marshal(creationData.Handle)
+	encodedHandle, err := json.Marshal(creationData.Handle)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot encode platform handle: %w", err)
 	}
@@ -746,7 +746,7 @@ func NewKeyData(creationData *KeyCreationData) (*KeyData, error) {
 	return &KeyData{
 		data: keyData{
 			PlatformName:     creationData.PlatformName,
-			PlatformHandle:   json.RawMessage(handle),
+			PlatformHandle:   json.RawMessage(encodedHandle),
 			EncryptedPayload: creationData.EncryptedPayload,
 			AuthorizedSnapModels: authorizedSnapModels{
 				Alg:       hashAlg{creationData.SnapModelAuthHash},

--- a/keydata.go
+++ b/keydata.go
@@ -504,7 +504,7 @@ func (d *KeyData) RecoverKeys() (DiskUnlockKey, AuxiliaryKey, error) {
 	}
 
 	c, err := handler.RecoverKeys(&PlatformKeyData{
-		Handle:           d.data.PlatformHandle,
+		EncodedHandle:    d.data.PlatformHandle,
 		EncryptedPayload: d.data.EncryptedPayload})
 	if err != nil {
 		return nil, nil, processPlatformHandlerError(err)
@@ -534,7 +534,7 @@ func (d *KeyData) RecoverKeysWithPassphrase(passphrase string, kdf KDF) (DiskUnl
 	}
 
 	data := &PlatformKeyData{
-		Handle:           d.data.PlatformHandle,
+		EncodedHandle:    d.data.PlatformHandle,
 		EncryptedPayload: payload}
 	c, err := handler.RecoverKeysWithAuthKey(data, key)
 	if err != nil {

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -108,7 +108,7 @@ func (h *mockPlatformKeyDataHandler) RecoverKeys(data *PlatformKeyData) (KeyPayl
 		return nil, err
 	}
 
-	handle, err := h.unmarshalHandle(data.Handle)
+	handle, err := h.unmarshalHandle(data.EncodedHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (h *mockPlatformKeyDataHandler) RecoverKeysWithAuthKey(data *PlatformKeyDat
 		return nil, err
 	}
 
-	handle, err := h.unmarshalHandle(data.Handle)
+	handle, err := h.unmarshalHandle(data.EncodedHandle)
 	if err != nil {
 		return nil, err
 	}

--- a/platform.go
+++ b/platform.go
@@ -62,15 +62,9 @@ func (e *PlatformHandlerError) Unwrap() error {
 }
 
 // PlatformKeyData represents the data exchanged between this package and
-// platform implementations.
+// platform implementations via the PlatformKeyDataHandler.
 type PlatformKeyData struct {
-	// Handle contains metadata required by the platform in order to recover
-	// this key. It is opaque to this go package. It should be an encoded JSON
-	// value, which could be something as simple as a single string containing
-	// a base64 encoded binary payload or a more complex JSON object, depending
-	// on the requirements of the implementation.
-	Handle []byte
-
+	Handle           []byte // The JSON encoded platform handle
 	EncryptedPayload []byte // The encrypted payload
 }
 

--- a/platform.go
+++ b/platform.go
@@ -64,7 +64,7 @@ func (e *PlatformHandlerError) Unwrap() error {
 // PlatformKeyData represents the data exchanged between this package and
 // platform implementations via the PlatformKeyDataHandler.
 type PlatformKeyData struct {
-	Handle           []byte // The JSON encoded platform handle
+	EncodedHandle    []byte // The JSON encoded platform handle
 	EncryptedPayload []byte // The encrypted payload
 }
 

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -49,7 +49,7 @@ func (h *legacyPlatformKeyDataHandler) RecoverKeys(data *secboot.PlatformKeyData
 	defer tpm.Close()
 
 	var handle []byte
-	if err := json.Unmarshal(data.Handle, &handle); err != nil {
+	if err := json.Unmarshal(data.EncodedHandle, &handle); err != nil {
 		return nil, &secboot.PlatformHandlerError{
 			Type: secboot.PlatformHandlerErrorInvalidData,
 			Err:  err}

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -125,9 +125,7 @@ func NewKeyDataFromSealedKeyObjectFile(path string) (*secboot.KeyData, error) {
 	}
 
 	creationData := secboot.KeyCreationData{
-		PlatformKeyData: secboot.PlatformKeyData{
-			Handle: handle,
-		},
+		Handle:            json.RawMessage(handle),
 		PlatformName:      legacyPlatformName,
 		AuxiliaryKey:      make([]byte, 32), // Not used, but must be the expected size
 		SnapModelAuthHash: crypto.SHA256,    // Not used, but just set it a valid alg


### PR DESCRIPTION
This aligns the representation of the platform handle in KeyCreationData
with the representation introduced to the KeyData API in
https://github.com/snapcore/secboot/pull/191.

Note that the representation of the platform handle in PlatformKeyDataHandler
remains unchanged (it is the encoded JSON). This is becuase
PlatformKeyDataHandler is used to call from KeyData to an implementation,
and it is not possible to decode the JSON in this scenario because the
data is opaque.