### PR TITLE
cryptsetup: add support for ICE flag

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -507,13 +507,17 @@ type InitializeLUKS2ContainerOptions struct {
 	// KDFOptions sets the KDF options for the initial keyslot. If this
 	// is nil then the defaults are used.
 	KDFOptions *KDFOptions
+
+	// InlineCryptoEngine set flag if to use Inline Crypto Engine
+	InlineCryptoEngine bool
 }
 
 func (o *InitializeLUKS2ContainerOptions) formatOpts() *luks2.FormatOptions {
 	return &luks2.FormatOptions{
 		MetadataKiBSize:     o.MetadataKiBSize,
 		KeyslotsAreaKiBSize: o.KeyslotsAreaKiBSize,
-		KDFOptions:          o.KDFOptions.internalOpts()}
+		KDFOptions:          o.KDFOptions.internalOpts(),
+		InlineCryptoEngine:  o.InlineCryptoEngine}
 }
 
 func validateInitializeLUKS2Options(options *InitializeLUKS2ContainerOptions) error {

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -143,6 +143,9 @@ type FormatOptions struct {
 	// KDFOptions describes the KDF options for the initial
 	// key slot.
 	KDFOptions KDFOptions
+
+	// InlineCryptoEngine set flag if to use Inline Crypto Engine
+	InlineCryptoEngine bool
 }
 
 // Format will initialize a LUKS2 container with the specified options and set the primary key to the
@@ -177,6 +180,10 @@ func Format(devicePath, label string, key []byte, opts *FormatOptions) error {
 	// apply KDF options
 	args = opts.KDFOptions.appendArguments(args)
 
+	if opts.InlineCryptoEngine {
+		// use inline crypto engine
+		args = append(args, "--inline-crypto-engine")
+	}
 	if opts.MetadataKiBSize != 0 {
 		// override the default metadata area size if specified
 		args = append(args, "--luks2-metadata-size", fmt.Sprintf("%dk", opts.MetadataKiBSize))

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -211,15 +211,20 @@ func (s *cryptsetupSuite) TestFormatWithCustomKeyslotsAreaSize(c *C) {
 }
 
 func (s *cryptsetupSuite) TestFormatWithInlineCryptoEngine(c *C) {
+	mockCryptsetup := snapd_testutil.MockCommand(c, "cryptsetup", "")
+	defer mockCryptsetup.Restore()
+
 	key := make([]byte, 32)
 	rand.Read(key)
-	s.testFormat(c, &testFormatData{
-		label: "test",
-		key:   key,
-		options: &FormatOptions{
-			KDFOptions:          KDFOptions{MemoryKiB: 32 * 1024, ForceIterations: 4},
-			KeyslotsAreaKiBSize: 2 * 1024,
-			InlineCryptoEngine:  true}})
+	options := &FormatOptions{
+		KDFOptions: KDFOptions{
+			MemoryKiB: 32 * 1024, ForceIterations: 4},
+		KeyslotsAreaKiBSize: 2 * 1024,
+		InlineCryptoEngine:  true}
+	err := Format("some-path", "test", key, options)
+	c.Check(err, IsNil)
+	c.Assert(mockCryptsetup.Calls(), HasLen, 1)
+	c.Check(mockCryptsetup.Calls()[0], snapd_testutil.Contains, "--inline-crypto-engine")
 }
 
 type testAddKeyData struct {

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -210,6 +210,18 @@ func (s *cryptsetupSuite) TestFormatWithCustomKeyslotsAreaSize(c *C) {
 			KeyslotsAreaKiBSize: 2 * 1024}})
 }
 
+func (s *cryptsetupSuite) TestFormatWithInlineCryptoEngine(c *C) {
+	key := make([]byte, 32)
+	rand.Read(key)
+	s.testFormat(c, &testFormatData{
+		label: "test",
+		key:   key,
+		options: &FormatOptions{
+			KDFOptions:          KDFOptions{MemoryKiB: 32 * 1024, ForceIterations: 4},
+			KeyslotsAreaKiBSize: 2 * 1024,
+			InlineCryptoEngine:  true}})
+}
+
 type testAddKeyData struct {
 	key     []byte
 	options *AddKeyOptions


### PR DESCRIPTION
Adding support for InlineCryptoEngine flag.
This is passed to `cryptsetup` as an additional `--inline-crypto-engine` flag.

This requires a modified `cryptsetup` supporting `inline-crypto-engine` feature.
