### PR TITLE
internal/testutil: Add MockKDF

### DIFF
--- a/argon2_test.go
+++ b/argon2_test.go
@@ -20,14 +20,11 @@
 package secboot_test
 
 import (
-	"crypto"
-	"encoding/binary"
 	"math"
 	"os"
 	"runtime"
 	"time"
 
-	"github.com/canonical/go-sp800.108-kdf"
 	snapd_testutil "github.com/snapcore/snapd/testutil"
 
 	"golang.org/x/sys/unix"
@@ -38,28 +35,6 @@ import (
 	"github.com/snapcore/secboot/internal/argon2"
 	"github.com/snapcore/secboot/internal/testutil"
 )
-
-type mockKDF struct {
-	lastBenchmarkKeyLen uint32
-}
-
-func (_ *mockKDF) Derive(passphrase string, salt []byte, params *KDFCostParams, keyLen uint32) ([]byte, error) {
-	context := make([]byte, len(salt)+9)
-	copy(context, salt)
-	binary.LittleEndian.PutUint32(context[len(salt):], params.Time)
-	binary.LittleEndian.PutUint32(context[len(salt)+4:], params.MemoryKiB)
-	context[len(salt)+8] = params.Threads
-
-	return kdf.CounterModeKey(kdf.NewHMACPRF(crypto.SHA256), []byte(passphrase), nil, context, keyLen*8), nil
-}
-
-func (k *mockKDF) Time(params *KDFCostParams, keyLen uint32) (time.Duration, error) {
-	k.lastBenchmarkKeyLen = keyLen
-
-	const memBandwidthKiBPerMs = 2048
-	duration := (time.Duration(float64(params.MemoryKiB)/float64(memBandwidthKiBPerMs)) * time.Duration(params.Time)) * time.Millisecond
-	return duration, nil
-}
 
 type argon2Suite struct {
 	halfTotalRamKiB uint64
@@ -92,7 +67,7 @@ func (s *argon2Suite) checkParams(c *C, opts *KDFOptions, ncpus int, params *KDF
 		if targetDuration == 0 {
 			targetDuration = 2 * time.Second
 		}
-		var kdf mockKDF
+		var kdf testutil.MockKDF
 		duration, _ := kdf.Time(params, 0)
 		c.Check(duration, Equals, targetDuration)
 
@@ -119,47 +94,47 @@ func (s *argon2Suite) checkParams(c *C, opts *KDFOptions, ncpus int, params *KDF
 var _ = Suite(&argon2Suite{})
 
 func (s *argon2Suite) TestDeriveCostParamsDefault(c *C) {
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	params, err := opts.DeriveCostParams(48, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(48))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(48))
 
 	s.checkParams(c, &opts, s.cpus, params)
 }
 
 func (s *argon2Suite) TestDeriveCostParamsMemoryLimit(c *C) {
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	opts.MemoryKiB = 32 * 1024
 	params, err := opts.DeriveCostParams(48, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(48))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(48))
 
 	s.checkParams(c, &opts, s.cpus, params)
 }
 
 func (s *argon2Suite) TestDeriveCostParamsForceBenchmarkedThreads(c *C) {
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	opts.Parallel = 1
 	params, err := opts.DeriveCostParams(48, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(48))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(48))
 
 	s.checkParams(c, &opts, s.cpus, params)
 }
 
 func (s *argon2Suite) TestDeriveCostParamsDifferentKeyLen(c *C) {
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	params, err := opts.DeriveCostParams(32, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(32))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(32))
 
 	s.checkParams(c, &opts, s.cpus, params)
 }
@@ -168,13 +143,13 @@ func (s *argon2Suite) TestDeriveCostParamsForceIterations(c *C) {
 	restore := MockRuntimeNumCPU(2)
 	defer restore()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	opts.ForceIterations = 3
 	params, err := opts.DeriveCostParams(48, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(0))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(0))
 
 	s.checkParams(c, &opts, 2, params)
 }
