### PR TITLE
tpm2: update go-tpm2 dependency

### DIFF
--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -89,7 +89,7 @@ func (s *compatTestSuiteBase) SetUpTest(c *C) {
 		}()
 	}
 
-	simulatorShutdown, err := tpm2_testutil.LaunchTPMSimulator(&tpm2_testutil.TPMSimulatorOptions{SourceDir: s.dataPath})
+	simulatorShutdown, err := tpm2_testutil.LaunchTPMSimulator(&tpm2_testutil.TPMSimulatorOptions{SourcePath: s.dataPath + "/NVChip"})
 	c.Assert(err, IsNil)
 
 	s.InitCleanup(c)

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -139,15 +139,17 @@ func computePCRProtectionProfile(env secboot_efi.HostEnvironment) (*secboot_tpm2
 }
 
 func run() int {
+	var outputPath string
 	if outputDir != "" {
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
 			fmt.Fprintf(os.Stderr, "Cannot create output directory: %v\n", err)
 			return 1
 		}
+		outputPath = filepath.Join(outputDir, "NVChip")
 	}
 
 	cleanupTpmSimulator, err := tpm2_testutil.LaunchTPMSimulator(
-		&tpm2_testutil.TPMSimulatorOptions{SourceDir: outputDir, Manufacture: true, SavePersistent: true})
+		&tpm2_testutil.TPMSimulatorOptions{SourcePath: outputPath, Manufacture: true, SavePersistent: true})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot launch TPM simulator: %v\n", err)
 		return 1

--- a/tpm2/keydata_v0_test.go
+++ b/tpm2/keydata_v0_test.go
@@ -80,8 +80,6 @@ func (s *keyDataV0Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 	template.AuthPolicy = policy
 
 	policyData.(*KeyDataPolicy_v0).PCRData = &PcrPolicyData_v0{
-		Selection:        tpm2.PCRSelectionList{},
-		OrData:           PolicyOrData_v0{},
 		PolicySequence:   policyData.PCRPolicySequence(),
 		AuthorizedPolicy: make(tpm2.Digest, 32),
 		AuthorizedPolicySignature: &tpm2.Signature{
@@ -155,7 +153,7 @@ func (s *keyDataV0Suite) TestValidateNoLockIndex(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "lock NV index is unavailable")
 }
 
@@ -166,7 +164,7 @@ func (s *keyDataV0Suite) TestValidateInvalidAuthPublicKeyNameAlg(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "cannot compute name of dynamic authorization policy key: unsupported name algorithm or algorithm not linked into binary: TPM_ALG_NULL")
 }
 
@@ -177,7 +175,7 @@ func (s *keyDataV0Suite) TestValidateInvalidAuthPublicKeyType(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "public area of dynamic authorization policy signing key has the wrong type")
 }
 
@@ -191,7 +189,7 @@ func (s *keyDataV0Suite) TestValidateInvalidAuthPublicKeyScheme(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "dynamic authorization policy signing key has unexpected scheme")
 }
 
@@ -202,7 +200,7 @@ func (s *keyDataV0Suite) TestValidateInvalidPolicyCounterHandle(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter handle is invalid")
 }
 
@@ -215,7 +213,7 @@ func (s *keyDataV0Suite) TestValidateNoPolicyCounter(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter is unavailable")
 }
 
@@ -226,7 +224,7 @@ func (s *keyDataV0Suite) TestValidateInvalidSealedObjectNameAlg(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "cannot determine if static authorization policy matches sealed key object: algorithm unavailable")
 }
 
@@ -239,7 +237,7 @@ func (s *keyDataV0Suite) TestValidateWrongAuthKey(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
 
@@ -260,7 +258,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounter(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
 
@@ -280,7 +278,7 @@ func (s *keyDataV0Suite) TestValidateWrongLockIndex(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
 
@@ -291,7 +289,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounterAuthPolicies1(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "unexpected number of OR policy digests for PCR policy counter")
 }
 
@@ -302,7 +300,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounterAuthPolicies2(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "unexpected OR policy digest for PCR policy counter")
 }
 
@@ -313,7 +311,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounterAuthPolicies3(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter has unexpected authorization policy")
 }
 

--- a/tpm2/keydata_v1_test.go
+++ b/tpm2/keydata_v1_test.go
@@ -80,13 +80,11 @@ func (s *keyDataV1Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 
 	policyData, policy, err := NewKeyDataPolicy(template.NameAlg, authKeyPublic, policyCounterPub, policyCount)
 	c.Assert(err, IsNil)
-	c.Assert(policyData, tpm2_testutil.ConvertibleTo, &KeyDataPolicy_v1{})
+	c.Assert(policyData, testutil.ConvertibleTo, &KeyDataPolicy_v1{})
 
 	template.AuthPolicy = policy
 
 	policyData.(*KeyDataPolicy_v1).PCRData = &PcrPolicyData_v1{
-		Selection:        tpm2.PCRSelectionList{},
-		OrData:           PolicyOrData_v0{},
 		PolicySequence:   policyData.PCRPolicySequence(),
 		AuthorizedPolicy: make(tpm2.Digest, 32),
 		AuthorizedPolicySignature: &tpm2.Signature{
@@ -164,7 +162,7 @@ func (s *keyDataV1Suite) TestValidateInvalidAuthPublicKeyNameAlg(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "cannot compute name of dynamic authorization policy key: unsupported name algorithm or algorithm not linked into binary: TPM_ALG_NULL")
 }
 
@@ -175,7 +173,7 @@ func (s *keyDataV1Suite) TestValidateInvalidAuthPublicKeyType(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "public area of dynamic authorization policy signing key has the wrong type")
 }
 
@@ -189,7 +187,7 @@ func (s *keyDataV1Suite) TestValidateInvalidAuthPublicKeyScheme(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "dynamic authorization policy signing key has unexpected scheme")
 }
 
@@ -200,7 +198,7 @@ func (s *keyDataV1Suite) TestValidateInvalidPolicyCounterHandle(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter handle is invalid")
 }
 
@@ -213,7 +211,7 @@ func (s *keyDataV1Suite) TestValidateNoPolicyCounter(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter is unavailable")
 }
 
@@ -224,7 +222,7 @@ func (s *keyDataV1Suite) TestValidateInvalidSealedObjectNameAlg(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "cannot determine if static authorization policy matches sealed key object: algorithm unavailable")
 }
 
