### PR TITLE
tpm2: Add initial PlatformKeyDataHandler implementation

### DIFF
--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -36,14 +36,19 @@ var (
 	ComputeV0PinNVIndexPostInitAuthPolicies = computeV0PinNVIndexPostInitAuthPolicies
 	CreatePcrPolicyCounter                  = createPcrPolicyCounter
 	ComputeV1PcrPolicyRefFromCounterName    = computeV1PcrPolicyRefFromCounterName
+	ComputeV3PcrPolicyCounterAuthPolicies   = computeV3PcrPolicyCounterAuthPolicies
 	ComputeV3PcrPolicyRefFromCounterName    = computeV3PcrPolicyRefFromCounterName
 	ComputeSnapModelDigest                  = computeSnapModelDigest
 	DeriveV3PolicyAuthKey                   = deriveV3PolicyAuthKey
 	ErrSessionDigestNotFound                = errSessionDigestNotFound
 	IsPolicyDataError                       = isPolicyDataError
+	MakeKeyDataPolicy                       = makeKeyDataPolicy
+	MakeKeyDataWithPolicy                   = makeKeyDataWithPolicy
+	MakeNewKeyData                          = makeNewKeyData
 	NewKeyData                              = newKeyData
 	NewKeyDataPolicy                        = newKeyDataPolicy
 	NewKeyDataPolicyLegacy                  = newKeyDataPolicyLegacy
+	NewPolicyAuthPublicKey                  = newPolicyAuthPublicKey
 	NewPolicyOrDataV0                       = newPolicyOrDataV0
 	NewPolicyOrTree                         = newPolicyOrTree
 	ReadKeyDataV0                           = readKeyDataV0
@@ -61,7 +66,9 @@ type KeyData_v1 = keyData_v1
 type KeyData_v2 = keyData_v2
 type KeyData_v3 = keyData_v3
 type KeyDataError = keyDataError
+type KeyDataParams = keyDataParams
 type KeyDataPolicy = keyDataPolicy
+type KeyDataPolicyParams = keyDataPolicyParams
 type KeyDataPolicy_v0 = keyDataPolicy_v0
 type KeyDataPolicy_v1 = keyDataPolicy_v1
 type KeyDataPolicy_v2 = keyDataPolicy_v2
@@ -123,6 +130,8 @@ func NewPcrPolicyParams(key secboot.AuxiliaryKey, pcrs tpm2.PCRSelectionList, pc
 		policyCounterName: policyCounterName}
 }
 
+type PlatformKeyDataHandler = platformKeyDataHandler
+type SealedKeyDataBase = sealedKeyDataBase
 type SnapModelHasher = snapModelHasher
 type StaticPolicyData_v0 = staticPolicyData_v0
 type StaticPolicyData_v1 = staticPolicyData_v1
@@ -170,12 +179,76 @@ func MakeMockPolicyPCRValuesFull(params []MockPolicyPCRParam) (out []tpm2.PCRVal
 	return
 }
 