@@ -183,14 +158,14 @@ func (s *argon2Suite) TestDeriveCostParamsForceMemory(c *C) {
 	restore := MockRuntimeNumCPU(2)
 	defer restore()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	opts.ForceIterations = 3
 	opts.MemoryKiB = 32 * 1024
 	params, err := opts.DeriveCostParams(48, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(0))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(0))
 
 	s.checkParams(c, &opts, 2, params)
 }
@@ -199,13 +174,13 @@ func (s *argon2Suite) TestDeriveCostParamsForceIterationsDifferentCPUNum(c *C) {
 	restore := MockRuntimeNumCPU(8)
 	defer restore()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	opts.ForceIterations = 3
 	params, err := opts.DeriveCostParams(48, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(0))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(0))
 
 	s.checkParams(c, &opts, 4, params)
 }
@@ -214,14 +189,14 @@ func (s *argon2Suite) TestDeriveCostParamsForceThreads(c *C) {
 	restore := MockRuntimeNumCPU(8)
 	defer restore()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	var opts KDFOptions
 	opts.ForceIterations = 3
 	opts.Parallel = 1
 	params, err := opts.DeriveCostParams(48, &kdf)
 	c.Assert(err, IsNil)
-	c.Check(kdf.lastBenchmarkKeyLen, Equals, uint32(0))
+	c.Check(kdf.BenchmarkKeyLen, Equals, uint32(0))
 
 	s.checkParams(c, &opts, 1, params)
 }

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -797,7 +797,7 @@ func (s *cryptSuite) testActivateVolumeWithKeyData(c *C, data *testActivateVolum
 
 	authRequestor := &mockAuthRequestor{passphraseResponses: data.authResponses}
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	if data.passphrase != "" {
 		c.Check(keyData.SetPassphrase(data.passphrase, nil, &kdf), IsNil)
 	}
@@ -1154,7 +1154,7 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling10(c *C) {
 	keyData, key, _ := s.newNamedKeyData(c, "foo")
 	recoveryKey := s.newRecoveryKey()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase("1234", nil, &kdf), IsNil)
 
 	c.Check(s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
@@ -1202,7 +1202,7 @@ func (s *cryptSuite) TestActivateVolumeWithKeyDataErrorHandling13(c *C) {
 	keyData, key, _ := s.newNamedKeyData(c, "bar")
 	recoveryKey := s.newRecoveryKey()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase("1234", nil, &kdf), IsNil)
 
 	c.Check(s.testActivateVolumeWithKeyDataErrorHandling(c, &testActivateVolumeWithKeyDataErrorHandlingData{
@@ -1281,7 +1281,7 @@ func (s *cryptSuite) testActivateVolumeWithMultipleKeyData(c *C, data *testActiv
 
 	authRequestor := &mockAuthRequestor{passphraseResponses: data.authResponses}
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	options := &ActivateVolumeOptions{
 		PassphraseTries: data.passphraseTries,
 		KeyringPrefix:   data.keyringPrefix,
@@ -1385,7 +1385,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyData4(c *C) {
 	// Test with 2 keys that have a passphrase set, using the first key for activation.
 	keyData, keys, auxKeys := s.newMultipleNamedKeyData(c, "", "")
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData[0].SetPassphrase("1234", nil, &kdf), IsNil)
 	c.Check(keyData[1].SetPassphrase("5678", nil, &kdf), IsNil)
 
@@ -1417,7 +1417,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyData5(c *C) {
 	// Test with 2 keys that have a passphrase set, using the second key for activation.
 	keyData, keys, auxKeys := s.newMultipleNamedKeyData(c, "", "")
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData[0].SetPassphrase("1234", nil, &kdf), IsNil)
 	c.Check(keyData[1].SetPassphrase("5678", nil, &kdf), IsNil)
 
@@ -1450,7 +1450,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyData6(c *C) {
 	// should be used first.
 	keyData, keys, auxKeys := s.newMultipleNamedKeyData(c, "", "")
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData[0].SetPassphrase("1234", nil, &kdf), IsNil)
 
 	models := []SnapModel{
@@ -1481,7 +1481,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyData7(c *C) {
 	// after more than one attempt.
 	keyData, keys, auxKeys := s.newMultipleNamedKeyData(c, "", "")
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData[0].SetPassphrase("1234", nil, &kdf), IsNil)
 	c.Check(keyData[1].SetPassphrase("5678", nil, &kdf), IsNil)
 
@@ -1515,7 +1515,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyData8(c *C) {
 	// with the key that has a passphrase set.
 	keyData, keys, auxKeys := s.newMultipleNamedKeyData(c, "", "")
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData[1].SetPassphrase("5678", nil, &kdf), IsNil)
 
 	models := []SnapModel{
@@ -1830,7 +1830,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling10(c *C) 
 	keyData, keys, _ := s.newMultipleNamedKeyData(c, "foo", "bar")
 	recoveryKey := s.newRecoveryKey()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData[0].SetPassphrase("1234", nil, &kdf), IsNil)
 	c.Check(keyData[1].SetPassphrase("1234", nil, &kdf), IsNil)
 
@@ -1879,7 +1879,7 @@ func (s *cryptSuite) TestActivateVolumeWithMultipleKeyDataErrorHandling13(c *C) 
 	keyData, keys, _ := s.newMultipleNamedKeyData(c, "foo", "bar")
 	recoveryKey := s.newRecoveryKey()
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData[0].SetPassphrase("1234", nil, &kdf), IsNil)
 	c.Check(keyData[1].SetPassphrase("1234", nil, &kdf), IsNil)
 

--- a/internal/testutil/kdf.go
+++ b/internal/testutil/kdf.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"crypto"
+	_ "crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"time"
+
+	kdf "github.com/canonical/go-sp800.108-kdf"
+
+	"github.com/snapcore/secboot"
+)
+
+// MockKDF provides a mock implementation of secboot.KDF that isn't
+// memory intensive.
+type MockKDF struct {
+	// BenchmarkKeyLen is the key length that Time was called with. Set this
+	// to zero before running a mock benchmark.
+	BenchmarkKeyLen uint32
+}
+
+// Derive implements secboot.KDF.Derive and derives a key from the supplied
+// passphrase and parameters. This is only intended for testing and is not
+// meant to be secure in any way.
+func (_ *MockKDF) Derive(passphrase string, salt []byte, params *secboot.KDFCostParams, keyLen uint32) ([]byte, error) {
+	context := make([]byte, len(salt)+9)
+	copy(context, salt)
+	binary.LittleEndian.PutUint32(context[len(salt):], params.Time)
+	binary.LittleEndian.PutUint32(context[len(salt)+4:], params.MemoryKiB)
+	context[len(salt)+8] = params.Threads
+
+	return kdf.CounterModeKey(kdf.NewHMACPRF(crypto.SHA256), []byte(passphrase), nil, context, keyLen*8), nil
+}
+
+// Time implements secboot.KDF.Time and returns a time that is linearly
+// related to the specified cost parameters, suitable for mocking benchmarking.
+func (k *MockKDF) Time(params *secboot.KDFCostParams, keyLen uint32) (time.Duration, error) {
+	if k.BenchmarkKeyLen != 0 && k.BenchmarkKeyLen != keyLen {
+		return 0, errors.New("unexpected key length")
+	}
+	k.BenchmarkKeyLen = keyLen
+
+	const memBandwidthKiBPerMs = 2048
+	duration := (time.Duration(float64(params.MemoryKiB)/float64(memBandwidthKiBPerMs)) * time.Duration(params.Time)) * time.Millisecond
+	return duration, nil
+}

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -377,7 +377,7 @@ func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[
 		var def KDFOptions
 		kdfOpts = &def
 	}
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	costParams, err := kdfOpts.DeriveCostParams(0, &kdf)
 	c.Assert(err, IsNil)
@@ -633,7 +633,7 @@ func (s *keyDataSuite) TestRecoverKeysAuthModePassphrase(c *C) {
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase("passphrase", nil, &kdf), IsNil)
 
 	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeys()
@@ -663,7 +663,7 @@ func (s *keyDataSuite) testRecoverKeysWithPassphrase(c *C, passphrase string) {
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase(passphrase, nil, &kdf), IsNil)
 
 	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeysWithPassphrase(passphrase, &kdf)
@@ -686,7 +686,7 @@ func (s *keyDataSuite) TestSetPassphraseNotSupported(c *C) {
 
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
-	c.Check(keyData.SetPassphrase("passphrase", nil, &mockKDF{}), ErrorMatches, "not supported")
+	c.Check(keyData.SetPassphrase("passphrase", nil, new(testutil.MockKDF)), ErrorMatches, "not supported")
 
 	s.checkKeyDataJSONAuthModeNone(c, keyData, protected, 0)
 }
@@ -700,7 +700,7 @@ func (s *keyDataSuite) TestSetPassphraseAlreadySet(c *C) {
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 
 	c.Check(keyData.SetPassphrase("passphrase", nil, &kdf), IsNil)
 	c.Check(keyData.SetPassphrase("passphrase", nil, &kdf), ErrorMatches, "cannot set passphrase without authorization")
@@ -722,7 +722,7 @@ func (s *keyDataSuite) testSetPassphrase(c *C, data *testSetPassphraseData) {
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase(data.passphrase, data.kdfOptions, &kdf), IsNil)
 
 	s.checkKeyDataJSONAuthModePassphrase(c, keyData, protected, 0, data.passphrase, data.kdfOptions)
@@ -763,7 +763,7 @@ func (s *keyDataSuite) TestChangePassphraseAuthModeNone(c *C) {
 
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
-	err = keyData.ChangePassphrase("passphrase1", "passphrase2", &KDFOptions{}, &mockKDF{})
+	err = keyData.ChangePassphrase("passphrase1", "passphrase2", &KDFOptions{}, new(testutil.MockKDF))
 	c.Check(err, ErrorMatches, "cannot change passphrase without setting an initial passphrase")
 
 	s.checkKeyDataJSONAuthModeNone(c, keyData, protected, 0)
@@ -784,7 +784,7 @@ func (s *keyDataSuite) testChangePassphrase(c *C, data *testChangePassphraseData
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase(data.passphrase1, data.kdfOptions, &kdf), IsNil)
 	c.Check(keyData.ChangePassphrase(data.passphrase1, data.passphrase2, data.kdfOptions, &kdf), IsNil)
 
@@ -834,7 +834,7 @@ func (s *keyDataSuite) TestChangePassphraseWrongPassphrase(c *C) {
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase("12345678", nil, &kdf), IsNil)
 	c.Check(keyData.ChangePassphrase("passphrase", "12345678", &KDFOptions{TargetDuration: 100 * time.Millisecond}, &kdf), Equals, ErrInvalidPassphrase)
 
@@ -847,7 +847,7 @@ func (s *keyDataSuite) TestClearPassphraseWithPassphraseAuthModeNone(c *C) {
 
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
-	err = keyData.ClearPassphraseWithPassphrase("passphrase", &mockKDF{})
+	err = keyData.ClearPassphraseWithPassphrase("passphrase", new(testutil.MockKDF))
 	c.Check(err, ErrorMatches, "no passphrase is set")
 
 	s.checkKeyDataJSONAuthModeNone(c, keyData, protected, 0)
@@ -862,7 +862,7 @@ func (s *keyDataSuite) TestClearPassphraseWithPassphrase(c *C) {
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase("12345678", nil, &kdf), IsNil)
 	c.Check(keyData.ClearPassphraseWithPassphrase("12345678", &kdf), IsNil)
 
@@ -878,7 +878,7 @@ func (s *keyDataSuite) TestClearPassphraseWithPassphraseWrongPassphrase(c *C) {
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
 
-	var kdf mockKDF
+	var kdf testutil.MockKDF
 	c.Check(keyData.SetPassphrase("12345678", nil, &kdf), IsNil)
 	c.Check(keyData.ClearPassphraseWithPassphrase("passphrase", &kdf), Equals, ErrInvalidPassphrase)
 


### PR DESCRIPTION
This moves the mock KDF implementation in secboot_test to
internal/testutil, as it's going to be used inside the tpm2 package in a
follow up PR.