@@ -237,7 +235,7 @@ func (s *keyDataV1Suite) TestValidateWrongAuthKey(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
 
@@ -258,7 +256,7 @@ func (s *keyDataV1Suite) TestValidateWrongPolicyCounter1(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err = data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
 
@@ -269,7 +267,7 @@ func (s *keyDataV1Suite) TestValidateWrongPolicyCounter2(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
 
@@ -286,7 +284,7 @@ func (s *keyDataV1Suite) TestValidateWrongPolicyCounter3(c *C) {
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
 	_, err := data.ValidateData(s.TPM().TPMContext, session)
-	c.Check(err, tpm2_testutil.ConvertibleTo, KeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
 

--- a/tpm2/keydata_v2_test.go
+++ b/tpm2/keydata_v2_test.go
@@ -80,13 +80,11 @@ func (s *keyDataV2Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 
 	policyData, policy, err := NewKeyDataPolicy(template.NameAlg, authKeyPublic, policyCounterPub, policyCount)
 	c.Assert(err, IsNil)
-	c.Assert(policyData, tpm2_testutil.ConvertibleTo, &KeyDataPolicy_v2{})
+	c.Assert(policyData, testutil.ConvertibleTo, &KeyDataPolicy_v2{})
 
 	template.AuthPolicy = policy
 
 	policyData.(*KeyDataPolicy_v2).PCRData = &PcrPolicyData_v2{
-		Selection:        tpm2.PCRSelectionList{},
-		OrData:           PolicyOrData_v0{},
 		PolicySequence:   policyData.PCRPolicySequence(),
 		AuthorizedPolicy: make(tpm2.Digest, 32),
 		AuthorizedPolicySignature: &tpm2.Signature{
@@ -124,13 +122,11 @@ func (s *keyDataV2Suite) newMockImportableKeyData(c *C) KeyData {
 
 	policyData, policy, err := NewKeyDataPolicy(pub.NameAlg, authKeyPublic, nil, 0)
 	c.Assert(err, IsNil)
-	c.Assert(policyData, tpm2_testutil.ConvertibleTo, &KeyDataPolicy_v2{})
+	c.Assert(policyData, testutil.ConvertibleTo, &KeyDataPolicy_v2{})
 
 	pub.AuthPolicy = policy
 
 	policyData.(*KeyDataPolicy_v2).PCRData = &PcrPolicyData_v2{
-		Selection:        tpm2.PCRSelectionList{},
-		OrData:           PolicyOrData_v0{},
 		PolicySequence:   policyData.PCRPolicySequence(),
 		AuthorizedPolicy: make(tpm2.Digest, 32),
 		AuthorizedPolicySignature: &tpm2.Signature{
@@ -279,8 +275,7 @@ func (s *keyDataV2Suite) TestReadNonImportableAsV2Fails(c *C) {
 	c.Check(data.Write(buf), IsNil)
 
 	_, err := ReadKeyDataV2(buf)
-	c.Check(err, ErrorMatches, "cannot unmarshal argument whilst processing element of type tpm2.Digest: "+
-		"sized value has a size larger than the remaining bytes\n\n"+
+	c.Check(err, ErrorMatches, "cannot unmarshal argument 0 whilst processing element of type tpm2.Digest: unexpected EOF\n\n"+
 		"=== BEGIN STACK ===\n"+
 		"... tpm2.Public field AuthPolicy\n"+
 		"... tpm2.staticPolicyData_v1 field AuthPublicKey\n"+

--- a/tpm2/pcr_profile.go
+++ b/tpm2/pcr_profile.go
@@ -827,7 +827,10 @@ func (p *PCRProtectionProfile) ComputePCRDigests(tpm *tpm2.TPMContext, alg tpm2.
 	}
 
 	// Compute the PCR selection for this profile from the first branch.
-	pcrs := values[0].SelectionList()
+	pcrs, err := values[0].SelectionList()
+	if err != nil {
+		return nil, nil, xerrors.Errorf("cannot compute selection list: %w", err)
+	}
 
 	// Compute the PCR digests for all branches, making sure that they all contain values for the same sets of PCRs.
 	var pcrDigests tpm2.DigestList

--- a/tpm2/pcr_profile_test.go
+++ b/tpm2/pcr_profile_test.go
@@ -23,11 +23,11 @@ import (
 	"fmt"
 
 	"github.com/canonical/go-tpm2"
-	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/secboot/internal/testutil"
 	"github.com/snapcore/secboot/internal/tpm2test"
 	. "github.com/snapcore/secboot/tpm2"
 )
@@ -44,7 +44,9 @@ type testPCRProtectionProfileData struct {
 }
 
 func (s *pcrProfileSuite) testPCRProtectionProfile(c *C, data *testPCRProtectionProfileData) {
-	expectedPcrs := data.values[0].SelectionList()
+	expectedPcrs, err := data.values[0].SelectionList()
+	c.Assert(err, IsNil)
+
 	var expectedDigests tpm2.DigestList
 	for _, v := range data.values {
 		d, _ := util.ComputePCRDigest(data.alg, expectedPcrs, v)
@@ -53,7 +55,7 @@ func (s *pcrProfileSuite) testPCRProtectionProfile(c *C, data *testPCRProtection
 
 	pcrs, pcrDigests, err := data.profile.ComputePCRDigests(nil, data.alg)
 	c.Assert(err, IsNil)
-	c.Check(pcrs.Equal(expectedPcrs), tpm2_testutil.IsTrue)
+	c.Check(pcrs.Equal(expectedPcrs), testutil.IsTrue)
 	c.Check(pcrDigests, DeepEquals, expectedDigests)
 
 	if c.Failed() {
@@ -950,8 +952,8 @@ func (s *pcrProfileTPMSuite) TestAddValueFromTPM(c *C) {
 	p := NewPCRProtectionProfile().AddPCRValueFromTPM(tpm2.HashAlgorithmSHA256, 23)
 	pcrs, digests, err := p.ComputePCRDigests(s.TPM().TPMContext, tpm2.HashAlgorithmSHA256)
 	c.Check(err, IsNil)
-	c.Check(pcrs.Equal(tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{23}}}), tpm2_testutil.IsTrue)
-	c.Check(digests, tpm2_testutil.LenEquals, 1)
+	c.Check(pcrs.Equal(tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{23}}}), testutil.IsTrue)
+	c.Check(digests, HasLen, 1)
 
 	expectedDigest, _ := util.ComputePCRDigest(tpm2.HashAlgorithmSHA256, tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{23}}}, values)
 	c.Check(digests[0], DeepEquals, expectedDigest)

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -210,11 +210,11 @@ func ensureSufficientORDigests(digests tpm2.DigestList) tpm2.DigestList {
 }
 
 // newKeyDataPolicy creates a keyDataPolicy containing a static authorization policy that asserts:
-// - The PCR policy created by updatePcrPolicy and authorized by key is valid and has been satisfied (by way
-//   of a PolicyAuthorize assertion, which allows the PCR policy to be updated without creating a new sealed
-//   key object).
-// - Knowledge of the the authorization value for the entity on which the policy session is used has been
-//   demonstrated by the caller - this will be used in the future as part of the passphrase integration.
+//   - The PCR policy created by updatePcrPolicy and authorized by key is valid and has been satisfied (by way
+//     of a PolicyAuthorize assertion, which allows the PCR policy to be updated without creating a new sealed
+//     key object).
+//   - Knowledge of the the authorization value for the entity on which the policy session is used has been
+//     demonstrated by the caller - this will be used in the future as part of the passphrase integration.
 //
 // PCR policies support revocation by way of a NV counter. The revocation check is part of the PCR policy,
 // but the counter is bound to the static policy by including it in the policyRef for the PolicyAuthorize

--- a/tpm2/policy_test.go
+++ b/tpm2/policy_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/templates"
-	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
@@ -220,7 +219,7 @@ func (s *policySuiteNoTPM) testNewKeyDataPolicy(c *C, data *testNewKeyDataPolicy
 	c.Assert(block, NotNil)
 	key, err := x509.ParsePKIXPublicKey(block.Bytes)
 	c.Assert(err, IsNil)
-	c.Assert(key, tpm2_testutil.ConvertibleTo, &ecdsa.PublicKey{})
+	c.Assert(key, testutil.ConvertibleTo, &ecdsa.PublicKey{})
 
 	authKey := util.NewExternalECCPublicKeyWithDefaults(templates.KeyUsageSign, key.(*ecdsa.PublicKey))
 
@@ -231,7 +230,7 @@ func (s *policySuiteNoTPM) testNewKeyDataPolicy(c *C, data *testNewKeyDataPolicy
 
 	policy, digest, err := NewKeyDataPolicy(data.alg, authKey, data.pcrPolicyCounterPub, data.pcrPolicySequence)
 	c.Assert(err, IsNil)
-	c.Assert(policy, tpm2_testutil.ConvertibleTo, &KeyDataPolicy_v2{})
+	c.Assert(policy, testutil.ConvertibleTo, &KeyDataPolicy_v2{})
 	c.Check(policy.(*KeyDataPolicy_v2).StaticData.AuthPublicKey, DeepEquals, authKey)
 	c.Check(policy.PCRPolicyCounterHandle(), Equals, pcrPolicyCounterHandle)
 	c.Check(policy.PCRPolicySequence(), Equals, data.pcrPolicySequence)
@@ -364,7 +363,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9pYAXaeeWBHZZ9TCRXNHClxi6NBB
 	c.Assert(block, NotNil)
 	key, err := x509.ParsePKIXPublicKey(block.Bytes)
 	c.Assert(err, IsNil)
-	c.Assert(key, tpm2_testutil.ConvertibleTo, &ecdsa.PublicKey{})
+	c.Assert(key, testutil.ConvertibleTo, &ecdsa.PublicKey{})
 
 	handle := s.NextAvailableHandle(c, 0x0181ff00)
 	pub, count, err := CreatePcrPolicyCounter(s.TPM().TPMContext, handle,
@@ -442,7 +441,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9pYAXaeeWBHZZ9TCRXNHClxi6NBB
 	c.Assert(block, NotNil)
 	key, err := x509.ParsePKIXPublicKey(block.Bytes)
 	c.Assert(err, IsNil)
-	c.Assert(key, tpm2_testutil.ConvertibleTo, &ecdsa.PublicKey{})
+	c.Assert(key, testutil.ConvertibleTo, &ecdsa.PublicKey{})
 
 	handle := tpm2.Handle(0x0181ff00)
 	pub, count, err := CreatePcrPolicyCounter(s.TPM().TPMContext, handle,

--- a/tpm2/policy_v0.go
+++ b/tpm2/policy_v0.go
@@ -200,11 +200,11 @@ func newPolicyOrDataV0(tree *policyOrTree) (out policyOrData_v0) {
 
 // computeV0PinNVIndexPostInitAuthPolicies computes the authorization policy digests associated with the post-initialization
 // actions on a NV index created with the removed createPinNVIndex for version 0 key files. These are:
-// - A policy for updating the index to revoke old dynamic authorization policies, requiring an assertion signed by the key
-//   associated with updateKeyName.
-// - A policy for updating the authorization value (PIN / passphrase), requiring knowledge of the current authorization value.
-// - A policy for reading the counter value without knowing the authorization value, as the value isn't secret.
-// - A policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
+//   - A policy for updating the index to revoke old dynamic authorization policies, requiring an assertion signed by the key
+//     associated with updateKeyName.
+//   - A policy for updating the authorization value (PIN / passphrase), requiring knowledge of the current authorization value.
+//   - A policy for reading the counter value without knowing the authorization value, as the value isn't secret.
+//   - A policy for using the counter value in a TPM2_PolicyNV assertion without knowing the authorization value.
 func computeV0PinNVIndexPostInitAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyName tpm2.Name) tpm2.DigestList {
 	var out tpm2.DigestList
 	// Compute a policy for incrementing the index to revoke dynamic authorization policies, requiring an assertion signed by the
@@ -358,12 +358,13 @@ func (p *keyDataPolicy_v0) PCRPolicySequence() uint64 {
 
 // UpdatePCRPolicy updates the PCR policy associated with this keyDataPolicy. The PCR policy asserts
 // that the following are true:
-// - The selected PCRs contain expected values - ie, one of the sets of permitted values specified by
-//   the caller to this function, indicating that the device is in an expected state. This is done by a
-//   single PolicyPCR assertion and then one or more PolicyOR assertions (depending on how many sets of
-//   permitted PCR values there are).
-// - The PCR policy hasn't been revoked. This is done using a PolicyNV assertion to assert that the
-//   value of an optional NV counter is not greater than the PCR policy sequence.
+//   - The selected PCRs contain expected values - ie, one of the sets of permitted values specified by
+//     the caller to this function, indicating that the device is in an expected state. This is done by a
+//     single PolicyPCR assertion and then one or more PolicyOR assertions (depending on how many sets of
+//     permitted PCR values there are).
+//   - The PCR policy hasn't been revoked. This is done using a PolicyNV assertion to assert that the
+//     value of an optional NV counter is not greater than the PCR policy sequence.
+//
 // The computed PCR policy digest is authorized with the supplied key. The signature of this is
 // validated during execution before executing the corresponding PolicyAuthorize assertion as part of the
 // static policy.

--- a/tpm2/policy_v0_test.go
+++ b/tpm2/policy_v0_test.go
@@ -158,7 +158,7 @@ func (s *policyV0SuiteNoTPM) testPolicyOrTreeSerialization(c *C, data *testPolic
 	c.Assert(err, IsNil)
 
 	serialized := NewPolicyOrDataV0(tree)
-	c.Check(serialized, tpm2_testutil.LenEquals, data.numNodes)
+	c.Check(serialized, HasLen, data.numNodes)
 
 	tree2, err := serialized.Resolve()
 	c.Assert(err, IsNil)
@@ -344,7 +344,7 @@ func (s *policyV0SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV0UpdatePCRPoli
 	params := NewPcrPolicyParams(x509.MarshalPKCS1PrivateKey(key), data.pcrs, data.pcrDigests, policyCounterName)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
-	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.Selection.Equal(data.pcrs), tpm2_testutil.IsTrue)
+	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.Selection.Equal(data.pcrs), testutil.IsTrue)
 
 	orTree, err := policyData.(*KeyDataPolicy_v0).PCRData.OrData.Resolve()
 	c.Assert(err, IsNil)
@@ -367,7 +367,7 @@ func (s *policyV0SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV0UpdatePCRPoli
 	c.Check(err, IsNil)
 	ok, err := util.VerifySignature(&key.PublicKey, digest, policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicySignature)
 	c.Check(err, IsNil)
-	c.Check(ok, tpm2_testutil.IsTrue)
+	c.Check(ok, testutil.IsTrue)
 }
 
 func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicy(c *C) {
@@ -909,7 +909,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidSelection1(c *C)
 			data.PCRData.Selection = tpm2.PCRSelectionList{}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
 
@@ -950,7 +950,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidSelection2(c *C)
 			data.PCRData.Selection = tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{50}}}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: invalid PCR selection")
 }
 
@@ -991,7 +991,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree1(c *C) {
 			data.PCRData.OrData = PolicyOrData_v0{}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot resolve PolicyOR tree: no nodes")
 }
 
@@ -1032,7 +1032,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree2(c *C) {
 			data.PCRData.OrData[0].Next = 10
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot resolve PolicyOR tree: index 10 out of range")
 }
 
@@ -1077,7 +1077,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree3(c *C) {
 			copy(data.PCRData.OrData[4].Digests[0], make(tpm2.Digest, 32))
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: invalid data")
 }
 
@@ -1132,7 +1132,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree4(c *C) {
 			data.PCRData.OrData = NewPolicyOrDataV0(orData)
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "the PCR policy is invalid")
 }
 
@@ -1173,7 +1173,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidPolicySequence(c
 			data.PCRData.PolicySequence += 10
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "the PCR policy is invalid")
 }
 
@@ -1214,7 +1214,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingPCRMismatch(c *C) {
 		},
 		fn: func(data *KeyDataPolicy_v0, _ *rsa.PrivateKey) {},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
 
@@ -1255,7 +1255,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounter
 			data.StaticData.PCRPolicyCounterHandle = 0x81000000
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "invalid handle 0x81000000 for PCR policy counter")
 }
 
@@ -1301,7 +1301,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounter
 			data.StaticData.PCRPolicyCounterHandle = handle
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "no PCR policy counter found")
 }
 
@@ -1341,7 +1341,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounter
 			copy(data.StaticData.PCRPolicyCounterAuthPolicies[0], make(tpm2.Digest, 32))
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "invalid PCR policy counter or associated authorization policy metadata")
 }
 
@@ -1400,7 +1400,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 			}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "the PCR policy has been revoked")
 }
 
@@ -1441,7 +1441,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthPublicKey(c 
 			data.StaticData.AuthPublicKey.NameAlg = tpm2.HashAlgorithmId(tpm2.AlgorithmSM4)
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "public area of dynamic authorization policy signing key is invalid: TPM returned an error for parameter 2 whilst executing command TPM_CC_LoadExternal: "+
 		"TPM_RC_HASH \\(hash algorithm not supported or not appropriate\\)")
 }
@@ -1483,7 +1483,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 			copy(data.PCRData.AuthorizedPolicy, make(tpm2.Digest, 32))
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot verify PCR policy signature: TPM returned an error for parameter 2 whilst executing command TPM_CC_VerifySignature: TPM_RC_SIGNATURE \\(the signature is not valid\\)")
 }
 
@@ -1578,7 +1578,7 @@ func (s *policyV0Suite) TestExecutePCRPolicyErrorHandlingNoLockIndex(c *C) {
 			c.Check(s.TPM().NVUndefineSpace(s.TPM().OwnerHandleContext(), index, nil), IsNil)
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "no lock NV index found")
 }
 
@@ -1653,6 +1653,6 @@ func (s *policyV0SuiteNoTPM) TestValidateAuthKeyWrongKey(c *C) {
 	authKey, err = rsa.GenerateKey(testutil.RandReader, 2048)
 	c.Assert(err, IsNil)
 	err = data.ValidateAuthKey(x509.MarshalPKCS1PrivateKey(authKey))
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "dynamic authorization policy signing private key doesn't match public key")
 }

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -61,10 +61,10 @@ func computeV1PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyNa
 // computeV1PcrPolicyRefFromCounterName computes the reference used for authorization of signed
 // PCR policies from the supplied PCR policy counter name. If name is empty, then the name of
 // the null handle is assumed. The policy ref serves 2 purposes:
-// 1) It limits the scope of the signed policy to just PCR policies (the dynamic authorization
-//    policy key may be able to sign different types of policy in the future, for example, to
-//    permit recovery with a signed assertion.
-// 2) It binds the name of the PCR policy counter to the static authorization policy.
+//  1. It limits the scope of the signed policy to just PCR policies (the dynamic authorization
+//     policy key may be able to sign different types of policy in the future, for example, to
+//     permit recovery with a signed assertion.
+//  2. It binds the name of the PCR policy counter to the static authorization policy.
 func computeV1PcrPolicyRefFromCounterName(name tpm2.Name) tpm2.Nonce {
 	if len(name) == 0 {
 		name = make(tpm2.Name, binary.Size(tpm2.Handle(0)))
@@ -119,12 +119,13 @@ func (p *keyDataPolicy_v1) PCRPolicySequence() uint64 {
 
 // UpdatePCRPolicy updates the PCR policy associated with this keyDataPolicy. The PCR policy asserts
 // that the following are true:
-// - The selected PCRs contain expected values - ie, one of the sets of permitted values specified by
-//   the caller to this function, indicating that the device is in an expected state. This is done by a
-//   single PolicyPCR assertion and then one or more PolicyOR assertions (depending on how many sets of
-//   permitted PCR values there are).
-// - The PCR policy hasn't been revoked. This is done using a PolicyNV assertion to assert that the
-//   value of an optional NV counter is not greater than the PCR policy sequence.
+//   - The selected PCRs contain expected values - ie, one of the sets of permitted values specified by
+//     the caller to this function, indicating that the device is in an expected state. This is done by a
+//     single PolicyPCR assertion and then one or more PolicyOR assertions (depending on how many sets of
+//     permitted PCR values there are).
+//   - The PCR policy hasn't been revoked. This is done using a PolicyNV assertion to assert that the
+//     value of an optional NV counter is not greater than the PCR policy sequence.
+//
 // The computed PCR policy digest is authorized with the supplied key. The signature of this is
 // validated during execution before executing the corresponding PolicyAuthorize assertion as part of the
 // static policy.

--- a/tpm2/policy_v1_test.go
+++ b/tpm2/policy_v1_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/templates"
-	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 	"github.com/canonical/go-tpm2/util"
 
 	. "gopkg.in/check.v1"
@@ -113,7 +112,7 @@ func (s *policyV1SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV1UpdatePCRPoli
 	params := NewPcrPolicyParams(key.D.Bytes(), data.pcrs, data.pcrDigests, policyCounterName)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
-	c.Check(policyData.(*KeyDataPolicy_v1).PCRData.Selection.Equal(data.pcrs), tpm2_testutil.IsTrue)
+	c.Check(policyData.(*KeyDataPolicy_v1).PCRData.Selection.Equal(data.pcrs), testutil.IsTrue)
 
 	orTree, err := policyData.(*KeyDataPolicy_v1).PCRData.OrData.Resolve()
 	c.Assert(err, IsNil)
@@ -139,7 +138,7 @@ func (s *policyV1SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV1UpdatePCRPoli
 	c.Check(err, IsNil)
 	ok, err := util.VerifySignature(&key.PublicKey, digest, policyData.(*KeyDataPolicy_v1).PCRData.AuthorizedPolicySignature)
 	c.Check(err, IsNil)
-	c.Check(ok, tpm2_testutil.IsTrue)
+	c.Check(ok, testutil.IsTrue)
 }
 
 func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicy(c *C) {
@@ -309,7 +308,7 @@ func (s *policyV1Suite) testExecutePCRPolicy(c *C, data *testV1ExecutePCRPolicyD
 
 	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, policyCounterPub, policyCount)
 	c.Assert(err, IsNil)
-	c.Assert(policyData, tpm2_testutil.ConvertibleTo, &KeyDataPolicy_v1{})
+	c.Assert(policyData, testutil.ConvertibleTo, &KeyDataPolicy_v1{})
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
@@ -663,7 +662,7 @@ func (s *policyV1Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV1Exec
 
 	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, policyCounterPub, policyCount)
 	c.Assert(err, IsNil)
-	c.Assert(policyData, tpm2_testutil.ConvertibleTo, &KeyDataPolicy_v1{})
+	c.Assert(policyData, testutil.ConvertibleTo, &KeyDataPolicy_v1{})
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
@@ -734,7 +733,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidSelection1(c *C)
 			data.PCRData.Selection = tpm2.PCRSelectionList{}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
 
@@ -775,7 +774,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidSelection2(c *C)
 			data.PCRData.Selection = tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{50}}}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: invalid PCR selection")
 }
 
@@ -816,7 +815,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree1(c *C) {
 			data.PCRData.OrData = PolicyOrData_v0{}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot resolve PolicyOR tree: no nodes")
 }
 
@@ -857,7 +856,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree2(c *C) {
 			data.PCRData.OrData[0].Next = 10
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot resolve PolicyOR tree: index 10 out of range")
 }
 
@@ -902,7 +901,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree3(c *C) {
 			copy(data.PCRData.OrData[4].Digests[0], make(tpm2.Digest, 32))
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: invalid data")
 }
 
@@ -957,7 +956,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidOrTree4(c *C) {
 			data.PCRData.OrData = NewPolicyOrDataV0(orData)
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "the PCR policy is invalid")
 }
 
@@ -998,7 +997,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidPolicySequence(c
 			data.PCRData.PolicySequence += 10
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "the PCR policy is invalid")
 }
 
@@ -1039,7 +1038,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingPCRMismatch(c *C) {
 		},
 		fn: func(data *KeyDataPolicy_v1, _ *ecdsa.PrivateKey) {},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
 
@@ -1080,7 +1079,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounter
 			data.StaticData.PCRPolicyCounterHandle = 0x81000000
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "invalid handle 0x81000000 for PCR policy counter")
 }
 