+func MockCreatePcrPolicyCounter(fn func(*tpm2.TPMContext, tpm2.Handle, *tpm2.Public, tpm2.SessionContext) (*tpm2.NVPublic, uint64, error)) (restore func()) {
+	orig := createPcrPolicyCounter
+	createPcrPolicyCounter = fn
+	return func() {
+		createPcrPolicyCounter = orig
+	}
+}
+
+func MockNewKeyDataPolicy(fn func(tpm2.HashAlgorithmId, *tpm2.Public, *tpm2.NVPublic, uint64) (KeyDataPolicy, tpm2.Digest, error)) (restore func()) {
+	orig := newKeyDataPolicy
+	newKeyDataPolicy = fn
+	return func() {
+		newKeyDataPolicy = orig
+	}
+}
+
+func MockNewPolicyAuthPublicKey(fn func(authKey secboot.AuxiliaryKey) (*tpm2.Public, error)) (restore func()) {
+	orig := newPolicyAuthPublicKey
+	newPolicyAuthPublicKey = fn
+	return func() {
+		newPolicyAuthPublicKey = orig
+	}
+}
+
+func MockSecbootNewKeyData(fn func(*secboot.KeyParams) (*secboot.KeyData, error)) (restore func()) {
+	orig := secbootNewKeyData
+	secbootNewKeyData = fn
+	return func() {
+		secbootNewKeyData = orig
+	}
+}
+
+func MockSkdbUpdatePCRProtectionPolicyImpl(fn func(*sealedKeyDataBase, *tpm2.TPMContext, secboot.AuxiliaryKey, *tpm2.NVPublic, *PCRProtectionProfile, tpm2.SessionContext) error) (restore func()) {
+	orig := skdbUpdatePCRProtectionPolicyImpl
+	skdbUpdatePCRProtectionPolicyImpl = fn
+	return func() {
+		skdbUpdatePCRProtectionPolicyImpl = orig
+	}
+}
+
+func (k *SealedKeyData) Data() KeyData {
+	return k.data
+}
+
+func (k *SealedKeyData) Validate(tpm *tpm2.TPMContext, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {
+	if _, err := k.validateData(tpm, session); err != nil {
+		return err
+	}
+
+	return k.data.Policy().ValidateAuthKey(authKey)
+}
+
+func (k *SealedKeyObject) Data() KeyData {
+	return k.data
+}
+
 func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {
 	if _, err := k.validateData(tpm, session); err != nil {
 		return err
 	}
 
 	return k.data.Policy().ValidateAuthKey(authKey)
+}
+
+func (c *createdPcrPolicyCounter) TPM() *tpm2.TPMContext {
+	return c.tpm
+}
+
+func (c *createdPcrPolicyCounter) Session() tpm2.SessionContext {
+	return c.session
 }
 
 func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -42,9 +42,9 @@ var (
 	DeriveV3PolicyAuthKey                   = deriveV3PolicyAuthKey
 	ErrSessionDigestNotFound                = errSessionDigestNotFound
 	IsPolicyDataError                       = isPolicyDataError
+	MakeKeyData                             = makeKeyData
 	MakeKeyDataPolicy                       = makeKeyDataPolicy
 	MakeKeyDataWithPolicy                   = makeKeyDataWithPolicy
-	MakeNewKeyData                          = makeNewKeyData
 	NewKeyData                              = newKeyData
 	NewKeyDataPolicy                        = newKeyDataPolicy
 	NewKeyDataPolicyLegacy                  = newKeyDataPolicyLegacy

--- a/tpm2/keydata_legacy.go
+++ b/tpm2/keydata_legacy.go
@@ -45,7 +45,8 @@ type sealedData struct {
 	AuthPrivateKey secboot.AuxiliaryKey
 }
 
-// SealedKeyObject corresponds to a sealed key data file.
+// SealedKeyObject corresponds to a sealed key data file created by
+// [SealKeyToTPM], [SealKeyToExternalTPMStorageKey] or [SealKeyToTPMMultiple].
 type SealedKeyObject struct {
 	sealedKeyDataBase
 }

--- a/tpm2/keydata_legacy.go
+++ b/tpm2/keydata_legacy.go
@@ -47,6 +47,8 @@ type sealedData struct {
 
 // SealedKeyObject corresponds to a sealed key data file created by
 // [SealKeyToTPM], [SealKeyToExternalTPMStorageKey] or [SealKeyToTPMMultiple].
+//
+// Deprecated: Use [SealedKeyData].
 type SealedKeyObject struct {
 	sealedKeyDataBase
 }

--- a/tpm2/platform.go
+++ b/tpm2/platform.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/canonical/go-tpm2"
+
+	"golang.org/x/xerrors"
+
+	"github.com/snapcore/secboot"
+)
+
+const platformName = "tpm2"
+
+type platformKeyDataHandler struct{}
+
+func (h *platformKeyDataHandler) recoverKeysCommon(data *secboot.PlatformKeyData, authKey []byte) (secboot.KeyPayload, error) {
+	tpm, err := ConnectToTPM()
+	switch {
+	case err == ErrNoTPM2Device:
+		return nil, &secboot.PlatformHandlerError{
+			Type: secboot.PlatformHandlerErrorUnavailable,
+			Err:  err}
+	case err != nil:
+		return nil, xerrors.Errorf("cannot connect to TPM: %w", err)
+	}
+	defer tpm.Close()
+
+	var k *SealedKeyData
+	if err := json.Unmarshal(data.EncodedHandle, &k); err != nil {
+		return nil, &secboot.PlatformHandlerError{
+			Type: secboot.PlatformHandlerErrorInvalidData,
+			Err:  err}
+	}
+	if k.data.Version() < 3 {
+		// All KeyData objects created for this platform are at least v3, so this
+		// should never fail. Test it though to avoid a panic later on if the version
+		// has been manipulated.
+		return nil, &secboot.PlatformHandlerError{
+			Type: secboot.PlatformHandlerErrorInvalidData,
+			Err:  fmt.Errorf("invalid key data version: %d", k.data.Version())}
+	}
+
+	symKey, err := k.unsealDataFromTPM(tpm.TPMContext, tpm.HmacSession())
+	if err != nil {
+		var e InvalidKeyDataError
+		switch {
+		case xerrors.As(err, &e):
+			return nil, &secboot.PlatformHandlerError{
+				Type: secboot.PlatformHandlerErrorInvalidData,
+				Err:  errors.New(e.msg)}
+		case err == ErrTPMProvisioning:
+			return nil, &secboot.PlatformHandlerError{
+				Type: secboot.PlatformHandlerErrorUninitialized,
+				Err:  err}
+		case err == ErrTPMLockout:
+			return nil, &secboot.PlatformHandlerError{
+				Type: secboot.PlatformHandlerErrorUnavailable,
+				Err:  err}
+		case tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandUnseal, 1):
+			return nil, &secboot.PlatformHandlerError{
+				Type: secboot.PlatformHandlerErrorInvalidAuthKey,
+				Err:  err}
+		}
+		return nil, xerrors.Errorf("cannot unseal key: %w", err)
+	}
+
+	if len(symKey) != 32+aes.BlockSize {
+		return nil, &secboot.PlatformHandlerError{
+			Type: secboot.PlatformHandlerErrorInvalidData,
+			Err:  errors.New("unsealed symmetric key has the wrong length")}
+	}
+
+	payload := make(secboot.KeyPayload, len(data.EncryptedPayload))
+
+	b, err := aes.NewCipher(symKey[:32])
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create new cipher: %w", err)
+	}
+	stream := cipher.NewCFBDecrypter(b, symKey[32:])
+	stream.XORKeyStream(payload, data.EncryptedPayload)
+
+	return payload, nil
+}
+
+func (h *platformKeyDataHandler) RecoverKeys(data *secboot.PlatformKeyData) (secboot.KeyPayload, error) {
+	return h.recoverKeysCommon(data, nil)
+}
+
+func (h *platformKeyDataHandler) RecoverKeysWithAuthKey(data *secboot.PlatformKeyData, key []byte) (secboot.KeyPayload, error) {
+	return nil, fmt.Errorf("passphrase authentication is not supported for the %s platform", platformName)
+}
+
+func (h *platformKeyDataHandler) ChangeAuthKey(handle, old, new []byte) ([]byte, error) {
+	return nil, fmt.Errorf("passphrase authentication is not supported for the %s platform", platformName)
+}
+
+func init() {
+	secboot.RegisterPlatformKeyDataHandler(platformName, &platformKeyDataHandler{})
+}

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -1,0 +1,320 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2_test
+
+import (
+	"encoding/json"
+	"math/rand"
+	"os"
+	"syscall"
+
+	"github.com/canonical/go-tpm2"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/tcg"
+	"github.com/snapcore/secboot/internal/testutil"
+	"github.com/snapcore/secboot/internal/tpm2test"
+	. "github.com/snapcore/secboot/tpm2"
+)
+
+type platformSuite struct {
+	tpm2test.TPMTest
+
+	lastEncryptedPayload []byte
+}
+
+func (s *platformSuite) SetUpSuite(c *C) {
+	s.TPMFeatures = tpm2test.TPMFeatureOwnerHierarchy |
+		tpm2test.TPMFeatureEndorsementHierarchy |
+		tpm2test.TPMFeatureLockoutHierarchy |
+		tpm2test.TPMFeaturePCR |
+		tpm2test.TPMFeatureNV
+}
+
+func (s *platformSuite) SetUpTest(c *C) {
+	s.TPMTest.SetUpTest(c)
+
+	c.Check(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil), Equals, ErrTPMProvisioningRequiresLockout)
+
+	s.lastEncryptedPayload = nil
+	s.AddCleanup(MockSecbootNewKeyData(func(params *secboot.KeyParams) (*secboot.KeyData, error) {
+		s.lastEncryptedPayload = params.EncryptedPayload
+		return secboot.NewKeyData(params)
+	}))
+}
+
+var _ = Suite(&platformSuite{})
+
+func (s *platformSuite) TestRecoverKeysIntegrated(c *C) {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	params := &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0)}
+
+	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	c.Assert(err, IsNil)
+
+	keyUnsealed, authKeyUnsealed, err := k.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(keyUnsealed, DeepEquals, key)
+	c.Check(authKeyUnsealed, DeepEquals, authKey)
+}
+
+func (s *platformSuite) testRecoverKeys(c *C, params *ProtectKeyParams) {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	c.Assert(err, IsNil)
+
+	var platformHandle json.RawMessage
+	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
+
+	var handler PlatformKeyDataHandler
+	payload, err := handler.RecoverKeys(&secboot.PlatformKeyData{
+		EncodedHandle:    platformHandle,
+		EncryptedPayload: s.lastEncryptedPayload})
+
+	keyUnsealed, authKeyUnsealed, err := payload.Unmarshal()
+	c.Check(err, IsNil)
+	c.Check(keyUnsealed, DeepEquals, key)
+	c.Check(authKeyUnsealed, DeepEquals, authKey)
+}
+
+func (s *platformSuite) TestRecoverKeysSimplePCRProfile(c *C) {
+	s.testRecoverKeys(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0)})
+}
+
+func (s *platformSuite) TestRecoverKeysNilPCRProfile(c *C) {
+	s.testRecoverKeys(c, &ProtectKeyParams{
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0)})
+}
+
+func (s *platformSuite) TestRecoverKeysNoPCRPolicyCounter(c *C) {
+	s.testRecoverKeys(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+}
+
+func (s *platformSuite) testRecoverKeysNoValidSRK(c *C, prepareSrk func()) {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	params := &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0)}
+
+	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	c.Assert(err, IsNil)
+
+	prepareSrk()
+
+	var platformHandle json.RawMessage
+	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
+
+	var handler PlatformKeyDataHandler
+	payload, err := handler.RecoverKeys(&secboot.PlatformKeyData{
+		EncodedHandle:    platformHandle,
+		EncryptedPayload: s.lastEncryptedPayload})
+
+	keyUnsealed, authKeyUnsealed, err := payload.Unmarshal()
+	c.Check(err, IsNil)
+	c.Check(keyUnsealed, DeepEquals, key)
+	c.Check(authKeyUnsealed, DeepEquals, authKey)
+}
+
+func (s *platformSuite) TestRecoverKeysMissingSRK(c *C) {
+	s.testRecoverKeysNoValidSRK(c, func() {
+		srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+		c.Assert(err, IsNil)
+		s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+	})
+}
+
+func (s *platformSuite) TestRecoverKeysWrongSRK(c *C) {
+	s.testRecoverKeysNoValidSRK(c, func() {
+		srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+		c.Assert(err, IsNil)
+		s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+
+		srkTemplate := tcg.MakeDefaultSRKTemplate()
+		srkTemplate.Unique.RSA = nil
+		srk = s.CreatePrimary(c, tpm2.HandleOwner, srkTemplate)
+		s.EvictControl(c, tpm2.HandleOwner, srk, tcg.SRKHandle)
+	})
+}
+
+func (s *platformSuite) testRecoverKeysImportable(c *C, params *ProtectKeyParams) {
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+
+	srkPub, _, _, err := s.TPM().ReadPublic(srk)
+	c.Assert(err, IsNil)
+
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	k, authKey, err := ProtectKeyWithExternalStorageKey(srkPub, key, params)
+	c.Assert(err, IsNil)
+
+	var platformHandle json.RawMessage
+	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
+
+	var handler PlatformKeyDataHandler
+	payload, err := handler.RecoverKeys(&secboot.PlatformKeyData{
+		EncodedHandle:    platformHandle,
+		EncryptedPayload: s.lastEncryptedPayload})
+
+	keyUnsealed, authKeyUnsealed, err := payload.Unmarshal()
+	c.Check(err, IsNil)
+	c.Check(keyUnsealed, DeepEquals, key)
+	c.Check(authKeyUnsealed, DeepEquals, authKey)
+}
+
+func (s *platformSuite) TestRecoverKeysImportableSimplePCRProfile(c *C) {
+	s.testRecoverKeysImportable(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewResolvedPCRProfileFromCurrentValues(c, s.TPM().TPMContext, tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+}
+
+func (s *platformSuite) TestRecoverKeysImportableNilPCRProfile(c *C) {
+	s.testRecoverKeysImportable(c, &ProtectKeyParams{
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+}
+
+func (s *platformSuite) TestRecoverKeysNoTPMConnection(c *C) {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	k, _, err := ProtectKeyWithTPM(s.TPM(), key, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, IsNil)
+
+	restore := tpm2test.MockOpenDefaultTctiFn(func() (tpm2.TCTI, error) {
+		return nil, &os.PathError{Op: "open", Path: "/dev/tpm0", Err: syscall.ENOENT}
+	})
+	s.AddCleanup(restore)
+
+	var platformHandle json.RawMessage
+	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
+
+	var handler PlatformKeyDataHandler
+	_, err = handler.RecoverKeys(&secboot.PlatformKeyData{
+		EncodedHandle:    platformHandle,
+		EncryptedPayload: s.lastEncryptedPayload})
+	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
+	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorUnavailable)
+	c.Check(err, testutil.ErrorIs, ErrNoTPM2Device)
+	c.Check(err, ErrorMatches, "no TPM2 device is available")
+}
+
+func (s *platformSuite) testRecoverKeysUnsealErrorHandling(c *C, prepare func(*secboot.KeyData, secboot.AuxiliaryKey)) error {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	params := &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0)}
+
+	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	c.Assert(err, IsNil)
+
+	prepare(k, authKey)
+
+	var platformHandle json.RawMessage
+	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
+
+	var handler PlatformKeyDataHandler
+	_, err = handler.RecoverKeys(&secboot.PlatformKeyData{
+		EncodedHandle:    platformHandle,
+		EncryptedPayload: s.lastEncryptedPayload})
+	return err
+}
+
+func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingLockout(c *C) {
+	err := s.testRecoverKeysUnsealErrorHandling(c, func(_ *secboot.KeyData, _ secboot.AuxiliaryKey) {
+		// Put the TPM in DA lockout mode
+		c.Check(s.TPM().DictionaryAttackParameters(s.TPM().LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
+	})
+	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
+	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorUnavailable)
+	c.Check(err, testutil.ErrorIs, ErrTPMLockout)
+	c.Check(err, ErrorMatches, "the TPM is in DA lockout mode")
+}
+
+func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingInvalidPCRProfile(c *C) {
+	err := s.testRecoverKeysUnsealErrorHandling(c, func(_ *secboot.KeyData, _ secboot.AuxiliaryKey) {
+		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
+		c.Check(err, IsNil)
+	})
+	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
+	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorInvalidData)
+	c.Check(err, ErrorMatches, "cannot complete authorization policy assertions: "+
+		"cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+}
+
+func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingRevokedPolicy(c *C) {
+	err := s.testRecoverKeysUnsealErrorHandling(c, func(k *secboot.KeyData, authKey secboot.AuxiliaryKey) {
+		w := newMockKeyDataWriter()
+		c.Check(k.WriteAtomic(w), IsNil)
+
+		k2, err := secboot.ReadKeyData(w.Reader())
+		c.Assert(err, IsNil)
+		skd, err := NewSealedKeyData(k2)
+		c.Assert(err, IsNil)
+
+		c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), authKey, nil), IsNil)
+		c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), authKey), IsNil)
+	})
+	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
+	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorInvalidData)
+	c.Check(err, ErrorMatches, "cannot complete authorization policy assertions: "+
+		"the PCR policy has been revoked")
+}
+
+func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingSealedKeyAccessLocked(c *C) {
+	err := s.testRecoverKeysUnsealErrorHandling(c, func(_ *secboot.KeyData, _ secboot.AuxiliaryKey) {
+		c.Check(BlockPCRProtectionPolicies(s.TPM(), []int{23}), IsNil)
+	})
+	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
+	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorInvalidData)
+	c.Check(err, ErrorMatches, "cannot complete authorization policy assertions: "+
+		"cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+}
+
+func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingProvisioningError(c *C) {
+	err := s.testRecoverKeysUnsealErrorHandling(c, func(_ *secboot.KeyData, _ secboot.AuxiliaryKey) {
+		srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+		c.Assert(err, IsNil)
+		s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+
+		s.HierarchyChangeAuth(c, tpm2.HandleOwner, []byte("1234"))
+	})
+	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
+	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorUninitialized)
+	c.Check(err, ErrorMatches, "the TPM is not correctly provisioned")
+}

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -246,6 +246,9 @@ func ensureSufficientORDigests(digests tpm2.DigestList) tpm2.DigestList {
 // assertion, which can be used verify that a NV index is associated with this policy.
 //
 // The key argument must be created with newPolicyAuthPublicKey.
+//
+// This returns some policy metadata and a policy digest which is used as the auth policy field of the
+// protected object.
 var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (keyDataPolicy, tpm2.Digest, error) {
 	keyName, err := key.Name()
 	if err != nil {

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -126,12 +126,7 @@ type keyDataPolicy interface {
 	ValidateAuthKey(key secboot.AuxiliaryKey) error
 }
 
-// createPcrPolicyCounter creates and initializes a NV counter that is associated with a sealed key object
-// and is used for implementing PCR policy revocation.
-//
-// The NV index will be created with attributes that allow anyone to read the index, and an authorization
-// policy that permits TPM2_NV_Increment with a signed authorization policy.
-func createPcrPolicyCounter(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKey *tpm2.Public, hmacSession tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
+func createPcrPolicyCounterImpl(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKey *tpm2.Public, computeAuthPolicies func(tpm2.HashAlgorithmId, tpm2.Name) tpm2.DigestList, hmacSession tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
 	nameAlg := tpm2.HashAlgorithmSHA256
 
 	updateKeyName, err := updateKey.Name()
@@ -139,7 +134,7 @@ func createPcrPolicyCounter(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKey 
 		return nil, 0, xerrors.Errorf("cannot compute name of update key: %w", err)
 	}
 
-	authPolicies := computeV2PcrPolicyCounterAuthPolicies(nameAlg, updateKeyName)
+	authPolicies := computeAuthPolicies(nameAlg, updateKeyName)
 
 	trial := util.ComputeAuthPolicy(nameAlg)
 	trial.PolicyOR(authPolicies)
@@ -201,7 +196,25 @@ func createPcrPolicyCounter(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKey 
 	return public, value, nil
 }
 
-func newPolicyAuthPublicKey(key secboot.AuxiliaryKey) (*tpm2.Public, error) {
+// createPcrPolicyCounter creates and initializes a NV counter that is associated with a sealed key object
+// and is used for implementing PCR policy revocation.
+//
+// The NV index will be created with attributes that allow anyone to read the index, and an authorization
+// policy that permits TPM2_NV_Increment with a signed authorization policy.
+var createPcrPolicyCounter = func(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKey *tpm2.Public, hmacSession tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
+	return createPcrPolicyCounterImpl(tpm, handle, updateKey, computeV3PcrPolicyCounterAuthPolicies, hmacSession)
+}
+
+// createPcrPolicyCounterLegacy creates and initializes a NV counter that is associated with a sealed key object
+// and is used for implementing PCR policy revocation.
+//
+// The NV index will be created with attributes that allow anyone to read the index, and an authorization
+// policy that permits TPM2_NV_Increment with a signed authorization policy.
+func createPcrPolicyCounterLegacy(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKey *tpm2.Public, hmacSession tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
+	return createPcrPolicyCounterImpl(tpm, handle, updateKey, computeV2PcrPolicyCounterAuthPolicies, hmacSession)
+}
+
+var newPolicyAuthPublicKey = func(key secboot.AuxiliaryKey) (*tpm2.Public, error) {
 	ecdsaKey, err := deriveV3PolicyAuthKey(crypto.SHA256, key)
 	if err != nil {
 		return nil, err
@@ -233,7 +246,7 @@ func ensureSufficientORDigests(digests tpm2.DigestList) tpm2.DigestList {
 // assertion, which can be used verify that a NV index is associated with this policy.
 //
 // The key argument must be created with newPolicyAuthPublicKey.
-func newKeyDataPolicy(alg tpm2.HashAlgorithmId, key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (keyDataPolicy, tpm2.Digest, error) {
+var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (keyDataPolicy, tpm2.Digest, error) {
 	keyName, err := key.Name()
 	if err != nil {
 		return nil, nil, xerrors.Errorf("cannot compute name of signing key for dynamic policy authorization: %w", err)

--- a/tpm2/policy_v3.go
+++ b/tpm2/policy_v3.go
@@ -44,6 +44,10 @@ func computeV3PcrPolicyRefFromCounterContext(context tpm2.ResourceContext) tpm2.
 	return computeV1PcrPolicyRefFromCounterContext(context)
 }
 
+func computeV3PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) tpm2.DigestList {
+	return computeV1PcrPolicyCounterAuthPolicies(alg, updateKeyName)
+}
+
 // deriveV3PolicyAuthKey derives an elliptic curve key for signing authorization policies from the
 // supplied input key. Pre-v3 key objects stored the private part of the elliptic curve key inside
 // the sealed key, but v3 keys are wrapped by secboot.KeyData which protects an auxiliary key that

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -1,0 +1,445 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+
+	"github.com/canonical/go-tpm2"
+
+	"golang.org/x/xerrors"
+
+	"github.com/snapcore/secboot"
+)
+
+var (
+	secbootNewKeyData = secboot.NewKeyData
+)
+
+// ProtectKeyParams provides arguments for the ProtectKey* APIs.
+type ProtectKeyParams struct {
+	// PCRProfile defines the profile used to generate the initial PCR protection
+	// policy for the newly created sealed key data. This can be updated later on
+	// by calling SealedKeyData.UpdatePCRProtectionPolicy.
+	PCRProfile *PCRProtectionProfile
+
+	// PCRPolicyCounterHandle is the handle at which to create a NV index for PCR
+	// authorization policy revocation support. The handle must either be tpm2.HandleNull
+	// (in which case, no NV index will be created and the sealed key will not benefit
+	// from PCR authorization policy revocation support), or it must be a valid NV index
+	// handle (MSO == 0x01). The choice of handle should take in to consideration the
+	// reserved indices from the "Registry of reserved TPM 2.0 handles and localities"
+	// specification. It is recommended that the handle is in the block reserved for
+	// owner objects (0x01800000 - 0x01bfffff).
+	PCRPolicyCounterHandle tpm2.Handle
+
+	// AuthKey is the key used to authorize changes to the newly create key,
+	// via the SealedKeyObject.UpdatePCRProtectionPolicy and
+	// secboot.KeyData.SetAuthorizedSnapModels APIs. If set, this should be a
+	// random 32-byte number.
+	// If not set, one is generated automatically.
+	AuthKey secboot.AuxiliaryKey
+
+	// AuthorizedSnapModels is a list of models initially authorized to access
+	// the data protected by the newly created key. These can be updated later
+	// on by calling secboot.KeyData.SetAuthorizedSnapModels.
+	AuthorizedSnapModels []secboot.SnapModel
+}
+
+type keyDataPolicyParams struct {
+	Alg    tpm2.HashAlgorithmId
+	Data   keyDataPolicy
+	Digest tpm2.Digest
+}
+
+// makeKeyDataWithPolicy protects the supplied keys using the supplied keySealer and
+// policy data. This can be called multiple times to protect an arbitary number of
+// keys with an identical policy.
+func makeKeyDataWithPolicy(key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, policy *keyDataPolicyParams, sealer keySealer) (*secboot.KeyData, error) {
+	var symKey [32 + aes.BlockSize]byte
+	if _, err := rand.Read(symKey[:]); err != nil {
+		return nil, xerrors.Errorf("cannot create symmetric key: %w", err)
+	}
+
+	priv, pub, importSymSeed, err := sealer.CreateSealedObject(symKey[:], policy.Alg, policy.Digest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new SealedKeyObject.
+	data, err := newKeyData(priv, pub, importSymSeed, policy.Data)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create key data: %w", err)
+	}
+	skd := &SealedKeyData{sealedKeyDataBase: sealedKeyDataBase{data: data}}
+
+	// Create encrypted payload
+	payload := secboot.MarshalKeys(key, authKey)
+
+	b, err := aes.NewCipher(symKey[:32])
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create new cipher: %w", err)
+	}
+	stream := cipher.NewCFBEncrypter(b, symKey[32:])
+	stream.XORKeyStream(payload, payload)
+
+	kd, err := secbootNewKeyData(&secboot.KeyParams{
+		Handle:           skd,
+		EncryptedPayload: payload,
+		PlatformName:     platformName,
+		AuxiliaryKey:     authKey,
+		// Hardcode SHA-256 here. We already hardcode this as the name algorithm
+		// for the sealed object and elliptic key.
+		SnapModelAuthHash: crypto.SHA256})
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create key data object: %w", err)
+	}
+
+	return kd, nil
+}
+
+type createdPcrPolicyCounter struct {
+	tpm     *tpm2.TPMContext
+	session tpm2.SessionContext
+	pub     *tpm2.NVPublic
+}
+
+func (c *createdPcrPolicyCounter) Pub() *tpm2.NVPublic {
+	if c == nil {
+		return nil
+	}
+	return c.pub
+}
+
+func (c *createdPcrPolicyCounter) undefineOnError(err error) {
+	if c == nil {
+		return
+	}
+
+	if err == nil {
+		return
+	}
+
+	index, err := tpm2.CreateNVIndexResourceContextFromPublic(c.pub)
+	if err != nil {
+		return
+	}
+	c.tpm.NVUndefineSpace(c.tpm.OwnerHandleContext(), index, c.session)
+}
+
+// makeKeyDataPolicy creates the policy data required to seal a key with makeKeyDataWithPolicy
+// and creates a PCR policy counter if required.
+func makeKeyDataPolicy(tpm *tpm2.TPMContext, pcrPolicyCounterHandle tpm2.Handle, authKey secboot.AuxiliaryKey,
+	session tpm2.SessionContext) (data *keyDataPolicyParams, pcrPolicyCounter *createdPcrPolicyCounter,
+	authKeyOut secboot.AuxiliaryKey, err error) {
+	// Create an auth key.
+	if authKey == nil {
+		authKey = make(secboot.AuxiliaryKey, 32)
+		if _, err := rand.Read(authKey); err != nil {
+			return nil, nil, nil, xerrors.Errorf("cannot create key for signing dynamic authorization policies: %w", err)
+		}
+	}
+	authPublicKey, err := newPolicyAuthPublicKey(authKey)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot derive public area of key for signing dynamic authorization policies: %w", err)
+	}
+
+	// Create PCR policy counter, if requested.
+	var pcrPolicyCount uint64
+	if pcrPolicyCounterHandle != tpm2.HandleNull {
+		if tpm == nil {
+			return nil, nil, nil, errors.New("cannot create a PCR policy counter without a TPM connection")
+		}
+
+		var pub *tpm2.NVPublic
+		pub, pcrPolicyCount, err = createPcrPolicyCounter(tpm, pcrPolicyCounterHandle, authPublicKey, session)
+		switch {
+		case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
+			return nil, nil, nil, TPMResourceExistsError{pcrPolicyCounterHandle}
+		case isAuthFailError(err, tpm2.CommandNVDefineSpace, 1):
+			return nil, nil, nil, AuthFailError{tpm2.HandleOwner}
+		case err != nil:
+			return nil, nil, nil, xerrors.Errorf("cannot create new PCR policy counter: %w", err)
+		}
+
+		pcrPolicyCounter = &createdPcrPolicyCounter{
+			tpm:     tpm,
+			session: session,
+			pub:     pub}
+
+		defer func() { pcrPolicyCounter.undefineOnError(err) }()
+	}
+
+	nameAlg := tpm2.HashAlgorithmSHA256
+
+	// Create the initial policy data
+	policyData, authPolicy, err := newKeyDataPolicy(nameAlg, authPublicKey, pcrPolicyCounter.Pub(), pcrPolicyCount)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create initial policy data: %w", err)
+	}
+
+	return &keyDataPolicyParams{
+		Alg:    nameAlg,
+		Data:   policyData,
+		Digest: authPolicy}, pcrPolicyCounter, authKey, nil
+}
+
+type keyDataParams struct {
+	PCRPolicyCounterHandle tpm2.Handle
+	PCRProfile             *PCRProtectionProfile
+}
+
+// makeNewKeyData protects the supplied keys using the supplied keySealer and
+// parameters. If required, a PCR policy counter is created. The returned key
+// will have an initial PCR policy as specified via the supplied parameters.
+func makeNewKeyData(tpm *tpm2.TPMContext, key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, params *keyDataParams,
+	sealer keySealer, session tpm2.SessionContext) (protectedKey *secboot.KeyData, authKeyOut secboot.AuxiliaryKey,
+	pcrPolicyCounter *createdPcrPolicyCounter, err error) {
+	policy, pcrPolicyCounter, authKey, err := makeKeyDataPolicy(tpm, params.PCRPolicyCounterHandle, authKey, session)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer func() { pcrPolicyCounter.undefineOnError(err) }()
+
+	protectedKey, err = makeKeyDataWithPolicy(key, authKey, policy, sealer)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	skd, err := NewSealedKeyData(protectedKey)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot obtain SealedKeyObject from KeyData: %w", err)
+	}
+
+	pcrProfile := params.PCRProfile
+	if pcrProfile == nil {
+		pcrProfile = NewPCRProtectionProfile()
+	}
+	if err := skdbUpdatePCRProtectionPolicyImpl(&skd.sealedKeyDataBase, tpm, authKey, pcrPolicyCounter.Pub(), pcrProfile, session); err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot set initial PCR policy: %w", err)
+	}
+	if err := protectedKey.MarshalAndUpdatePlatformHandle(skd); err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot update platform handle: %w", err)
+	}
+
+	return protectedKey, authKey, pcrPolicyCounter, nil
+}
+
+// ProtectKeyWithExternalStorageKey seals the supplied disk encryption key to the TPM storage
+// key asociated with the supplied public tpmKey. This creates an importable sealed key and
+// is suitable in environments that don't have access to the TPM but do have access to the
+// public part of the TPM's storage primary key.
+//
+// The tpmKey argument must correspond to the storage primary key on the target TPM,
+// persisted at the standard handle (0x81000001).
+//
+// This function cannot create a sealed key that uses a PCR policy counter. The
+// PCRPolicyCounterHandle field of the params argument must be tpm2.HandleNull.
+//
+// The key will be protected with a PCR policy computed from the PCRProtectionProfile
+// supplied via the PCRProfile field of the params argument. The PCR policy can be updated
+// later on via the SealedKeyObject.UpdatePCRProtectionPolicy API.
+//
+// The sealed key will be created with the snap models provided via the AuthorizedSnapModels
+// field of params authorized to access the data protected by this key. The set of
+// authorized models can be updated later on by calling
+// secboot.KeyData.SetAuthorizedSnapModels.
+//
+// The key used for authorizing changes to the sealed key object via the
+// SealedKeyObject.UpdatePCRProtectionPolicy and secboot.KeyData.SetAuthorizedSnapModels
+// APIs can be supplied via the AuthKey field of params. This should be cryptographically
+// strong 32-byte key. If one is not supplied, it will be created automatically.
+//
+// On success, this function returns the the sealed key object and a key used for
+// authorizing changes via the SealedKeyObject.UpdatePCRProtectionPolicy and
+// secboot.KeyData.SetAuthorizedSnapModels APIs. This key doesn't need to be
+// stored anywhere, and certainly mustn't be stored outside of the encrypted container
+// protected by the supplied key. The key is stored encrypted inside the sealed
+// key data and will be returnred from future calls to secboot.KeyData.RecoverKeys.
+func ProtectKeyWithExternalStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockKey, params *ProtectKeyParams) (protectedKey *secboot.KeyData, authKey secboot.AuxiliaryKey, err error) {
+	// params is mandatory.
+	if params == nil {
+		return nil, nil, errors.New("no ProtectKeyParams provided")
+	}
+	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		return nil, nil, errors.New("PCR policy counter handle must be tpm2.HandleNull when creating an importable sealed key")
+	}
+
+	sealer := &importableObjectKeySealer{tpmKey: tpmKey}
+
+	protectedKey, authKey, _, err = makeNewKeyData(nil, key, params.AuthKey, &keyDataParams{
+		PCRPolicyCounterHandle: params.PCRPolicyCounterHandle,
+		PCRProfile:             params.PCRProfile}, sealer, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := protectedKey.SetAuthorizedSnapModels(authKey, params.AuthorizedSnapModels...); err != nil {
+		return nil, nil, xerrors.Errorf("cannot set authorized snap models: %w", err)
+	}
+
+	return protectedKey, authKey, nil
+}
+
+// ProtectKeysWithTPM seals the supplied disk encryption keys to the storage
+// hierarchy of the TPM. The keys are specified by the keys argument.
+//
+// This function requires knowledge of the authorization value for the storage hierarchy,
+// which must be provided by calling Connection.OwnerHandleContext().SetAuthValue() prior
+// to calling this function. If the provided authorization value is incorrect, a
+// AuthFailError error will be returned.
+//
+// This function will create a NV index at the handle specified by the
+// PCRPolicyCounterHandle field of the params argument if it is not tpm2.HandleNull. If
+// the handle is already in use, a TPMResourceExistsError error will be returned. In this
+// case, the caller will need to either choose a different handle or undefine the existing
+// one. If it is not tpm2.HandleNull, then it must be a valid NV index handle (MSO == 0x01),
+// and the choice of handle should take in to consideration the reserved indices from the
+// "Registry of reserved TPM 2.0 handles and localities" specification. It is recommended
+// that the handle is in the block reserved for owner objects (0x01800000 - 0x01bfffff).
+//
+// All keys will be created with the same authorization policy, and will be protected with
+// a PCR policy computed from the PCRProtectionProfile supplied via the PCRProfile field
+// of the params argument. The PCR policy can be updated later on via the
+// UpdateKeyPCRProtectionPolicyMultiple API.
+//
+// The sealed keys will be created with the snap models provided via the AuthorizedSnapModels
+// field of params authorized to access the data protected by these keys. The set
+// of authorized models can be updated later on by calling
+// secboot.KeyData.SetAuthorizedSnapModels for each key.
+//
+// The key used for authorizing changes to the sealed key objects via the
+// UpdateKeyPCRProtectionPolicyMultiple and secboot.KeyData.SetAuthorizedSnapModels
+// APIs can be supplied via the AuthKey field of params. This should be cryptographically
+// strong 32-byte key. If one is not supplied, it will be created automatically.
+//
+// On success, this function returns the the sealed key objects and a key used for
+// authorizing changes via the UpdateKeyPCRProtectionPolicyMultiple and
+// secboot.KeyData.SetAuthorizedSnapModels APIs. This key doesn't need to be
+// stored anywhere, and certainly mustn't be stored outside of the encrypted containers
+// protected by the supplied keys. The key is stored encrypted inside the sealed
+// key data and will be returnred from future calls to secboot.KeyData.RecoverKeys.
+func ProtectKeysWithTPM(tpm *Connection, keys []secboot.DiskUnlockKey, params *ProtectKeyParams) (protectedKeys []*secboot.KeyData, authKey secboot.AuxiliaryKey, err error) {
+	// params is mandatory.
+	if params == nil {
+		return nil, nil, errors.New("no ProtectKeyParams provided")
+	}
+	if len(keys) == 0 {
+		return nil, nil, errors.New("no keys provided")
+	}
+
+	sealer := &sealedObjectKeySealer{tpm}
+
+	var protectedKey *secboot.KeyData
+	var pcrPolicyCounter *createdPcrPolicyCounter
+
+	protectedKey, authKey, pcrPolicyCounter, err = makeNewKeyData(tpm.TPMContext, keys[0], params.AuthKey,
+		&keyDataParams{
+			PCRPolicyCounterHandle: params.PCRPolicyCounterHandle,
+			PCRProfile:             params.PCRProfile},
+		sealer, tpm.HmacSession())
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { pcrPolicyCounter.undefineOnError(err) }()
+	protectedKeys = append(protectedKeys, protectedKey)
+
+	skd, err := NewSealedKeyData(protectedKey)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("cannot obtain SealedKeyObject from KeyData: %w", err)
+	}
+
+	policy := &keyDataPolicyParams{
+		Alg:    skd.data.Public().NameAlg,
+		Digest: skd.data.Public().AuthPolicy,
+		Data:   skd.data.Policy()}
+	for _, key := range keys[1:] {
+		protectedKey, err := makeKeyDataWithPolicy(key, authKey, policy, sealer)
+		if err != nil {
+			return nil, nil, err
+		}
+		protectedKeys = append(protectedKeys, protectedKey)
+	}
+
+	for _, kd := range protectedKeys {
+		if err := kd.SetAuthorizedSnapModels(authKey, params.AuthorizedSnapModels...); err != nil {
+			return nil, nil, xerrors.Errorf("cannot set authorized snap models: %w", err)
+		}
+	}
+
+	return protectedKeys, authKey, nil
+}
+
+// ProtectKeyWithTPM seals the supplied disk encryption key to the storage hierarchy of
+// the TPM.
+//
+// This function requires knowledge of the authorization value for the storage hierarchy,
+// which must be provided by calling Connection.OwnerHandleContext().SetAuthValue() prior
+// to calling this function. If the provided authorization value is incorrect, a
+// AuthFailError error will be returned.
+//
+// This function will create a NV index at the handle specified by the
+// PCRPolicyCounterHandle field of the params argument if it is not tpm2.HandleNull. If
+// the handle is already in use, a TPMResourceExistsError error will be returned. In this
+// case, the caller will need to either choose a different handle or undefine the existing
+// one. If it is not tpm2.HandleNull, then it must be a valid NV index handle (MSO == 0x01),
+// and the choice of handle should take in to consideration the reserved indices from the
+// "Registry of reserved TPM 2.0 handles and localities" specification. It is recommended
+// that the handle is in the block reserved for owner objects (0x01800000 - 0x01bfffff).
+//
+// The key will be protected with a PCR policy computed from the PCRProtectionProfile
+// supplied via the PCRProfile field of the params argument. The PCR policy can be updated
+// later on via the SealedKeyObject.UpdatePCRProtectionPolicy API.
+//
+// The sealed key will be created with the snap models provided via the AuthorizedSnapModels
+// field of params authorized to access the data protected by this key. The set of
+// authorized models can be updated later on by calling
+// secboot.KeyData.SetAuthorizedSnapModels.
+//
+// The key used for authorizing changes to the sealed key object via the
+// SealedKeyObject.UpdatePCRProtectionPolicy and secboot.KeyData.SetAuthorizedSnapModels
+// APIs can be supplied via the AuthKey field of params. This should be cryptographically
+// strong 32-byte key. If one is not supplied, it will be created automatically.
+//
+// On success, this function returns the the sealed key object and a key used for
+// authorizing changes via the SealedKeyObject.UpdatePCRProtectionPolicy and
+// secboot.KeyData.SetAuthorizedSnapModels APIs. This key doesn't need to be
+// stored anywhere, and certainly mustn't be stored outside of the encrypted container
+// protected by the supplied key. The key is stored encrypted inside the sealed
+// key data and will be returnred from future calls to secboot.KeyData.RecoverKeys.
+func ProtectKeyWithTPM(tpm *Connection, key secboot.DiskUnlockKey, params *ProtectKeyParams) (protectedKey *secboot.KeyData, authKey secboot.AuxiliaryKey, err error) {
+	// params is mandatory.
+	if params == nil {
+		return nil, nil, errors.New("no ProtectKeyParams provided")
+	}
+
+	var protectedKeys []*secboot.KeyData
+
+	protectedKeys, authKey, err = ProtectKeysWithTPM(tpm, []secboot.DiskUnlockKey{key}, params)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return protectedKeys[0], authKey, nil
+}

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -154,7 +154,7 @@ type keyDataPolicyParams struct {
 // makeKeyDataPolicy creates the policy data required to seal a key with makeKeyDataWithPolicy
 // and creates a PCR policy counter if required.
 func makeKeyDataPolicy(tpm *tpm2.TPMContext, pcrPolicyCounterHandle tpm2.Handle, authKey secboot.AuxiliaryKey,
-	session tpm2.SessionContext) (data *keyDataPolicyParams, pcrPolicyCounter *createdPcrPolicyCounter,
+	session tpm2.SessionContext) (data *keyDataPolicyParams, pcrPolicyCounterOut *createdPcrPolicyCounter,
 	authKeyOut secboot.AuxiliaryKey, err error) {
 	// Create an auth key.
 	if authKey == nil {
@@ -170,6 +170,7 @@ func makeKeyDataPolicy(tpm *tpm2.TPMContext, pcrPolicyCounterHandle tpm2.Handle,
 
 	// Create PCR policy counter, if requested.
 	var pcrPolicyCount uint64
+	var pcrPolicyCounter *createdPcrPolicyCounter
 	if pcrPolicyCounterHandle != tpm2.HandleNull {
 		if tpm == nil {
 			return nil, nil, nil, errors.New("cannot create a PCR policy counter without a TPM connection")
@@ -219,7 +220,7 @@ type keyDataParams struct {
 // will have an initial PCR policy as specified via the supplied parameters.
 func makeKeyData(tpm *tpm2.TPMContext, key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, params *keyDataParams,
 	sealer keySealer, session tpm2.SessionContext) (protectedKey *secboot.KeyData, authKeyOut secboot.AuxiliaryKey,
-	pcrPolicyCounter *createdPcrPolicyCounter, err error) {
+	pcrPolicyCounterOut *createdPcrPolicyCounter, err error) {
 	policy, pcrPolicyCounter, authKey, err := makeKeyDataPolicy(tpm, params.PCRPolicyCounterHandle, authKey, session)
 	if err != nil {
 		return nil, nil, nil, err

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -210,10 +210,10 @@ type keyDataParams struct {
 	PCRProfile             *PCRProtectionProfile
 }
 
-// makeNewKeyData protects the supplied keys using the supplied keySealer and
+// makeKeyData protects the supplied keys using the supplied keySealer and
 // parameters. If required, a PCR policy counter is created. The returned key
 // will have an initial PCR policy as specified via the supplied parameters.
-func makeNewKeyData(tpm *tpm2.TPMContext, key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, params *keyDataParams,
+func makeKeyData(tpm *tpm2.TPMContext, key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, params *keyDataParams,
 	sealer keySealer, session tpm2.SessionContext) (protectedKey *secboot.KeyData, authKeyOut secboot.AuxiliaryKey,
 	pcrPolicyCounter *createdPcrPolicyCounter, err error) {
 	policy, pcrPolicyCounter, authKey, err := makeKeyDataPolicy(tpm, params.PCRPolicyCounterHandle, authKey, session)
@@ -288,7 +288,7 @@ func ProtectKeyWithExternalStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnloc
 
 	sealer := &importableObjectKeySealer{tpmKey: tpmKey}
 
-	protectedKey, authKey, _, err = makeNewKeyData(nil, key, params.AuthKey, &keyDataParams{
+	protectedKey, authKey, _, err = makeKeyData(nil, key, params.AuthKey, &keyDataParams{
 		PCRPolicyCounterHandle: params.PCRPolicyCounterHandle,
 		PCRProfile:             params.PCRProfile}, sealer, nil)
 	if err != nil {
@@ -354,7 +354,7 @@ func ProtectKeysWithTPM(tpm *Connection, keys []secboot.DiskUnlockKey, params *P
 	var protectedKey *secboot.KeyData
 	var pcrPolicyCounter *createdPcrPolicyCounter
 
-	protectedKey, authKey, pcrPolicyCounter, err = makeNewKeyData(tpm.TPMContext, keys[0], params.AuthKey,
+	protectedKey, authKey, pcrPolicyCounter, err = makeKeyData(tpm.TPMContext, keys[0], params.AuthKey,
 		&keyDataParams{
 			PCRPolicyCounterHandle: params.PCRPolicyCounterHandle,
 			PCRProfile:             params.PCRProfile},

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -67,15 +67,6 @@ type ProtectKeyParams struct {
 	AuthorizedSnapModels []secboot.SnapModel
 }
 
-// keyDataPolicyParams corresponds to the parameters of a key's computed authorization
-// policy, consisting of the digest algorithm, the policy digest and the associated policy
-// data.
-type keyDataPolicyParams struct {
-	Alg        tpm2.HashAlgorithmId
-	PolicyData keyDataPolicy
-	AuthPolicy tpm2.Digest
-}
-
 // makeKeyDataWithPolicy protects the supplied keys using the supplied keySealer and
 // policy data. This can be called multiple times to protect an arbitary number of
 // keys with an identical policy.
@@ -149,6 +140,15 @@ func (c *createdPcrPolicyCounter) undefineOnError(err error) {
 		return
 	}
 	c.tpm.NVUndefineSpace(c.tpm.OwnerHandleContext(), index, c.session)
+}
+
+// keyDataPolicyParams corresponds to the parameters of a key's computed authorization
+// policy, consisting of the digest algorithm, the policy digest and the associated policy
+// data.
+type keyDataPolicyParams struct {
+	Alg        tpm2.HashAlgorithmId
+	PolicyData keyDataPolicy
+	AuthPolicy tpm2.Digest
 }
 
 // makeKeyDataPolicy creates the policy data required to seal a key with makeKeyDataWithPolicy

--- a/tpm2/seal_legacy.go
+++ b/tpm2/seal_legacy.go
@@ -52,6 +52,8 @@ func makeImportableSealedKeyTemplate() *tpm2.Public {
 }
 
 // KeyCreationParams provides arguments for SealKeyToTPM.
+//
+// Deprecated: Use ProtectKeys* APIs.
 type KeyCreationParams struct {
 	// PCRProfile defines the profile used to generate a PCR protection policy for the newly created sealed key file.
 	PCRProfile *PCRProtectionProfile
@@ -92,6 +94,8 @@ type KeyCreationParams struct {
 //
 // The authorization key can also be chosen and provided by setting
 // AuthKey in the params argument.
+//
+// Deprecated: Use ProtectKeyWithExternalStorageKey.
 func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockKey, keyPath string, params *KeyCreationParams) (authKey secboot.AuxiliaryKey, err error) {
 	// params is mandatory.
 	if params == nil {
@@ -193,6 +197,8 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockK
 
 // SealKeyRequest corresponds to a key that should be sealed by SealKeyToTPMMultiple
 // to a file at the specified path.
+//
+// Deprecated: Use ProtectKeys* APIs.
 type SealKeyRequest struct {
 	Key  secboot.DiskUnlockKey
 	Path string
@@ -226,6 +232,8 @@ type SealKeyRequest struct {
 //
 // The authorization key can also be chosen and provided by setting
 // AuthKey in the params argument.
+//
+// Deprecated: Use ProtectKeysWithTPM.
 func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCreationParams) (authKey secboot.AuxiliaryKey, err error) {
 	// params is mandatory.
 	if params == nil {
@@ -401,6 +409,8 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 //
 // The authorization key can also be chosen and provided by setting
 // AuthKey in the params argument.
+//
+// Deprecated: Use ProtectKeyWithTPM.
 func SealKeyToTPM(tpm *Connection, key secboot.DiskUnlockKey, keyPath string, params *KeyCreationParams) (authKey secboot.AuxiliaryKey, err error) {
 	return SealKeyToTPMMultiple(tpm, []*SealKeyRequest{{Key: key, Path: keyPath}}, params)
 }

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -1049,13 +1049,13 @@ func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithProvidedAuthKey(c *C) {
 		authKey: testutil.DecodeHexString(c, "fb8978601d0c2dd4129e3b9c1bb3f3116f4c5dd217c29b1017ab7cd31a882d3c")})
 }
 
-type testMakeNewKeyDataData struct {
+type testMakeKeyDataData struct {
 	authKey                      secboot.AuxiliaryKey
 	params                       *KeyDataParams
 	initialPcrPolicyCounterValue uint64
 }
 
-func (s *sealSuiteNoTPM) testMakeNewKeyData(c *C, data *testMakeNewKeyDataData) {
+func (s *sealSuiteNoTPM) testMakeKeyData(c *C, data *testMakeKeyDataData) {
 	var mockTpm *tpm2.TPMContext
 	var mockSession tpm2.SessionContext
 	if data.params.PCRPolicyCounterHandle != tpm2.HandleNull {
@@ -1131,7 +1131,7 @@ func (s *sealSuiteNoTPM) testMakeNewKeyData(c *C, data *testMakeNewKeyDataData) 
 	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
-	kd, authKeyOut, pcrPolicyCounter, err := MakeNewKeyData(mockTpm, key, data.authKey, data.params, &sealer, mockSession)
+	kd, authKeyOut, pcrPolicyCounter, err := MakeKeyData(mockTpm, key, data.authKey, data.params, &sealer, mockSession)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.lastAuthKey, NotNil)
@@ -1179,31 +1179,31 @@ func (s *sealSuiteNoTPM) testMakeNewKeyData(c *C, data *testMakeNewKeyDataData) 
 	}
 }
 
-func (s *sealSuiteNoTPM) TestMakeNewKeyData(c *C) {
-	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+func (s *sealSuiteNoTPM) TestMakeKeyData(c *C) {
+	s.testMakeKeyData(c, &testMakeKeyDataData{
 		params: &KeyDataParams{
 			PCRPolicyCounterHandle: tpm2.HandleNull,
 			PCRProfile:             NewPCRProtectionProfile()}})
 }
 
-func (s *sealSuiteNoTPM) TestMakeNewKeyDataWithPolicyCounter(c *C) {
-	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyCounter(c *C) {
+	s.testMakeKeyData(c, &testMakeKeyDataData{
 		params: &KeyDataParams{
 			PCRPolicyCounterHandle: 0x01810000,
 			PCRProfile:             NewPCRProtectionProfile()},
 		initialPcrPolicyCounterValue: 30})
 }
 
-func (s *sealSuiteNoTPM) TestMakeNewKeyDataWithPolicyCounterDifferentInitialValue(c *C) {
-	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyCounterDifferentInitialValue(c *C) {
+	s.testMakeKeyData(c, &testMakeKeyDataData{
 		params: &KeyDataParams{
 			PCRPolicyCounterHandle: 0x01810000,
 			PCRProfile:             NewPCRProtectionProfile()},
 		initialPcrPolicyCounterValue: 500})
 }
 
-func (s *sealSuiteNoTPM) TestMakeNewKeyDataNilPCRProfile(c *C) {
-	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+func (s *sealSuiteNoTPM) TestMakeKeyDataNilPCRProfile(c *C) {
+	s.testMakeKeyData(c, &testMakeKeyDataData{
 		params: &KeyDataParams{
 			PCRPolicyCounterHandle: tpm2.HandleNull}})
 }

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -1,0 +1,1209 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2_test
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	_ "crypto/sha256"
+	"errors"
+	"math/rand"
+
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
+	"github.com/canonical/go-tpm2/templates"
+	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/tcg"
+	"github.com/snapcore/secboot/internal/testutil"
+	"github.com/snapcore/secboot/internal/tpm2test"
+	. "github.com/snapcore/secboot/tpm2"
+)
+
+type sealSuite struct {
+	tpm2test.TPMTest
+	primaryKeyMixin
+}
+
+func (s *sealSuite) SetUpSuite(c *C) {
+	s.TPMFeatures = tpm2test.TPMFeatureOwnerHierarchy |
+		tpm2test.TPMFeatureEndorsementHierarchy |
+		tpm2test.TPMFeatureLockoutHierarchy | // Allow the test fixture to reset the DA counter
+		tpm2test.TPMFeaturePCR |
+		tpm2test.TPMFeatureNV
+}
+
+func (s *sealSuite) SetUpTest(c *C) {
+	s.TPMTest.SetUpTest(c)
+
+	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+}
+
+var _ = Suite(&sealSuite{})
+
+func (s *sealSuite) testProtectKeyWithTPM(c *C, params *ProtectKeyParams) {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	c.Assert(err, IsNil)
+
+	for _, model := range params.AuthorizedSnapModels {
+		ok, err := k.IsSnapModelAuthorized(authKey, model)
+		c.Check(err, IsNil)
+		c.Check(ok, testutil.IsTrue)
+	}
+
+	skd, err := NewSealedKeyData(k)
+	c.Assert(err, IsNil)
+	c.Check(skd.Validate(s.TPM().TPMContext, authKey, s.TPM().HmacSession()), IsNil)
+
+	c.Check(skd.Version(), Equals, uint32(3))
+	c.Check(skd.PCRPolicyCounterHandle(), Equals, params.PCRPolicyCounterHandle)
+
+	policyAuthPublicKey, err := NewPolicyAuthPublicKey(authKey)
+	c.Assert(err, IsNil)
+
+	var pcrPolicyCounterPub *tpm2.NVPublic
+	var pcrPolicySequence uint64
+	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		index, err := s.TPM().CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
+		c.Assert(err, IsNil)
+
+		pcrPolicyCounterPub, _, err = s.TPM().NVReadPublic(index)
+		c.Check(err, IsNil)
+
+		pcrPolicySequence, err = s.TPM().NVReadCounter(index, index, nil)
+		c.Check(err, IsNil)
+	}
+
+	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, pcrPolicyCounterPub, pcrPolicySequence)
+	c.Assert(err, IsNil)
+
+	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
+	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
+	c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
+
+	if params.AuthKey != nil {
+		c.Check(authKey, DeepEquals, params.AuthKey)
+	}
+
+	keyUnsealed, authKeyUnsealed, err := k.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(keyUnsealed, DeepEquals, key)
+	c.Check(authKeyUnsealed, DeepEquals, authKey)
+
+	if params.PCRProfile != nil {
+		// Verify that the key is sealed with the supplied PCR profile by changing
+		// the PCR values.
+		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
+		c.Check(err, IsNil)
+		_, _, err = k.RecoverKeys()
+		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
+	}
+
+	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		c.Check(s.TPM().DoesHandleExist(params.PCRPolicyCounterHandle), testutil.IsTrue)
+	}
+}
+
+func (s *sealSuite) TestProtectKeyWithTPM(c *C) {
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMDifferentPCRPolicyCounterHandle(c *C) {
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMWithNewConnection(c *C) {
+	// ProtectKeyWithTPM behaves slightly different if called immediately after
+	// EnsureProvisioned with the same Connection
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+
+	s.validateSRK(c)
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMMissingSRK(c *C) {
+	// Ensure that calling ProtectKeyWithTPM recreates the SRK with the standard template
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+
+	s.validateSRK(c)
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMMissingCustomSRK(c *C) {
+	// Ensure that calling ProtectKeyWithTPM recreates the SRK with the custom
+	// template originally supplied during provisioning
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+
+	template := &tpm2.Public{
+		Type:    tpm2.ObjectTypeRSA,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrUserWithAuth | tpm2.AttrNoDA |
+			tpm2.AttrRestricted | tpm2.AttrDecrypt,
+		Params: &tpm2.PublicParamsU{
+			RSADetail: &tpm2.RSAParams{
+				Symmetric: tpm2.SymDefObject{
+					Algorithm: tpm2.SymObjectAlgorithmAES,
+					KeyBits:   &tpm2.SymKeyBitsU{Sym: 128},
+					Mode:      &tpm2.SymModeU{Sym: tpm2.SymModeCFB}},
+				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
+				KeyBits:  2048,
+				Exponent: 0}}}
+	tmplBytes := mu.MustMarshalToBytes(template)
+
+	nvPub := tpm2.NVPublic{
+		Index:   SrkTemplateHandle,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVOwnerRead | tpm2.AttrNVNoDA),
+		Size:    uint16(len(tmplBytes))}
+	nv := s.NVDefineSpace(c, tpm2.HandleOwner, nil, &nvPub)
+	c.Check(s.TPM().NVWrite(nv, nv, tmplBytes, 0, nil), IsNil)
+
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+
+	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, template)
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMMissingSRKWithInvalidCustomTemplate(c *C) {
+	// Ensure that calling ProtectKeyWithTPM recreates the SRK with the standard
+	// template if the NV index we use to store custom templates has invalid
+	// contents - if the contents are invalid then we didn't create it.
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+
+	template := tpm2.Public{
+		Type:    tpm2.ObjectTypeRSA,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs: tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin | tpm2.AttrUserWithAuth | tpm2.AttrNoDA |
+			tpm2.AttrRestricted | tpm2.AttrSign,
+		Params: &tpm2.PublicParamsU{
+			RSADetail: &tpm2.RSAParams{
+				Symmetric: tpm2.SymDefObject{Algorithm: tpm2.SymObjectAlgorithmNull},
+				Scheme: tpm2.RSAScheme{
+					Scheme: tpm2.RSASchemeRSAPSS,
+					Details: &tpm2.AsymSchemeU{
+						RSAPSS: &tpm2.SigSchemeRSAPSS{HashAlg: tpm2.HashAlgorithmSHA256},
+					},
+				},
+				KeyBits:  2048,
+				Exponent: 0}}}
+	tmplBytes := mu.MustMarshalToBytes(template)
+
+	nvPub := tpm2.NVPublic{
+		Index:   SrkTemplateHandle,
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVOwnerRead | tpm2.AttrNVNoDA),
+		Size:    uint16(len(tmplBytes))}
+	nv := s.NVDefineSpace(c, tpm2.HandleOwner, nil, &nvPub)
+	c.Check(s.TPM().NVWrite(nv, nv, tmplBytes, 0, nil), IsNil)
+
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+
+	s.validateSRK(c)
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMNilPCRProfileAndNoAuthorizedSnapModels(c *C) {
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)})
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMNoPCRPolicyCounterHandle(c *C) {
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: tpm2.HandleNull,
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMWithProvidedAuthKey(c *C) {
+	authKey := make(secboot.AuxiliaryKey, 32)
+	rand.Read(authKey)
+
+	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")},
+		AuthKey: authKey})
+}
+
+type testProtectKeysWithTPMData struct {
+	n      int
+	params *ProtectKeyParams
+}
+
+func (s *sealSuite) testProtectKeysWithTPM(c *C, data *testProtectKeysWithTPMData) {
+	var keys []secboot.DiskUnlockKey
+	for i := 0; i < data.n; i++ {
+		key := make(secboot.DiskUnlockKey, 32)
+		rand.Read(key)
+
+		keys = append(keys, key)
+	}
+
+	protectedKeys, authKey, err := ProtectKeysWithTPM(s.TPM(), keys, data.params)
+	c.Check(err, IsNil)
+	c.Check(protectedKeys, HasLen, data.n)
+
+	policyAuthPublicKey, err := NewPolicyAuthPublicKey(authKey)
+	c.Assert(err, IsNil)
+
+	var pcrPolicyCounterPub *tpm2.NVPublic
+	var pcrPolicySequence uint64
+	if data.params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		index, err := s.TPM().CreateResourceContextFromTPM(data.params.PCRPolicyCounterHandle)
+		c.Assert(err, IsNil)
+
+		pcrPolicyCounterPub, _, err = s.TPM().NVReadPublic(index)
+		c.Check(err, IsNil)
+
+		pcrPolicySequence, err = s.TPM().NVReadCounter(index, index, nil)
+		c.Check(err, IsNil)
+	}
+
+	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, pcrPolicyCounterPub, pcrPolicySequence)
+	c.Assert(err, IsNil)
+
+	for i, k := range protectedKeys {
+		for _, model := range data.params.AuthorizedSnapModels {
+			ok, err := k.IsSnapModelAuthorized(authKey, model)
+			c.Check(err, IsNil)
+			c.Check(ok, testutil.IsTrue)
+		}
+
+		skd, err := NewSealedKeyData(k)
+		c.Assert(err, IsNil)
+		c.Check(skd.Validate(s.TPM().TPMContext, authKey, s.TPM().HmacSession()), IsNil)
+
+		c.Check(skd.Version(), Equals, uint32(3))
+		c.Check(skd.PCRPolicyCounterHandle(), Equals, data.params.PCRPolicyCounterHandle)
+
+		c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
+		c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
+		c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
+
+		keyUnsealed, authKeyUnsealed, err := k.RecoverKeys()
+		c.Check(err, IsNil)
+		c.Check(keyUnsealed, DeepEquals, keys[i])
+		c.Check(authKeyUnsealed, DeepEquals, authKey)
+	}
+
+	if data.params.AuthKey != nil {
+		c.Check(authKey, DeepEquals, data.params.AuthKey)
+	}
+
+	if data.params.PCRProfile != nil {
+		// Verify that the keys are sealed with the supplied PCR profile by changing
+		// the PCR values.
+		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
+		c.Check(err, IsNil)
+
+		for _, k := range protectedKeys {
+			_, _, err = k.RecoverKeys()
+			c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+				"cannot execute PolicyOR assertions: current session digest not found in policy data")
+		}
+	}
+}
+
+func (s *sealSuite) TestProtectKeysWithTPMSingle(c *C) {
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 1,
+		params: &ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			AuthorizedSnapModels: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
+}
+
+func (s *sealSuite) TestProtectKeysWithTPM2Keys(c *C) {
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 2,
+		params: &ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			AuthorizedSnapModels: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
+}
+
+func (s *sealSuite) TestProtectKeysWithTPMDifferentPCRPolicyCounterHandle(c *C) {
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 2,
+		params: &ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
+			AuthorizedSnapModels: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
+}
+
+func (s *sealSuite) TestProtectKeysWithTPMWithNewConnection(c *C) {
+	// ProtectKeysWithTPM behaves slightly different if called immediately
+	// after EnsureProvisioned with the same Connection
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 2,
+		params: &ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			AuthorizedSnapModels: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
+}
+
+func (s *sealSuite) TestProtectKeysWithTPMMissingSRK(c *C) {
+	// Ensure that calling ProtectKeysWithTPM recreates the SRK with the standard
+	// template
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 2,
+		params: &ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			AuthorizedSnapModels: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
+
+	s.validateSRK(c)
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMMultipeNilPCRProfileAndNoAuthorizedSnapModels(c *C) {
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 2,
+		params: &ProtectKeyParams{
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)}})
+}
+
+func (s *sealSuite) TestProtectKeysWithTPMNoPCRPolicyCounterHandle(c *C) {
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 2,
+		params: &ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: tpm2.HandleNull,
+			AuthorizedSnapModels: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
+}
+
+func (s *sealSuite) TestProtectKeysWithTPMWithProvidedAuthKey(c *C) {
+	authKey := make(secboot.AuxiliaryKey, 32)
+	rand.Read(authKey)
+
+	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
+		n: 2,
+		params: &ProtectKeyParams{
+			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+			AuthorizedSnapModels: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")},
+			AuthKey: authKey}})
+}
+
+func (s *sealSuite) testProtectKeyWithTPMErrorHandling(c *C, params *ProtectKeyParams) error {
+	var origCounter tpm2.ResourceContext
+	if params != nil && params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		var err error
+		origCounter, err = s.TPM().CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
+		if tpm2.IsResourceUnavailableError(err, params.PCRPolicyCounterHandle) {
+			err = nil
+		}
+		c.Check(err, IsNil)
+	}
+
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	_, _, sealErr := ProtectKeyWithTPM(s.TPM(), key, params)
+
+	var counter tpm2.ResourceContext
+	if params != nil && params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		var err error
+		counter, err = s.TPM().CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
+		if tpm2.IsResourceUnavailableError(err, params.PCRPolicyCounterHandle) {
+			err = nil
+		}
+		c.Check(err, IsNil)
+	}
+
+	switch {
+	case origCounter == nil:
+		c.Check(counter, IsNil)
+	case origCounter != nil:
+		c.Assert(counter, NotNil)
+		c.Check(counter.Name(), DeepEquals, origCounter.Name())
+	}
+
+	return sealErr
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingNilParams(c *C) {
+	c.Check(s.testProtectKeyWithTPMErrorHandling(c, nil), ErrorMatches, "no ProtectKeyParams provided")
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingOwnerAuthFail(c *C) {
+	s.HierarchyChangeAuth(c, tpm2.HandleOwner, []byte("1234"))
+	s.TPM().OwnerHandleContext().SetAuthValue(nil)
+
+	s.ReinitTPMConnectionFromExisting(c)
+
+	err := s.testProtectKeyWithTPMErrorHandling(c, &ProtectKeyParams{
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Assert(err, testutil.ConvertibleTo, AuthFailError{})
+	c.Check(err.(AuthFailError).Handle, Equals, tpm2.HandleOwner)
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingPCRPolicyCounterExists(c *C) {
+	public := tpm2.NVPublic{
+		Index:   s.NextAvailableHandle(c, 0x0181ffff),
+		NameAlg: tpm2.HashAlgorithmSHA256,
+		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVAuthRead),
+		Size:    0}
+	s.NVDefineSpace(c, tpm2.HandleOwner, nil, &public)
+
+	err := s.testProtectKeyWithTPMErrorHandling(c, &ProtectKeyParams{
+		PCRPolicyCounterHandle: public.Index})
+	c.Assert(err, testutil.ConvertibleTo, TPMResourceExistsError{})
+	c.Check(err.(TPMResourceExistsError).Handle, Equals, public.Index)
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingInvalidPCRProfile(c *C) {
+	err := s.testProtectKeyWithTPMErrorHandling(c, &ProtectKeyParams{
+		PCRProfile: tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}).
+			AddProfileOR(
+				NewPCRProtectionProfile(),
+				NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 8)),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, ErrorMatches, "cannot set initial PCR policy: cannot compute PCR digests from protection profile: "+
+		"not all branches contain values for the same sets of PCRs")
+}
+
+func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingInvalidPCRProfileSelection(c *C) {
+	err := s.testProtectKeyWithTPMErrorHandling(c, &ProtectKeyParams{
+		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 50, make([]byte, tpm2.HashAlgorithmSHA256.Size())),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, ErrorMatches, "cannot set initial PCR policy: PCR protection profile contains digests for unsupported PCRs")
+}
+
+func (s *sealSuite) testProtectKeyWithExternalStorageKey(c *C, params *ProtectKeyParams) {
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+
+	srkPub, _, _, err := s.TPM().ReadPublic(srk)
+	c.Assert(err, IsNil)
+
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	k, authKey, err := ProtectKeyWithExternalStorageKey(srkPub, key, params)
+	c.Assert(err, IsNil)
+
+	for _, model := range params.AuthorizedSnapModels {
+		ok, err := k.IsSnapModelAuthorized(authKey, model)
+		c.Check(err, IsNil)
+		c.Check(ok, testutil.IsTrue)
+	}
+
+	skd, err := NewSealedKeyData(k)
+	c.Assert(err, IsNil)
+	c.Check(skd.Validate(s.TPM().TPMContext, authKey, s.TPM().HmacSession()), IsNil)
+
+	c.Check(skd.Version(), Equals, uint32(3))
+	c.Check(skd.PCRPolicyCounterHandle(), Equals, tpm2.HandleNull)
+
+	policyAuthPublicKey, err := NewPolicyAuthPublicKey(authKey)
+	c.Assert(err, IsNil)
+
+	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, nil, 0)
+	c.Assert(err, IsNil)
+
+	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
+	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
+	c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
+
+	if params.AuthKey != nil {
+		c.Check(authKey, DeepEquals, params.AuthKey)
+	}
+
+	keyUnsealed, authKeyUnsealed, err := k.RecoverKeys()
+	c.Check(err, IsNil)
+	c.Check(keyUnsealed, DeepEquals, key)
+	c.Check(authKeyUnsealed, DeepEquals, authKey)
+
+	if params.PCRProfile != nil {
+		// Verify that the key is sealed with the supplied PCR profile by changing
+		// the PCR values.
+		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
+		c.Check(err, IsNil)
+		_, _, err = k.RecoverKeys()
+		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
+	}
+}
+
+func (s *sealSuite) TestProtectKeyWithExternalStorageKey(c *C) {
+	s.testProtectKeyWithExternalStorageKey(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewResolvedPCRProfileFromCurrentValues(c, s.TPM().TPMContext, tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: tpm2.HandleNull,
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+}
+
+func (s *sealSuite) TestProtectKeyWithExternalStorageKeyNilPCRProfileAndNoAuthorizedSnapModels(c *C) {
+	s.testProtectKeyWithExternalStorageKey(c, &ProtectKeyParams{
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+}
+
+func (s *sealSuite) TestProtectKeyWithExternalStorageKeyWithProvidedAuthKey(c *C) {
+	authKey := make(secboot.AuxiliaryKey, 32)
+	rand.Read(authKey)
+
+	s.testProtectKeyWithExternalStorageKey(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewResolvedPCRProfileFromCurrentValues(c, s.TPM().TPMContext, tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: tpm2.HandleNull,
+		AuthorizedSnapModels: []secboot.SnapModel{
+			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")},
+		AuthKey: authKey})
+}
+
+func (s *sealSuite) testProtectKeyWithExternalStorageKeyErrorHandling(c *C, params *ProtectKeyParams) error {
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+
+	srkPub, _, _, err := s.TPM().ReadPublic(srk)
+	c.Assert(err, IsNil)
+
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	_, _, sealErr := ProtectKeyWithExternalStorageKey(srkPub, key, params)
+	return sealErr
+}
+
+func (s *sealSuite) TestProtectKeyWithExternalStorageKeyErrorHandlingNilParams(c *C) {
+	c.Check(s.testProtectKeyWithExternalStorageKeyErrorHandling(c, nil), ErrorMatches, "no ProtectKeyParams provided")
+}
+
+func (s *sealSuite) TestProtectKeyWithExternalStorageKeyErrorHandlingInvalidPCRProfile(c *C) {
+	err := s.testProtectKeyWithExternalStorageKeyErrorHandling(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, ErrorMatches, "cannot set initial PCR policy: cannot compute PCR digests from protection profile: "+
+		"cannot read current PCR values from TPM: no context")
+}
+
+func (s *sealSuite) TestProtectKeyWithExternalStorageKeyErrorHandlingInvalidPCRProfileSelection(c *C) {
+	err := s.testProtectKeyWithExternalStorageKeyErrorHandling(c, &ProtectKeyParams{
+		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 50, make([]byte, tpm2.HashAlgorithmSHA256.Size())),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, ErrorMatches, "cannot set initial PCR policy: PCR protection profile contains digests for unsupported PCRs")
+}
+
+func (s *sealSuite) TestProtectKeyWithExternalStorageKeyErrorHandlingWithPCRPolicyCounter(c *C) {
+	err := s.testProtectKeyWithExternalStorageKeyErrorHandling(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewResolvedPCRProfileFromCurrentValues(c, s.TPM().TPMContext, tpm2.HashAlgorithmSHA256, []int{7}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)})
+	c.Check(err, ErrorMatches, "PCR policy counter handle must be tpm2.HandleNull when creating an importable sealed key")
+}
+
+type mockKeySealer struct {
+	called bool
+}
+
+func (s *mockKeySealer) CreateSealedObject(data []byte, nameAlg tpm2.HashAlgorithmId, policy tpm2.Digest) (tpm2.Private, *tpm2.Public, tpm2.EncryptedSecret, error) {
+	if s.called {
+		return nil, nil, nil, errors.New("called more than once")
+	}
+
+	pub := templates.NewSealedObject(nameAlg)
+	pub.AuthPolicy = policy
+
+	return tpm2.Private(data), pub, nil, nil
+}
+
+type mockSessionContext struct {
+	tpm2.SessionContext
+}
+
+type sealSuiteNoTPM struct {
+	tpm2_testutil.BaseTest
+
+	lastKeyParams *secboot.KeyParams
+
+	lastAuthKey       secboot.AuxiliaryKey
+	lastAuthKeyPublic *tpm2.Public
+}
+
+func (s *sealSuiteNoTPM) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.lastKeyParams = nil
+	s.AddCleanup(MockSecbootNewKeyData(func(params *secboot.KeyParams) (*secboot.KeyData, error) {
+		s.lastKeyParams = params
+		return secboot.NewKeyData(params)
+	}))
+
+	s.lastAuthKey = nil
+	s.lastAuthKeyPublic = nil
+	s.AddCleanup(MockNewPolicyAuthPublicKey(func(authKey secboot.AuxiliaryKey) (*tpm2.Public, error) {
+		s.lastAuthKey = authKey
+
+		pub, err := NewPolicyAuthPublicKey(authKey)
+		s.lastAuthKeyPublic = pub
+		return pub, err
+	}))
+}
+
+var _ = Suite(&sealSuiteNoTPM{})
+
+type testMakeKeyDataWithPolicyData struct {
+	policy *KeyDataPolicyParams
+}
+
+func (s *sealSuiteNoTPM) testMakeKeyDataWithPolicy(c *C, data *testMakeKeyDataWithPolicyData) {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+	authKey := make(secboot.AuxiliaryKey, 32)
+	rand.Read(authKey)
+
+	var sealer mockKeySealer
+
+	kd, err := MakeKeyDataWithPolicy(key, authKey, data.policy, &sealer)
+	c.Check(err, IsNil)
+	c.Assert(kd, NotNil)
+
+	c.Assert(s.lastKeyParams, NotNil)
+	c.Check(s.lastKeyParams.PlatformName, Equals, "tpm2")
+	c.Check(s.lastKeyParams.AuxiliaryKey, DeepEquals, authKey)
+	c.Check(s.lastKeyParams.SnapModelAuthHash, Equals, crypto.SHA256)
+
+	skd, err := NewSealedKeyData(kd)
+	c.Assert(err, IsNil)
+
+	c.Check(skd.Data().Policy(), tpm2_testutil.TPMValueDeepEquals, data.policy.Data)
+	c.Check(skd.Data().Public().NameAlg, Equals, data.policy.Alg)
+	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, data.policy.Digest)
+
+	payload := make(secboot.KeyPayload, len(s.lastKeyParams.EncryptedPayload))
+
+	c.Assert(skd.Data().Private(), HasLen, 48)
+	b, err := aes.NewCipher(skd.Data().Private()[:32])
+	c.Assert(err, IsNil)
+	stream := cipher.NewCFBDecrypter(b, skd.Data().Private()[32:])
+	stream.XORKeyStream(payload, s.lastKeyParams.EncryptedPayload)
+
+	recoveredKey, recoveredAuthKey, err := payload.Unmarshal()
+	c.Check(err, IsNil)
+	c.Check(recoveredKey, DeepEquals, key)
+	c.Check(recoveredAuthKey, DeepEquals, authKey)
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicy(c *C) {
+	policyData := &KeyDataPolicy_v3{
+		StaticData: &StaticPolicyData_v3{
+			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
+			PCRPolicyCounterHandle: tpm2.HandleNull,
+		},
+		PCRData: &PcrPolicyData_v3{
+			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
+		},
+	}
+
+	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
+		policy: &KeyDataPolicyParams{
+			Alg:    tpm2.HashAlgorithmSHA256,
+			Data:   policyData,
+			Digest: []byte{1, 2, 3, 4}}})
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyDifferentNameAlg(c *C) {
+	policyData := &KeyDataPolicy_v3{
+		StaticData: &StaticPolicyData_v3{
+			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
+			PCRPolicyCounterHandle: tpm2.HandleNull,
+		},
+		PCRData: &PcrPolicyData_v3{
+			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
+		},
+	}
+
+	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
+		policy: &KeyDataPolicyParams{
+			Alg:    tpm2.HashAlgorithmSHA1,
+			Data:   policyData,
+			Digest: []byte{1, 2, 3, 4}}})
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyDifferentPolicyDigest(c *C) {
+	policyData := &KeyDataPolicy_v3{
+		StaticData: &StaticPolicyData_v3{
+			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
+			PCRPolicyCounterHandle: tpm2.HandleNull,
+		},
+		PCRData: &PcrPolicyData_v3{
+			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
+		},
+	}
+
+	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
+		policy: &KeyDataPolicyParams{
+			Alg:    tpm2.HashAlgorithmSHA256,
+			Data:   policyData,
+			Digest: []byte{5, 6, 7, 8, 9}}})
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyDifferentPolicyVersion(c *C) {
+	policyData := &KeyDataPolicy_v1{
+		StaticData: &StaticPolicyData_v1{
+			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
+			PCRPolicyCounterHandle: tpm2.HandleNull,
+		},
+		PCRData: &PcrPolicyData_v1{
+			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
+		},
+	}
+
+	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
+		policy: &KeyDataPolicyParams{
+			Alg:    tpm2.HashAlgorithmSHA256,
+			Data:   policyData,
+			Digest: []byte{1, 2, 3, 4}}})
+}
+
+type testMakeKeyDataPolicyData struct {
+	pcrPolicyCounterHandle       tpm2.Handle
+	authKey                      secboot.AuxiliaryKey
+	initialPcrPolicyCounterValue uint64
+}
+
+func (s *sealSuiteNoTPM) testMakeKeyDataPolicy(c *C, data *testMakeKeyDataPolicyData) {
+	var mockTpm *tpm2.TPMContext
+	var mockSession tpm2.SessionContext
+	if data.pcrPolicyCounterHandle != tpm2.HandleNull {
+		mockTpm = new(tpm2.TPMContext)
+		mockSession = new(mockSessionContext)
+	}
+
+	var mockPcrPolicyCounterPub *tpm2.NVPublic
+	restore := MockCreatePcrPolicyCounter(func(tpm *tpm2.TPMContext, handle tpm2.Handle, pub *tpm2.Public, session tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
+		c.Assert(mockTpm, NotNil)
+
+		c.Check(tpm, Equals, mockTpm)
+		c.Check(handle, Equals, data.pcrPolicyCounterHandle)
+		c.Check(pub, Equals, s.lastAuthKeyPublic)
+		c.Check(session, Equals, mockSession)
+
+		mockPcrPolicyCounterPub = &tpm2.NVPublic{
+			Index:      handle,
+			NameAlg:    tpm2.HashAlgorithmSHA256,
+			Attrs:      tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
+			AuthPolicy: make([]byte, 32),
+			Size:       8}
+
+		return mockPcrPolicyCounterPub, data.initialPcrPolicyCounterValue, nil
+	})
+	defer restore()
+
+	var mockPolicyData *KeyDataPolicy_v3
+	var mockPolicyDigest tpm2.Digest
+	restore = MockNewKeyDataPolicy(func(alg tpm2.HashAlgorithmId, key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (KeyDataPolicy, tpm2.Digest, error) {
+		c.Check(alg, Equals, tpm2.HashAlgorithmSHA256)
+		c.Check(key, Equals, s.lastAuthKeyPublic)
+		c.Check(pcrPolicyCounterPub, Equals, mockPcrPolicyCounterPub)
+		c.Check(pcrPolicySequence, Equals, data.initialPcrPolicyCounterValue)
+
+		index := tpm2.HandleNull
+		if pcrPolicyCounterPub != nil {
+			index = pcrPolicyCounterPub.Index
+		}
+
+		mockPolicyData = &KeyDataPolicy_v3{
+			StaticData: &StaticPolicyData_v3{
+				AuthPublicKey:          key,
+				PCRPolicyCounterHandle: index},
+			PCRData: &PcrPolicyData_v3{
+				PolicySequence:            pcrPolicySequence,
+				AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgNull}}}
+
+		mockPolicyDigest = make([]byte, alg.Size())
+		rand.Read(mockPolicyDigest)
+
+		return mockPolicyData, mockPolicyDigest, nil
+	})
+	defer restore()
+
+	policyData, pcrPolicyCounter, authKeyOut, err := MakeKeyDataPolicy(mockTpm, data.pcrPolicyCounterHandle, data.authKey, mockSession)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.lastAuthKey, NotNil)
+	c.Assert(mockPolicyData, NotNil)
+
+	c.Assert(policyData, NotNil)
+	c.Check(policyData.Alg, Equals, tpm2.HashAlgorithmSHA256)
+	c.Assert(policyData.Data, testutil.ConvertibleTo, new(KeyDataPolicy_v3))
+	c.Check(policyData.Data.(*KeyDataPolicy_v3), Equals, mockPolicyData)
+	c.Check(policyData.Digest, DeepEquals, mockPolicyDigest)
+
+	if data.pcrPolicyCounterHandle == tpm2.HandleNull {
+		c.Check(pcrPolicyCounter, IsNil)
+	} else {
+		c.Check(pcrPolicyCounter, NotNil)
+		c.Check(pcrPolicyCounter.Pub(), Equals, mockPcrPolicyCounterPub)
+		c.Check(pcrPolicyCounter.TPM(), Equals, mockTpm)
+		c.Check(pcrPolicyCounter.Session(), Equals, mockSession)
+	}
+
+	c.Check(authKeyOut, DeepEquals, s.lastAuthKey)
+	c.Check(policyData.Data.ValidateAuthKey(authKeyOut), IsNil)
+	if data.authKey != nil {
+		c.Check(authKeyOut, DeepEquals, data.authKey)
+	}
+
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataPolicy(c *C) {
+	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
+		pcrPolicyCounterHandle: tpm2.HandleNull})
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithPolicyCounter(c *C) {
+	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
+		pcrPolicyCounterHandle:       0x01800001,
+		initialPcrPolicyCounterValue: 20})
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithPolicyCounterDifferentInitialValue(c *C) {
+	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
+		pcrPolicyCounterHandle:       0x01800001,
+		initialPcrPolicyCounterValue: 1000})
+}
+
+func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithProvidedAuthKey(c *C) {
+	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
+		authKey: testutil.DecodeHexString(c, "fb8978601d0c2dd4129e3b9c1bb3f3116f4c5dd217c29b1017ab7cd31a882d3c")})
+}
+
+type testMakeNewKeyDataData struct {
+	authKey                      secboot.AuxiliaryKey
+	params                       *KeyDataParams
+	initialPcrPolicyCounterValue uint64
+}
+
+func (s *sealSuiteNoTPM) testMakeNewKeyData(c *C, data *testMakeNewKeyDataData) {
+	var mockTpm *tpm2.TPMContext
+	var mockSession tpm2.SessionContext
+	if data.params.PCRPolicyCounterHandle != tpm2.HandleNull {
+		mockTpm = new(tpm2.TPMContext)
+		mockSession = new(mockSessionContext)
+	}
+
+	var mockPcrPolicyCounterPub *tpm2.NVPublic
+	restore := MockCreatePcrPolicyCounter(func(tpm *tpm2.TPMContext, handle tpm2.Handle, pub *tpm2.Public, session tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
+		c.Assert(mockTpm, NotNil)
+
+		c.Check(tpm, Equals, mockTpm)
+		c.Check(handle, Equals, data.params.PCRPolicyCounterHandle)
+		c.Check(pub, Equals, s.lastAuthKeyPublic)
+		c.Check(session, Equals, mockSession)
+
+		mockPcrPolicyCounterPub = &tpm2.NVPublic{
+			Index:      handle,
+			NameAlg:    tpm2.HashAlgorithmSHA256,
+			Attrs:      tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
+			AuthPolicy: make([]byte, 32),
+			Size:       8}
+
+		return mockPcrPolicyCounterPub, data.initialPcrPolicyCounterValue, nil
+	})
+	defer restore()
+
+	var mockPolicyData *KeyDataPolicy_v3
+	var mockPolicyDigest tpm2.Digest
+	restore = MockNewKeyDataPolicy(func(alg tpm2.HashAlgorithmId, key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (KeyDataPolicy, tpm2.Digest, error) {
+		c.Check(alg, Equals, tpm2.HashAlgorithmSHA256)
+		c.Check(key, Equals, s.lastAuthKeyPublic)
+		c.Check(pcrPolicyCounterPub, Equals, mockPcrPolicyCounterPub)
+		c.Check(pcrPolicySequence, Equals, data.initialPcrPolicyCounterValue)
+
+		index := tpm2.HandleNull
+		if pcrPolicyCounterPub != nil {
+			index = pcrPolicyCounterPub.Index
+		}
+
+		mockPolicyData = &KeyDataPolicy_v3{
+			StaticData: &StaticPolicyData_v3{
+				AuthPublicKey:          key,
+				PCRPolicyCounterHandle: index},
+			PCRData: &PcrPolicyData_v3{
+				PolicySequence:            pcrPolicySequence,
+				AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgNull}}}
+
+		mockPolicyDigest = make([]byte, alg.Size())
+		rand.Read(mockPolicyDigest)
+
+		return mockPolicyData, mockPolicyDigest, nil
+	})
+	defer restore()
+
+	pcrPolicyInitialized := false
+	restore = MockSkdbUpdatePCRProtectionPolicyImpl(func(skdb *SealedKeyDataBase, tpm *tpm2.TPMContext, authKey secboot.AuxiliaryKey, counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, session tpm2.SessionContext) error {
+		c.Check(tpm, Equals, mockTpm)
+		c.Check(authKey, DeepEquals, s.lastAuthKey)
+		c.Check(counterPub, Equals, mockPcrPolicyCounterPub)
+		c.Check(profile, NotNil)
+		if data.params.PCRProfile != nil {
+			c.Check(profile, Equals, data.params.PCRProfile)
+		}
+		c.Check(session, Equals, mockSession)
+		pcrPolicyInitialized = true
+		return nil
+	})
+	defer restore()
+
+	var sealer mockKeySealer
+
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	kd, authKeyOut, pcrPolicyCounter, err := MakeNewKeyData(mockTpm, key, data.authKey, data.params, &sealer, mockSession)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.lastAuthKey, NotNil)
+	c.Assert(mockPolicyData, NotNil)
+	c.Assert(pcrPolicyInitialized, testutil.IsTrue)
+
+	c.Assert(s.lastKeyParams, NotNil)
+	c.Check(s.lastKeyParams.PlatformName, Equals, "tpm2")
+	c.Check(s.lastKeyParams.AuxiliaryKey, DeepEquals, s.lastAuthKey)
+	c.Check(s.lastKeyParams.SnapModelAuthHash, Equals, crypto.SHA256)
+
+	skd, err := NewSealedKeyData(kd)
+	c.Assert(err, IsNil)
+
+	c.Check(skd.Data().Policy(), tpm2_testutil.TPMValueDeepEquals, mockPolicyData)
+	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
+	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, mockPolicyDigest)
+
+	payload := make(secboot.KeyPayload, len(s.lastKeyParams.EncryptedPayload))
+
+	c.Assert(skd.Data().Private(), HasLen, 48)
+	b, err := aes.NewCipher(skd.Data().Private()[:32])
+	c.Assert(err, IsNil)
+	stream := cipher.NewCFBDecrypter(b, skd.Data().Private()[32:])
+	stream.XORKeyStream(payload, s.lastKeyParams.EncryptedPayload)
+
+	recoveredKey, recoveredAuthKey, err := payload.Unmarshal()
+	c.Check(err, IsNil)
+	c.Check(recoveredKey, DeepEquals, key)
+	c.Check(recoveredAuthKey, DeepEquals, s.lastAuthKey)
+
+	c.Check(skd.Data().Policy().ValidateAuthKey(authKeyOut), IsNil)
+	c.Check(authKeyOut, DeepEquals, s.lastAuthKey)
+	if data.authKey != nil {
+		c.Check(authKeyOut, DeepEquals, data.authKey)
+	}
+
+	if data.params.PCRPolicyCounterHandle == tpm2.HandleNull {
+		c.Check(pcrPolicyCounter, IsNil)
+	} else {
+		c.Check(pcrPolicyCounter, NotNil)
+		c.Check(pcrPolicyCounter.Pub(), Equals, mockPcrPolicyCounterPub)
+		c.Check(pcrPolicyCounter.TPM(), Equals, mockTpm)
+		c.Check(pcrPolicyCounter.Session(), Equals, mockSession)
+	}
+}
+
+func (s *sealSuiteNoTPM) TestMakeNewKeyData(c *C) {
+	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+		params: &KeyDataParams{
+			PCRPolicyCounterHandle: tpm2.HandleNull,
+			PCRProfile:             NewPCRProtectionProfile()}})
+}
+
+func (s *sealSuiteNoTPM) TestMakeNewKeyDataWithPolicyCounter(c *C) {
+	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+		params: &KeyDataParams{
+			PCRPolicyCounterHandle: 0x01810000,
+			PCRProfile:             NewPCRProtectionProfile()},
+		initialPcrPolicyCounterValue: 30})
+}
+
+func (s *sealSuiteNoTPM) TestMakeNewKeyDataWithPolicyCounterDifferentInitialValue(c *C) {
+	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+		params: &KeyDataParams{
+			PCRPolicyCounterHandle: 0x01810000,
+			PCRProfile:             NewPCRProtectionProfile()},
+		initialPcrPolicyCounterValue: 500})
+}
+
+func (s *sealSuiteNoTPM) TestMakeNewKeyDataNilPCRProfile(c *C) {
+	s.testMakeNewKeyData(c, &testMakeNewKeyDataData{
+		params: &KeyDataParams{
+			PCRPolicyCounterHandle: tpm2.HandleNull}})
+}

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -627,7 +627,8 @@ func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingInvalidPCRProfile(c *C) {
 			AddProfileOR(
 				NewPCRProtectionProfile(),
 				NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 8)),
