### PR TITLE
Backport PR#220 to uc22

### DIFF
--- a/tpm2/tpm.go
+++ b/tpm2/tpm.go
@@ -79,11 +79,11 @@ func (t *Connection) IsEnabled() bool {
 }
 
 func (t *Connection) LockoutAuthSet() bool {
-	props, err := t.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1)
-	if err != nil || len(props) == 0 {
+	value, err := t.GetCapabilityTPMProperty(tpm2.PropertyPermanent)
+	if err != nil {
 		return false
 	}
-	return tpm2.PermanentAttributes(props[0].Value)&tpm2.AttrLockoutAuthSet > 0
+	return tpm2.PermanentAttributes(value)&tpm2.AttrLockoutAuthSet > 0
 }
 
 // VerifiedEKCertChain returns the verified certificate chain for the endorsement key certificate obtained from this TPM. It was

--- a/tpm2/tpm.go
+++ b/tpm2/tpm.go
@@ -78,6 +78,14 @@ func (t *Connection) IsEnabled() bool {
 	return tpm2.StartupClearAttributes(props[0].Value)&enabledMask == enabledMask
 }
 
+func (t *Connection) LockoutAuthSet() bool {
+	props, err := t.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1)
+	if err != nil || len(props) == 0 {
+		return false
+	}
+	return tpm2.PermanentAttributes(props[0].Value)&tpm2.AttrLockoutAuthSet > 0
+}
+
 // VerifiedEKCertChain returns the verified certificate chain for the endorsement key certificate obtained from this TPM. It was
 // verified using one of the built-in TPM manufacturer root CA certificates.
 func (t *Connection) VerifiedEKCertChain() []*x509.Certificate {


### PR DESCRIPTION
This is a backport of https://github.com/snapcore/secboot/pull/220/files to the uc22 branch so that it can be consumed by snapd.