### PR TITLE
tpm2: Make newKeyData support multiple metadata versions

### DIFF
--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -41,6 +41,7 @@ var (
 	DeriveV3PolicyAuthKey                   = deriveV3PolicyAuthKey
 	ErrSessionDigestNotFound                = errSessionDigestNotFound
 	IsPolicyDataError                       = isPolicyDataError
+	NewKeyData                              = newKeyData
 	NewKeyDataPolicy                        = newKeyDataPolicy
 	NewKeyDataPolicyLegacy                  = newKeyDataPolicyLegacy
 	NewPolicyOrDataV0                       = newPolicyOrDataV0

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -131,13 +131,7 @@ func newKeyData(keyPrivate tpm2.Private, keyPublic *tpm2.Public, importSymSeed t
 	// downgraded to v1 when serialized if it is not importable
 	// case *keyDataPolicy_v1:
 	case *keyDataPolicy_v0:
-		if len(importSymSeed) != 0 {
-			return nil, errors.New("no importable key data support for v0")
-		}
-		return &keyData_v0{
-			KeyPrivate: keyPrivate,
-			KeyPublic:  keyPublic,
-			PolicyData: p}, nil
+		return nil, errors.New("no support for creating v0 keys")
 	default:
 		panic("invalid policy")
 	}

--- a/tpm2/keydata_test.go
+++ b/tpm2/keydata_test.go
@@ -46,26 +46,8 @@ func (s *keydataSuiteNoTPM) TestNewKeyDataV0(c *C) {
 	pub := new(tpm2.Public)
 	policy := new(KeyDataPolicy_v0)
 
-	data, err := NewKeyData(priv, pub, nil, policy)
-	c.Assert(err, IsNil)
-
-	_, ok := data.(*KeyData_v0)
-	c.Check(ok, testutil.IsTrue)
-
-	c.Check(data.Private(), DeepEquals, priv)
-	c.Check(data.Public(), Equals, pub)
-	c.Check(data.ImportSymSeed(), IsNil)
-	c.Check(data.Policy(), Equals, policy)
-}
-
-func (s *keydataSuiteNoTPM) TestNewKeyDataV0RejectsImportSymSeed(c *C) {
-	priv := tpm2.Private{1, 2, 3, 4}
-	pub := new(tpm2.Public)
-	importSymSeed := tpm2.EncryptedSecret{5, 6, 7, 8}
-	policy := new(KeyDataPolicy_v0)
-
-	_, err := NewKeyData(priv, pub, importSymSeed, policy)
-	c.Assert(err, ErrorMatches, "no importable key data support for v0")
+	_, err := NewKeyData(priv, pub, nil, policy)
+	c.Check(err, ErrorMatches, "no support for creating v0 keys")
 }
 
 func (s *keydataSuiteNoTPM) TestNewKeyDataV2(c *C) {

--- a/tpm2/seal_legacy.go
+++ b/tpm2/seal_legacy.go
@@ -167,8 +167,13 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockK
 
 	w := NewFileSealedKeyObjectWriter(keyPath)
 
+	data, err := newKeyData(priv, pub, importSymSeed, policyData)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create key data: %w", err)
+	}
+
 	// Marshal the entire object (sealed key object and auxiliary data) to disk
-	sko := newSealedKeyObject(newKeyData(priv, pub, importSymSeed, policyData))
+	sko := newSealedKeyObject(data)
 
 	// Create a PCR authorization policy
 	pcrProfile := params.PCRProfile
@@ -339,8 +344,13 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 
 		w := NewFileSealedKeyObjectWriter(key.Path)
 
+		data, err := newKeyData(priv, pub, nil, policyData)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot create key data: %w", err)
+		}
+
 		// Marshal the entire object (sealed key object and auxiliary data) to disk
-		sko := newSealedKeyObject(newKeyData(priv, pub, nil, policyData))
+		sko := newSealedKeyObject(data)
 
 		// Create a PCR authorization policy, only for the first key though. Subsequent keys
 		// share the same keyDataPolicy structure.


### PR DESCRIPTION
In order to support the ability to add additional keys to an existing
system in the future, newKeyData must be able to return a keyData
implementation that has the same metadata version as the supplied
keyDataPolicy implementation - this may not always be the latest
version.