-		PCRPolicyCounterHandle: tpm2.HandleNull})
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181ffff), // verify that this gets undefined on error
+	})
 	c.Check(err, ErrorMatches, "cannot set initial PCR policy: cannot compute PCR digests from protection profile: "+
 		"not all branches contain values for the same sets of PCRs")
 }

--- a/tpm2/unseal_legacy.go
+++ b/tpm2/unseal_legacy.go
@@ -72,6 +72,8 @@ import (
 // On success, the unsealed cleartext key is returned as the first return value, and the
 // private part of the key used for authorizing PCR policy updates with
 // SealedKeyObject.UpdatePCRProtectionPolicy is returned as the second return value.
+//
+// Deprecated: Use NewKeyData and the secboot.KeyData API for key recovery.
 func (k *SealedKeyObject) UnsealFromTPM(tpm *Connection) (key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, err error) {
 	data, err := k.unsealDataFromTPM(tpm.TPMContext, tpm.HmacSession())
 	if err != nil {

--- a/tpm2/update_legacy.go
+++ b/tpm2/update_legacy.go
@@ -137,6 +137,8 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPolicies(tpm *Connection, authKe
 // On success, each of the supplied SealedKeyObjects will have an updated authorization policy that includes a
 // PCR policy computed from the supplied PCRProtectionProfile. They must be persisted using
 // SealedKeyObject.WriteAtomic.
+//
+// Deprecated: Use UpdateKeyDataPCRProtectionPolicy.
 func UpdateKeyPCRProtectionPolicyMultiple(tpm *Connection, keys []*SealedKeyObject, authKey secboot.AuxiliaryKey, pcrProfile *PCRProtectionProfile) error {
 	if len(keys) == 0 {
 		return errors.New("no sealed keys supplied")

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -1,0 +1,270 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2_test
+
+import (
+	"math/rand"
+
+	"github.com/canonical/go-tpm2"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot"
+	"github.com/snapcore/secboot/internal/testutil"
+	"github.com/snapcore/secboot/internal/tpm2test"
+	. "github.com/snapcore/secboot/tpm2"
+)
+
+type updateSuite struct {
+	tpm2test.TPMTest
+	primaryKeyMixin
+}
+
+func (s *updateSuite) SetUpSuite(c *C) {
+	s.TPMFeatures = tpm2test.TPMFeatureOwnerHierarchy |
+		tpm2test.TPMFeatureEndorsementHierarchy |
+		tpm2test.TPMFeatureLockoutHierarchy | // Allow the test fixture to reset the DA counter
+		tpm2test.TPMFeaturePCR |
+		tpm2test.TPMFeatureNV
+}
+
+func (s *updateSuite) SetUpTest(c *C) {
+	s.TPMTest.SetUpTest(c)
+
+	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+}
+
+var _ = Suite(&updateSuite{})
+
+type testUpdatePCRProtectionPolicyData struct {
+	pcrPolicyCounterHandle tpm2.Handle
+	authKey                secboot.AuxiliaryKey
+}
+
+func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRProtectionPolicyData) {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	// Protect the key with an initial PCR policy that can't be satisfied
+	params := &ProtectKeyParams{
+		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
+		PCRPolicyCounterHandle: data.pcrPolicyCounterHandle,
+		AuthKey:                data.authKey}
+	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	c.Assert(err, IsNil)
+
+	_, _, err = k.RecoverKeys()
+	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+		"cannot execute PolicyOR assertions: current session digest not found in policy data")
+
+	skd, err := NewSealedKeyData(k)
+	c.Assert(err, IsNil)
+
+	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), authKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23})), IsNil)
+
+	_, _, err = k.RecoverKeys()
+	c.Check(err, IsNil)
+
+	_, err = s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
+	c.Check(err, IsNil)
+	_, _, err = k.RecoverKeys()
+	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+		"cannot execute PolicyOR assertions: current session digest not found in policy data")
+}
+
+func (s *updateSuite) TestUpdatePCRProtectionPolicyWithPCRPolicyCounter(c *C) {
+	s.testUpdatePCRProtectionPolicy(c, &testUpdatePCRProtectionPolicyData{
+		pcrPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)})
+}
+
+func (s *updateSuite) TestUpdatePCRProtectionPolicyNoPCRPolicyCounter(c *C) {
+	s.testUpdatePCRProtectionPolicy(c, &testUpdatePCRProtectionPolicyData{
+		pcrPolicyCounterHandle: tpm2.HandleNull})
+}
+
+func (s *updateSuite) TestUpdatePCRProtectionPolicyWithProvidedAuthKey(c *C) {
+	authKey := make(secboot.AuxiliaryKey, 32)
+	rand.Read(authKey)
+
+	s.testUpdatePCRProtectionPolicy(c, &testUpdatePCRProtectionPolicyData{
+		pcrPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
+		authKey:                authKey})
+}
+
+func (s *updateSuite) testRevokeOldPCRProtectionPolicies(c *C, params *ProtectKeyParams) error {
+	key := make(secboot.DiskUnlockKey, 32)
+	rand.Read(key)
+
+	k1, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	c.Assert(err, IsNil)
+
+	w := newMockKeyDataWriter()
+	c.Check(k1.WriteAtomic(w), IsNil)
+
+	k2, err := secboot.ReadKeyData(w.Reader())
+	c.Assert(err, IsNil)
+
+	skd, err := NewSealedKeyData(k2)
+	c.Assert(err, IsNil)
+	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), authKey, params.PCRProfile), IsNil)
+
+	_, _, err = k1.RecoverKeys()
+	c.Check(err, IsNil)
+	_, _, err = k2.RecoverKeys()
+	c.Check(err, IsNil)
+
+	skd, err = NewSealedKeyData(k1)
+	c.Assert(err, IsNil)
+	c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), authKey), IsNil)
+
+	_, _, err = k1.RecoverKeys()
+	c.Check(err, IsNil)
+	_, _, err = k2.RecoverKeys()
+	c.Check(err, IsNil)
+
+	skd, err = NewSealedKeyData(k2)
+	c.Assert(err, IsNil)
+	c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), authKey), IsNil)
+
+	_, _, err = k2.RecoverKeys()
+	c.Check(err, IsNil)
+	_, _, err = k1.RecoverKeys()
+	return err
+}
+
+func (s *updateSuite) TestRevokeOldPCRProtectionPoliciesWithPCRPolicyCounter(c *C) {
+	err := s.testRevokeOldPCRProtectionPolicies(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)})
+	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: the PCR policy has been revoked")
+}
+
+func (s *updateSuite) TestRevokeOldPCRProtectionPoliciesWithoutPCRPolicyCounter(c *C) {
+	err := s.testRevokeOldPCRProtectionPolicies(c, &ProtectKeyParams{
+		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
+		PCRPolicyCounterHandle: tpm2.HandleNull})
+	c.Check(err, IsNil)
+}
+
+func (s *updateSuite) testUpdateKeyDataPCRProtectionPolicy(c *C, n int) {
+	var keys []secboot.DiskUnlockKey
+	for i := 0; i < n; i++ {
+		key := make(secboot.DiskUnlockKey, 32)
+		rand.Read(key)
+		keys = append(keys, key)
+	}
+
+	// Protect the key with an initial PCR policy that can't be satisfied
+	params := &ProtectKeyParams{
+		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
+		PCRPolicyCounterHandle: tpm2.HandleNull}
+	ks, authKey, err := ProtectKeysWithTPM(s.TPM(), keys, params)
+	c.Assert(err, IsNil)
+
+	for _, k := range ks {
+		_, _, err = k.RecoverKeys()
+		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
+	}
+
+	c.Check(UpdateKeyDataPCRProtectionPolicy(s.TPM(), authKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), ks...), IsNil)
+
+	for _, k := range ks {
+		_, _, err = k.RecoverKeys()
+		c.Check(err, IsNil)
+	}
+
+	_, err = s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
+	c.Check(err, IsNil)
+
+	for _, k := range ks {
+		_, _, err = k.RecoverKeys()
+		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
+			"cannot execute PolicyOR assertions: current session digest not found in policy data")
+	}
+}
+
+func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy1(c *C) {
+	s.testUpdateKeyDataPCRProtectionPolicy(c, 1)
+}
+
+func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy2(c *C) {
+	s.testUpdateKeyDataPCRProtectionPolicy(c, 2)
+}
+
+func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy3(c *C) {
+	s.testUpdateKeyDataPCRProtectionPolicy(c, 3)
+}
+
+func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicyUnrelated1(c *C) {
+	var keys []secboot.DiskUnlockKey
+	for i := 0; i < 2; i++ {
+		key := make(secboot.DiskUnlockKey, 32)
+		rand.Read(key)
+		keys = append(keys, key)
+	}
+
+	authKey := make(secboot.AuxiliaryKey, 32)
+	rand.Read(authKey)
+
+	var ks []*secboot.KeyData
+	for i := 0; i < 2; i++ {
+		params := &ProtectKeyParams{
+			PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
+			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181ff00+tpm2.Handle(i)),
+			AuthKey:                authKey}
+		k, _, err := ProtectKeyWithTPM(s.TPM(), keys[i], params)
+		c.Assert(err, IsNil)
+		ks = append(ks, k)
+	}
+
+	err := UpdateKeyDataPCRProtectionPolicy(s.TPM(), authKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), ks...)
+	c.Check(err, ErrorMatches, "invalid key data: key data at index 1 is not related to the primary key data")
+}
+
+func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicyUnrelated2(c *C) {
+	var keys []secboot.DiskUnlockKey
+	var authKeys []secboot.AuxiliaryKey
+	for i := 0; i < 2; i++ {
+		key := make(secboot.DiskUnlockKey, 32)
+		rand.Read(key)
+		keys = append(keys, key)
+
+		authKey := make(secboot.AuxiliaryKey, 32)
+		rand.Read(authKey)
+		authKeys = append(authKeys, authKey)
+	}
+
+	var ks []*secboot.KeyData
+	for i := 0; i < 2; i++ {
+		params := &ProtectKeyParams{
+			PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
+			PCRPolicyCounterHandle: tpm2.HandleNull,
+			AuthKey:                authKeys[i]}
+		k, _, err := ProtectKeyWithTPM(s.TPM(), keys[i], params)
+		c.Assert(err, IsNil)
+		ks = append(ks, k)
+	}
+
+	err := UpdateKeyDataPCRProtectionPolicy(s.TPM(), authKeys[0], tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), ks...)
+	c.Check(err, ErrorMatches, "invalid key data: key data at index 1 is not related to the primary key data")
+}


### PR DESCRIPTION
This adds an initial TPM2 implementation of PlatformKeyDataHandler, plus
new APIs for sealing keys to make use of secboot.KeyData.

The new sealing APIs are ProtectKeyWithTPM, ProtectKeysWithTPM and
ProtectKeyWithExternalStorageKey, to replace the SealKeyToTPM,
SealKeyToTPMMultiple and SealKeyToExternalTPMStorageKey. They are
implemented in a way to facilitate adding another API in the future to
protect additional keys using the same policy as an existing key.

Also added is a new API to update the PCR policy for multiple keys in
one go - UpdateKeyDataPCRProtectionPolicy, which replaces
UpdateKeyPCRProtectionPolicyMultiple.

Obtaining a SealedKeyObject data structure associated with a key is done
differently for keys created with the new APIs. There is a new API to
decode a SealedKeyObject from a secboot.KeyData object -
NewSealedKeyObjectFromKeyData.
