### PR TITLE
keydata: use HKDF to derive the snap model HMAC key

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -351,6 +351,12 @@
 			"revisionTime": "2020-04-11T01:31:37Z"
 		},
 		{
+			"checksumSHA1": "ELSEW2KG0p3oua5lIxl1xW2oFBo=",
+			"path": "golang.org/x/crypto/hkdf",
+			"revision": "a3485e174077e5296d3d4a43ca31d2d21b40be2c",
+			"revisionTime": "2022-10-24T15:44:58Z"
+		},
+		{
 			"checksumSHA1": "juTyoXrV63uP4Quf10LtBfNdHO0=",
 			"path": "golang.org/x/crypto/openpgp/elgamal",
 			"revision": "0848c9571904fcbcb24543358ca8b5a7dbfde875",


### PR DESCRIPTION
The current implementation uses a DRBG where a simpler KDF would be more appropriate. DRBGs provide some additional features that are just not required here, which are intended to protect prior and future random numbers generated from the same source. All of the extra keys derived from the recovered key payload are all used for protection of the same resource.

HKDF is a core part of the TLS1.3 key schedule. Using this rather than a module we've developed is probably going to make future FIPS 140-3 efforts quite a bit easier given that the go standard library already makes use of it internally (the version it vendors will most likely require openssl integration which we could just copy for external use)

This maintains backwards compatibility with existing keys, with a test to ensure that continues to work.