@@ -1126,7 +1125,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounter
 			data.StaticData.PCRPolicyCounterHandle = handle
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "no PCR policy counter found")
 }
 
@@ -1168,7 +1167,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounter
 			data.StaticData.PCRPolicyCounterHandle = tpm2.HandleNull
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot verify PCR policy signature: TPM returned an error for parameter 2 whilst executing command TPM_CC_VerifySignature: TPM_RC_SIGNATURE \\(the signature is not valid\\)")
 }
 
@@ -1225,7 +1224,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 			}
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "the PCR policy has been revoked")
 }
 
@@ -1266,7 +1265,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthPublicKey(c 
 			data.StaticData.AuthPublicKey.NameAlg = tpm2.HashAlgorithmId(tpm2.AlgorithmSM4)
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "public area of dynamic authorization policy signing key is invalid: TPM returned an error for parameter 2 whilst executing command TPM_CC_LoadExternal: "+
 		"TPM_RC_HASH \\(hash algorithm not supported or not appropriate\\)")
 }
@@ -1308,7 +1307,7 @@ func (s *policyV1Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 			copy(data.PCRData.AuthorizedPolicy, make(tpm2.Digest, 32))
 		},
 	})
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "cannot verify PCR policy signature: TPM returned an error for parameter 2 whilst executing command TPM_CC_VerifySignature: TPM_RC_SIGNATURE \\(the signature is not valid\\)")
 }
 
