### PR TITLE
tpm2: add internal key sealer interface

### DIFF
--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -60,6 +60,14 @@ type KeyDataPolicy_v0 = keyDataPolicy_v0
 type KeyDataPolicy_v1 = keyDataPolicy_v1
 type KeyDataPolicy_v2 = keyDataPolicy_v2
 
+func NewImportableObjectKeySealer(key *tpm2.Public) keySealer {
+	return &importableObjectKeySealer{key}
+}
+
+func NewSealedObjectKeySealer(tpm *Connection) keySealer {
+	return &sealedObjectKeySealer{tpm}
+}
+
 type PolicyDataError = policyDataError
 type PolicyOrData_v0 = policyOrData_v0
 

--- a/tpm2/key_sealer.go
+++ b/tpm2/key_sealer.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2
+
+import (
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/templates"
+	"github.com/canonical/go-tpm2/util"
+
+	"golang.org/x/xerrors"
+)
+
+// keySealer is an abstraction for creating a sealed key object
+type keySealer interface {
+	CreateSealedObject(data []byte, nameAlg tpm2.HashAlgorithmId, policy tpm2.Digest) (tpm2.Private, *tpm2.Public, tpm2.EncryptedSecret, error)
+}
+
+// sealedObjectKeySealer is an implementation of keySealer that seals keys to
+// a TPM.
+type sealedObjectKeySealer struct {
+	tpm *Connection
+}
+
+func (s *sealedObjectKeySealer) CreateSealedObject(data []byte, nameAlg tpm2.HashAlgorithmId, policy tpm2.Digest) (tpm2.Private, *tpm2.Public, tpm2.EncryptedSecret, error) {
+	// Obtain a context for the SRK now. If we're called immediately after ProvisionTPM without
+	// closing the Connection, we use the context cached by ProvisionTPM, which corresponds to
+	// the object provisioned. If not, we just unconditionally provision a new SRK as this function
+	// requires knowledge of the owner hierarchy authorization anyway. This way, we know that the
+	// primary key we seal to is good and future calls to ProvisionTPM won't provision an object
+	// that cannot unseal the key we protect.
+	srk := s.tpm.provisionedSrk
+	if srk == nil {
+		var err error
+		srk, err = provisionStoragePrimaryKey(s.tpm.TPMContext, s.tpm.HmacSession())
+		switch {
+		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
+			return nil, nil, nil, AuthFailError{tpm2.HandleOwner}
+		case err != nil:
+			return nil, nil, nil, xerrors.Errorf("cannot provision storage root key: %w", err)
+		}
+	}
+
+	// Create the sensitive data
+	sensitive := tpm2.SensitiveCreate{Data: data}
+
+	// Define the template
+	template := templates.NewSealedObject(nameAlg)
+	template.Attrs &^= tpm2.AttrUserWithAuth
+	template.AuthPolicy = policy
+
+	// Now create the sealed key object. The command is integrity protected so if the object
+	// at the handle we expect the SRK to reside at has a different name (ie, if we're
+	// connected via a resource manager and somebody swapped the object with another one), this
+	// command will fail.
+	priv, pub, _, _, _, err := s.tpm.Create(srk, &sensitive, template, nil, nil,
+		s.tpm.HmacSession().IncludeAttrs(tpm2.AttrCommandEncrypt))
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create sealed object: %w", err)
+	}
+	return priv, pub, nil, err
+}
+
+// importableObjectKeySealer is an implementation of keySealer that seals keys to
+// a storage key in the form of an importable object.
+type importableObjectKeySealer struct {
+	tpmKey *tpm2.Public
+}
+
+func (s *importableObjectKeySealer) CreateSealedObject(data []byte, nameAlg tpm2.HashAlgorithmId, policy tpm2.Digest) (tpm2.Private, *tpm2.Public, tpm2.EncryptedSecret, error) {
+	pub, sensitive := util.NewExternalSealedObject(nameAlg, nil, data)
+	pub.Attrs &^= tpm2.AttrUserWithAuth
+	pub.AuthPolicy = policy
+
+	// Now create the importable sealed key object (duplication object).
+	_, priv, importSymSeed, err := util.CreateDuplicationObjectFromSensitive(sensitive, pub, s.tpmKey, nil, nil)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create duplication object: %w", err)
+	}
+	return priv, pub, importSymSeed, nil
+}

