### PR TITLE
Support measuring extended classic models with a distinct hash

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -297,6 +297,7 @@ type nullSnapModel struct{}
 func (_ nullSnapModel) Series() string            { return "" }
 func (_ nullSnapModel) BrandID() string           { return "" }
 func (_ nullSnapModel) Model() string             { return "" }
+func (_ nullSnapModel) Classic() bool             { return false }
 func (_ nullSnapModel) Grade() asserts.ModelGrade { return "" }
 func (_ nullSnapModel) SignKeyID() string         { return "" }
 

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -945,6 +945,63 @@ func (s *keyDataSuite) TestSnapModelAuth4(c *C) {
 		authModels: models,
 		model:      models[0],
 		authorized: true})
+}
+func (s *keyDataSuite) TestSnapModelAuth5(c *C) {
+	models := []SnapModel{
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"classic":      "true",
+			"distribution": "ubuntu",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"classic":      "true",
+			"distribution": "ubuntu",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	s.testSnapModelAuth(c, &testSnapModelAuthData{
+		alg:        crypto.SHA256,
+		authModels: models,
+		model:      models[1],
+		authorized: true})
+}
+
+func (s *keyDataSuite) TestSnapModelAuth6(c *C) {
+	models := []SnapModel{
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	s.testSnapModelAuth(c, &testSnapModelAuthData{
+		alg:        crypto.SHA256,
+		authModels: models,
+		model: testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"classic":      "true",
+			"distribution": "ubuntu",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		authorized: false})
 }
 
 func (s *keyDataSuite) TestSetAuthorizedSnapModelsWithWrongKey(c *C) {

--- a/snap.go
+++ b/snap.go
@@ -35,7 +35,9 @@ import (
 
 var sha3_384oid = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 9}
 
-const ClassicCode uint32 = 0x80000000
+// ClassicModelGradeMask is ORed with the model grade code when
+// measuring a classic snap model.
+const ClassicModelGradeMask uint32 = 0x80000000
 
 // SnapModel exposes the details of a snap device model that are bound
 // to an encrypted container.
@@ -79,7 +81,7 @@ func computeSnapModelHMAC(alg crypto.Hash, key []byte, model SnapModel) (snapMod
 	h.Write([]byte(model.Series()))
 	gradeCode := model.Grade().Code()
 	if model.Classic() {
-		gradeCode |= ClassicCode
+		gradeCode |= ClassicModelGradeMask
 	}
 	binary.Write(h, binary.LittleEndian, gradeCode)
 

--- a/snap.go
+++ b/snap.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -35,12 +35,15 @@ import (
 
 var sha3_384oid = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 9}
 
+const ClassicCode uint32 = 0x80000000
+
 // SnapModel exposes the details of a snap device model that are bound
 // to an encrypted container.
 type SnapModel interface {
 	Series() string
 	BrandID() string
 	Model() string
+	Classic() bool
 	Grade() asserts.ModelGrade
 	SignKeyID() string
 }
@@ -74,7 +77,11 @@ func computeSnapModelHMAC(alg crypto.Hash, key []byte, model SnapModel) (snapMod
 	h = hmac.New(func() hash.Hash { return alg.New() }, key)
 	h.Write(d)
 	h.Write([]byte(model.Series()))
-	binary.Write(h, binary.LittleEndian, model.Grade().Code())
+	gradeCode := model.Grade().Code()
+	if model.Classic() {
+		gradeCode |= ClassicCode
+	}
+	binary.Write(h, binary.LittleEndian, gradeCode)
 
 	return h.Sum(nil), nil
 }

--- a/tpm2/snapmodel_policy.go
+++ b/tpm2/snapmodel_policy.go
@@ -113,7 +113,7 @@ func computeSnapModelDigest(newHash func() (snapModelHasher, error), model secbo
 	h.Write([]byte(model.Series()))
 	gradeCode := model.Grade().Code()
 	if model.Classic() {
-		gradeCode |= secboot.ClassicCode
+		gradeCode |= secboot.ClassicModelGradeMask
 	}
 	binary.Write(h, binary.LittleEndian, gradeCode)
 	return h.Complete()

--- a/tpm2/snapmodel_policy.go
+++ b/tpm2/snapmodel_policy.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -111,7 +111,11 @@ func computeSnapModelDigest(newHash func() (snapModelHasher, error), model secbo
 	h, err = newHash()
 	h.Write(digest)
 	h.Write([]byte(model.Series()))
-	binary.Write(h, binary.LittleEndian, model.Grade().Code())
+	gradeCode := model.Grade().Code()
+	if model.Classic() {
+		gradeCode |= secboot.ClassicCode
+	}
+	binary.Write(h, binary.LittleEndian, gradeCode)
 	return h.Complete()
 }
 

--- a/tpm2/snapmodel_policy_test.go
+++ b/tpm2/snapmodel_policy_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -376,6 +376,34 @@ func (s *snapModelProfileSuite) TestAddSnapModelProfile11(c *C) {
 			{
 				tpm2.HashAlgorithmSHA256: {
 					12: testutil.DecodeHexString(c, "27db1fa15c2fd09361f6812bca72c3285e889dd20fcfbbe509e153b302046820"),
+				},
+			},
+		},
+	})
+}
+
+func (s *snapModelProfileSuite) TestAddSnapModelProfile12(c *C) {
+	// Test with a classic model.
+	s.testAddSnapModelProfile(c, &testAddSnapModelProfileData{
+		params: &SnapModelProfileParams{
+			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
+			PCRIndex:     12,
+			Models: []secboot.SnapModel{
+				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+					"authority-id": "fake-brand",
+					"series":       "16",
+					"brand-id":     "fake-brand",
+					"model":        "fake-model",
+					"classic":      "true",
+					"distribution": "ubuntu",
+					"grade":        "secured",
+				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+			},
+		},
+		values: []tpm2.PCRValues{
+			{
+				tpm2.HashAlgorithmSHA256: {
+					12: testutil.DecodeHexString(c, "ab2a6cbcd2e4a29a0a18b6bfe751b73efc54d5b50f2d07b80d6e1da6c4401606"),
 				},
 			},
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -173,14 +173,16 @@
 			"revisionTime": "2020-04-20T18:59:55Z"
 		},
 		{
-			"checksumSHA1": "jgludPPsAFSrXo5BMucAcj7A8gY=",
+			"checksumSHA1": "wEB8YkRMFzTAGCH0VxYcaaSFD3c=",
 			"path": "github.com/snapcore/snapd/asserts",
-			"revision": "cba748d1244e6861a5e407f7abe90fb2f76b6f80",
-			"revisionTime": "2020-04-20T18:59:55Z"
+			"revision": "4a1f4c93fc855b63d4f324b6c8fd02a5b56f53ff",
+			"revisionTime": "2022-07-12T14:41:13Z"
 		},
 		{
+			"checksumSHA1": "0YzOVu0qp5+Yv9cgkivWq+U0dtw=",
 			"path": "github.com/snapcore/snapd/asserts/internal",
-			"revision": ""
+			"revision": "4a1f4c93fc855b63d4f324b6c8fd02a5b56f53ff",
+			"revisionTime": "2022-07-12T14:41:13Z"
 		},
 		{
 			"checksumSHA1": "3Db7Lb2ueEX1hc6WoIM79lk6lbM=",
@@ -219,22 +221,22 @@
 			"revisionTime": "2020-04-20T18:59:55Z"
 		},
 		{
-			"checksumSHA1": "wtg8UKbHVL8qRZ8ggQb+cDQlVNo=",
+			"checksumSHA1": "s/Xqd0zMDeZa6gSNSaz01JPlCn0=",
 			"path": "github.com/snapcore/snapd/osutil",
-			"revision": "cba748d1244e6861a5e407f7abe90fb2f76b6f80",
-			"revisionTime": "2020-04-20T18:59:55Z"
+			"revision": "4a1f4c93fc855b63d4f324b6c8fd02a5b56f53ff",
+			"revisionTime": "2022-07-12T14:41:13Z"
 		},
 		{
 			"checksumSHA1": "uviyHf48hcnZN/cGKNUxmvqLISQ=",
 			"path": "github.com/snapcore/snapd/osutil/mount",
-			"revision": "cba748d1244e6861a5e407f7abe90fb2f76b6f80",
-			"revisionTime": "2020-04-20T18:59:55Z"
+			"revision": "4a1f4c93fc855b63d4f324b6c8fd02a5b56f53ff",
+			"revisionTime": "2022-07-12T14:41:13Z"
 		},
 		{
-			"checksumSHA1": "EYRtD9fNCHSSnWkkZSNTAB63IhQ=",
+			"checksumSHA1": "q20WkTcG9ibM58/gdP+73OQjIW0=",
 			"path": "github.com/snapcore/snapd/osutil/sys",
-			"revision": "cba748d1244e6861a5e407f7abe90fb2f76b6f80",
-			"revisionTime": "2020-04-20T18:59:55Z"
+			"revision": "4a1f4c93fc855b63d4f324b6c8fd02a5b56f53ff",
+			"revisionTime": "2022-07-12T14:41:13Z"
 		},
 		{
 			"checksumSHA1": "1LtMtOxaLmu0tGueD4kzOVgUpjs=",
@@ -273,10 +275,10 @@
 			"revisionTime": "2020-04-20T18:59:55Z"
 		},
 		{
-			"checksumSHA1": "bvtO/K0/j2AzLlIVIoTSMMKoWdg=",
+			"checksumSHA1": "+B0W5/en/RsscyEDhyMddlQIWio=",
 			"path": "github.com/snapcore/snapd/snap/naming",
-			"revision": "cba748d1244e6861a5e407f7abe90fb2f76b6f80",
-			"revisionTime": "2020-04-20T18:59:55Z"
+			"revision": "4a1f4c93fc855b63d4f324b6c8fd02a5b56f53ff",
+			"revisionTime": "2022-07-12T14:41:13Z"
 		},
 		{
 			"checksumSHA1": "vm3N9KUtggnspT4hGPd3Nw3yTHM=",


### PR DESCRIPTION
The simplest approach seemed to be to integrate that info as a high
bit in the grade code, for clarity snapd can grow an internal constant
as well to reserve this.

I moved snapd only partially forward because go-tpm2/testutil needs
fixing first, the signature of UserCommonDataDir has changed,
eventually that code will need to consider two possible directories.