@@ -1432,6 +1431,6 @@ func (s *policyV1SuiteNoTPM) TestValidateAuthKeyWrongKey(c *C) {
 	authKey, err = ecdsa.GenerateKey(elliptic.P256(), testutil.RandReader)
 	c.Assert(err, IsNil)
 	err = data.ValidateAuthKey(authKey.D.Bytes())
-	c.Check(IsPolicyDataError(err), tpm2_testutil.IsTrue)
+	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "dynamic authorization policy signing private key doesn't match public key")
 }

--- a/tpm2/seal_legacy_test.go
+++ b/tpm2/seal_legacy_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
-	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 
 	. "gopkg.in/check.v1"
 
@@ -58,7 +57,7 @@ func (s *sealLegacySuite) SetUpTest(c *C) {
 
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
 	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
-		tpm2_testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 
 var _ = Suite(&sealLegacySuite{})
@@ -394,7 +393,7 @@ func (s *sealLegacySuite) testSealKeyToTPMErrorHandling(c *C, params *KeyCreatio
 	_, sealErr := SealKeyToTPM(s.TPM(), key, path, params)
 
 	_, err := os.Stat(path)
-	c.Check(err, tpm2_testutil.ErrorIs, os.ErrNotExist)
+	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
 
 	var counter tpm2.ResourceContext
 	if params != nil && params.PCRPolicyCounterHandle != tpm2.HandleNull {
@@ -428,7 +427,7 @@ func (s *sealLegacySuite) TestSealKeyToTPMErrorHandlingOwnerAuthFail(c *C) {
 	err := s.testSealKeyToTPMErrorHandling(c, &KeyCreationParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)})
-	c.Assert(err, tpm2_testutil.ConvertibleTo, AuthFailError{})
+	c.Assert(err, testutil.ConvertibleTo, AuthFailError{})
 	c.Check(err.(AuthFailError).Handle, Equals, tpm2.HandleOwner)
 }
 
@@ -443,7 +442,7 @@ func (s *sealLegacySuite) TestSealKeyToTPMErrorHandlingPCRPolicyCounterExists(c 
 	err := s.testSealKeyToTPMErrorHandling(c, &KeyCreationParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7}),
 		PCRPolicyCounterHandle: public.Index})