--- a/tpm2/key_sealer.go
+++ b/tpm2/key_sealer.go
@@ -29,11 +29,15 @@ import (
 
 // keySealer is an abstraction for creating a sealed key object
 type keySealer interface {
+	// CreateSealedObject creates a new sealed object containing the supplied data
+	// and with the specified name algorithm and authorization policy. It returns
+	// the private and public parts of the object, and an optional secret value if
+	// the returned object has to be imported.
 	CreateSealedObject(data []byte, nameAlg tpm2.HashAlgorithmId, policy tpm2.Digest) (tpm2.Private, *tpm2.Public, tpm2.EncryptedSecret, error)
 }
 
-// sealedObjectKeySealer is an implementation of keySealer that seals keys to
-// a TPM.
+// sealedObjectKeySealer is an implementation of keySealer that seals data to
+// to the storage primary key of the associated TPM.
 type sealedObjectKeySealer struct {
 	tpm *Connection
 }
@@ -77,8 +81,11 @@ func (s *sealedObjectKeySealer) CreateSealedObject(data []byte, nameAlg tpm2.Has
 	return priv, pub, nil, err
 }
 
-// importableObjectKeySealer is an implementation of keySealer that seals keys to
-// a storage key in the form of an importable object.
+// importableObjectKeySealer is an implementation of keySealer that seals data to
+// an object that can be imported to the hierarchy protected by the specified storage
+// key, which should correspond to the TPM's storage primary key. This is suitable in
+// environments that don't have access to the TPM but do have access to the public part
+// of its storage primary key.
 type importableObjectKeySealer struct {
 	tpmKey *tpm2.Public
 }

--- a/tpm2/key_sealer_test.go
+++ b/tpm2/key_sealer_test.go
@@ -1,0 +1,219 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tpm2_test
+
+import (
+	"crypto/rsa"
+
+	"github.com/canonical/go-tpm2"
+	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
+	"github.com/canonical/go-tpm2/util"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/secboot/internal/tcg"
+	"github.com/snapcore/secboot/internal/testutil"
+	"github.com/snapcore/secboot/internal/tpm2test"
+	. "github.com/snapcore/secboot/tpm2"
+)
+
+type sealedObjectKeySealerSuite struct {
+	tpm2test.TPMTest
+}
+
+func (s *sealedObjectKeySealerSuite) SetUpSuite(c *C) {
+	s.TPMFeatures = tpm2test.TPMFeatureOwnerHierarchy |
+		tpm2test.TPMFeatureEndorsementHierarchy |
+		tpm2test.TPMFeatureLockoutHierarchy | // Allow the test fixture to reset the DA counter
+		tpm2test.TPMFeaturePCR |
+		tpm2test.TPMFeatureNV
+}
+
+func (s *sealedObjectKeySealerSuite) SetUpTest(c *C) {
+	s.TPMTest.SetUpTest(c)
+
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
+}
+
+var _ = Suite(&sealedObjectKeySealerSuite{})
+
+type testCreateSealedObjectData struct {
+	data         tpm2.SensitiveData
+	nameAlg      tpm2.HashAlgorithmId
+	policyDigest tpm2.Digest
+	session      tpm2.SessionContext
+}
+
+func (s *sealedObjectKeySealerSuite) testCreateSealedObject(c *C, data *testCreateSealedObjectData) {
+	sealer := NewSealedObjectKeySealer(s.TPM())
+
+	priv, pub, importSymSeed, err := sealer.CreateSealedObject(data.data, data.nameAlg, data.policyDigest)
+	c.Assert(err, IsNil)
+	c.Check(importSymSeed, IsNil)
+
+	c.Check(pub.Type, Equals, tpm2.ObjectTypeKeyedHash)
+	c.Check(pub.NameAlg, Equals, data.nameAlg)
+	c.Check(pub.Attrs, Equals, tpm2.AttrFixedParent|tpm2.AttrFixedTPM)
+	c.Check(pub.AuthPolicy, DeepEquals, data.policyDigest)
+	c.Check(pub.Params, DeepEquals,
+		&tpm2.PublicParamsU{
+			KeyedHashDetail: &tpm2.KeyedHashParams{
+				Scheme: tpm2.KeyedHashScheme{
+					Scheme:  tpm2.KeyedHashSchemeNull,
+					Details: &tpm2.SchemeKeyedHashU{}}}})
+
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+
+	k, err := s.TPM().Load(srk, priv, pub, nil)
+	c.Assert(err, IsNil)
+
+	recoveredData, err := s.TPM().Unseal(k, data.session)
+	c.Check(err, IsNil)
+	c.Check(recoveredData, DeepEquals, data.data)
+}
+
+func (s *sealedObjectKeySealerSuite) TestCreateSealedObject(c *C) {
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: make([]byte, 32),
+		session:      s.StartAuthSession(c, nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)})
+}
+
+func (s *sealedObjectKeySealerSuite) TestCreateSealedObjectWithNewConnection(c *C) {
+	// createSealedObject behaves slightly different if called immediately after
+	// EnsureProvisioned with the same Connection
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: make([]byte, 32),
+		session:      s.StartAuthSession(c, nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)})
+}
+
+func (s *sealedObjectKeySealerSuite) TestCreateSealedObjectMissingSRK(c *C) {
+	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
+	c.Assert(err, IsNil)
+	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
+
+	s.ReinitTPMConnectionFromExisting(c)
+
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: make([]byte, 32),
+		session:      s.StartAuthSession(c, nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)})
+}
+
+func (s *sealedObjectKeySealerSuite) TestCreateSealedObjectDifferentData(c *C) {
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("bar"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: make([]byte, 32),
+		session:      s.StartAuthSession(c, nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)})
+}
+
+func (s *sealedObjectKeySealerSuite) TestCreateSealedObjectDifferentNameAlg(c *C) {
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA1,
+		policyDigest: make([]byte, 20),
+		session:      s.StartAuthSession(c, nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA1)})
+}
+
+func (s *sealedObjectKeySealerSuite) TestCreateSealedObjectDifferentPolicy(c *C) {
+	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	trial.PolicyAuthValue()
+
+	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)
+	c.Check(s.TPM().PolicyAuthValue(session), IsNil)
+
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: trial.GetDigest(),
+		session:      session})
+}
+
+type importableObjectKeySealerSuite struct{}
+
+var _ = Suite(&importableObjectKeySealerSuite{})
+
+func (s *importableObjectKeySealerSuite) testCreateSealedObject(c *C, data *testCreateSealedObjectData) {
+	key, err := rsa.GenerateKey(testutil.RandReader, 2048)
+	c.Assert(err, IsNil)
+
+	srk := tpm2_testutil.NewExternalRSAStoragePublicKey(&key.PublicKey)
+
+	sealer := NewImportableObjectKeySealer(srk)
+
+	priv, pub, importSymSeed, err := sealer.CreateSealedObject(data.data, data.nameAlg, data.policyDigest)
+	c.Assert(err, IsNil)
+
+	c.Check(pub.Type, Equals, tpm2.ObjectTypeKeyedHash)
+	c.Check(pub.NameAlg, Equals, data.nameAlg)
+	c.Check(pub.Attrs, Equals, tpm2.ObjectAttributes(0))
+	c.Check(pub.AuthPolicy, DeepEquals, data.policyDigest)
+	c.Check(pub.Params, DeepEquals,
+		&tpm2.PublicParamsU{
+			KeyedHashDetail: &tpm2.KeyedHashParams{
+				Scheme: tpm2.KeyedHashScheme{Scheme: tpm2.KeyedHashSchemeNull}}})
+
+	sensitive, err := util.UnwrapDuplicationObjectToSensitive(priv, pub, key, srk.NameAlg, &srk.Params.RSADetail.Symmetric, nil, importSymSeed, nil)
+	c.Assert(err, IsNil)
+
+	c.Check(sensitive.Type, Equals, tpm2.ObjectTypeKeyedHash)
+	c.Check(sensitive.AuthValue, DeepEquals, make(tpm2.Auth, data.nameAlg.Size()))
+	c.Check(sensitive.Sensitive.Bits, DeepEquals, data.data)
+}
+
+func (s *importableObjectKeySealerSuite) TestCreateSealedObject(c *C) {
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: make([]byte, 32)})
+}
+
+func (s *importableObjectKeySealerSuite) TestCreateSealedObjectDifferentData(c *C) {
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("bar"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: make([]byte, 32)})
+}
+
+func (s *importableObjectKeySealerSuite) TestCreateSealedObjectiDifferentNameAlg(c *C) {
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA1,
+		policyDigest: make([]byte, 20)})
+}
+
+func (s *importableObjectKeySealerSuite) TestCreateSealedObjectWithDifferentPolicy(c *C) {
+	trial := util.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+	trial.PolicyAuthValue()
+
+	s.testCreateSealedObject(c, &testCreateSealedObjectData{
+		data:         []byte("foo"),
+		nameAlg:      tpm2.HashAlgorithmSHA256,
+		policyDigest: trial.GetDigest()})
+}


### PR DESCRIPTION
This is a new internal interface that is going to be used by the new key
sealing APIs in order to increase code use between them.