-	c.Assert(err, tpm2_testutil.ConvertibleTo, TPMResourceExistsError{})
+	c.Assert(err, testutil.ConvertibleTo, TPMResourceExistsError{})
 	c.Check(err.(TPMResourceExistsError).Handle, Equals, public.Index)
 }
 
@@ -556,7 +555,7 @@ func (s *sealLegacySuite) testSealKeyToExternalTPMStorageKeyErrorHandling(c *C, 
 	_, sealErr := SealKeyToExternalTPMStorageKey(srkPub, key, path, params)
 
 	_, err = os.Stat(path)
-	c.Check(err, tpm2_testutil.ErrorIs, os.ErrNotExist)
+	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
 
 	return sealErr
 }

--- a/tpm2/snapmodel_policy.go
+++ b/tpm2/snapmodel_policy.go
@@ -138,18 +138,22 @@ type SnapModelProfileParams struct {
 // of the model that it has measured.
 //
 // The profile consists of 2 measurements:
-//  digestEpoch
-//  digestModel
+//
+//	digestEpoch
+//	digestModel
 //
 // digestEpoch is currently hardcoded as (where H is the digest algorithm supplied via params.PCRAlgorithm):
-//  digestEpoch = H(uint32(0))
+//
+//	digestEpoch = H(uint32(0))
 //
 // A future version of this package may allow another epoch to be supplied.
 //
 // digestModel is computed as follows (where H is the digest algorithm supplied via params.PCRAlgorithm):
-//  digest1 = H(tpm2.HashAlgorithmSHA384 || sign-key-sha3-384 || brand-id)
-//  digest2 = H(digest1 || model)
-//  digestModel = H(digest2 || series || grade)
+//
+//	digest1 = H(tpm2.HashAlgorithmSHA384 || sign-key-sha3-384 || brand-id)
+//	digest2 = H(digest1 || model)
+//	digestModel = H(digest2 || series || grade)
+//
 // The signing key digest algorithm is encoded in little-endian format, and the sign-key-sha3-384 field is hashed in decoded (binary)
 // form. The brand-id, model and series fields are hashed without null terminators. The grade field is encoded as the 32 bits from
 // asserts.ModelGrade.Code in little-endian format.

--- a/tpm2/unseal_legacy_test.go
+++ b/tpm2/unseal_legacy_test.go
@@ -24,12 +24,12 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/go-tpm2"
-	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/secboot"
 	"github.com/snapcore/secboot/internal/tcg"
+	"github.com/snapcore/secboot/internal/testutil"
 	"github.com/snapcore/secboot/internal/tpm2test"
 	. "github.com/snapcore/secboot/tpm2"
 )
@@ -49,7 +49,7 @@ func (s *unsealSuite) SetUpSuite(c *C) {
 func (s *unsealSuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
-		tpm2_testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 
 var _ = Suite(&unsealSuite{})
@@ -201,7 +201,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingInvalidPCRProfile(c *C) {
 		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
 		c.Check(err, IsNil)
 	})
-	c.Check(err, tpm2_testutil.ConvertibleTo, InvalidKeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, InvalidKeyDataError{})
 	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
 		"cannot execute PolicyOR assertions: current session digest not found in policy data")
 }
@@ -213,7 +213,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingRevokedPolicy(c *C) {
 		c.Check(k.UpdatePCRProtectionPolicy(s.TPM(), authKey, nil), IsNil)
 		c.Check(k.RevokeOldPCRProtectionPolicies(s.TPM(), authKey), IsNil)
 	})
-	c.Check(err, tpm2_testutil.ConvertibleTo, InvalidKeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, InvalidKeyDataError{})
 	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: "+
 		"the PCR policy has been revoked")
 }
@@ -222,7 +222,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingSealedKeyAccessLocked(c *C) 
 	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.AuxiliaryKey) {
 		c.Check(BlockPCRProtectionPolicies(s.TPM(), []int{23}), IsNil)
 	})
-	c.Check(err, tpm2_testutil.ConvertibleTo, InvalidKeyDataError{})
+	c.Check(err, testutil.ConvertibleTo, InvalidKeyDataError{})
 	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
 		"cannot execute PolicyOR assertions: current session digest not found in policy data")
 }

--- a/tpm2/update_legacy_test.go
+++ b/tpm2/update_legacy_test.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/go-tpm2"
-	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 
 	. "gopkg.in/check.v1"
 
@@ -55,7 +54,7 @@ func (s *updateLegacySuite) SetUpTest(c *C) {
 
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
 	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
-		tpm2_testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 
 var _ = Suite(&updateLegacySuite{})

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/go-tpm2"
-	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 
 	. "gopkg.in/check.v1"
 
@@ -54,7 +53,7 @@ func (s *updateSuite) SetUpTest(c *C) {
 
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
 	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
-		tpm2_testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 
 var _ = Suite(&updateSuite{})

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -61,66 +61,76 @@
 			"revisionTime": "2021-03-12T20:55:53Z"
 		},
 		{
-			"checksumSHA1": "6UqrJSrfA2t8UiyyLDFg/L4PQBI=",
+			"checksumSHA1": "IP8bXJ/G+HxDqIPwr0X5iQO4kt4=",
 			"path": "github.com/canonical/go-tpm2",
-			"revision": "de82cde8ad087dc6bbe6825adffa64ab28c7dda1",
-			"revisionTime": "2021-10-12T20:59:38Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "0wuA3btHc67a/DaiXem7zlpPRw4=",
-			"path": "github.com/canonical/go-tpm2/internal",
-			"revision": "1e41994e137391ff77b39c416e625575afb18872",
-			"revisionTime": "2021-09-30T14:01:45Z"
+			"checksumSHA1": "NKgskH7rjr817CiFVKR0W4AJaWU=",
+			"path": "github.com/canonical/go-tpm2/crypto",
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "hcs0X8rKQni3LBBPquw7GZ7KF4A=",
+			"checksumSHA1": "/Ie85OrKOl1pAObNgy15Rc8g+7E=",
+			"path": "github.com/canonical/go-tpm2/internal/testutil",
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
+		},
+		{
+			"checksumSHA1": "n4mMf5g8YgTq9jjhcU4F3Vvc4GY=",
 			"path": "github.com/canonical/go-tpm2/linux",
-			"revision": "de82cde8ad087dc6bbe6825adffa64ab28c7dda1",
-			"revisionTime": "2021-10-12T20:59:38Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "CaogwrlaFaf5AHOunuxYZbMhE2o=",
+			"checksumSHA1": "E8dwXLGiOO9RIcXgIdcBN1XuBQY=",
 			"path": "github.com/canonical/go-tpm2/mssim",
-			"revision": "de82cde8ad087dc6bbe6825adffa64ab28c7dda1",
-			"revisionTime": "2021-10-12T20:59:38Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "XhX0jJCdJOvsn4pIOL0H8J9YV54=",
+			"checksumSHA1": "bDTi/HuoCoTiPaVxr6G99nRZoFw=",
 			"path": "github.com/canonical/go-tpm2/mu",
-			"revision": "de82cde8ad087dc6bbe6825adffa64ab28c7dda1",
-			"revisionTime": "2021-10-12T20:59:38Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
 			"checksumSHA1": "uZAV20wIyayJqOPyFAf3H5V4o3k=",
 			"path": "github.com/canonical/go-tpm2/templates",
-			"revision": "de82cde8ad087dc6bbe6825adffa64ab28c7dda1",
-			"revisionTime": "2021-10-12T20:59:38Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "QKI6DV2GmXTdx+8hu05RK+nUoZE=",
+			"checksumSHA1": "Srj1+5SbbLBYxZESOBXsoSIZxAA=",
 			"path": "github.com/canonical/go-tpm2/testutil",
-			"revision": "de82cde8ad087dc6bbe6825adffa64ab28c7dda1",
-			"revisionTime": "2021-10-12T20:59:38Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "LiIpt5bsF9g4NskPRzeCDGc8Mkg=",
+			"checksumSHA1": "V1VvSPKRamf99lPl561GB5i8AzA=",
 			"path": "github.com/canonical/go-tpm2/util",
-			"revision": "de82cde8ad087dc6bbe6825adffa64ab28c7dda1",
-			"revisionTime": "2021-10-12T20:59:38Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "104d978386818d4023decd55c390a098fb5f2a86",
+			"revisionTime": "2022-11-24T01:51:30Z",
+			"version": "v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
 			"checksumSHA1": "pjpC3gtdvLblTbmFOnvc8MzbaLs=",


### PR DESCRIPTION
This includes a hardening fix for data that is deserialized from disk (see https://github.com/canonical/go-tpm2/commit/1a80c4b47c2b8f0e7a013b4ff5df27d331c48548).

There are some other changes, mostly removal of some checkers from the testutil package because they aren't TPM-specific and don't really belong there.

This adds a few things I want to use in secboot.