### PR TITLE
keydata: Use the saved key size consistently when using a passphrase

### DIFF
--- a/keydata.go
+++ b/keydata.go
@@ -39,9 +39,9 @@ import (
 )
 
 const (
-	kdfType                 = "argon2i"
-	passphraseDerivedKeyLen = 32
-	passphraseEncryption    = "aes-cfb"
+	kdfType                    = "argon2i"
+	passphraseEncryptionKeyLen = 32
+	passphraseEncryption       = "aes-cfb"
 )
 
 var (
@@ -484,7 +484,7 @@ func (d *KeyData) updatePassphrase(payload, oldKey []byte, passphrase string, kd
 	}
 
 	// Derive both a key and an IV from the passphrase in a single pass.
-	keyLen := passphraseDerivedKeyLen + aes.BlockSize
+	keyLen := passphraseEncryptionKeyLen + aes.BlockSize
 
 	params, err := kdfOptions.deriveCostParams(keyLen, kdf)
 	if err != nil {
@@ -509,7 +509,7 @@ func (d *KeyData) updatePassphrase(payload, oldKey []byte, passphrase string, kd
 		return err
 	}
 
-	c, err := aes.NewCipher(key[:passphraseDerivedKeyLen])
+	c, err := aes.NewCipher(key[:passphraseEncryptionKeyLen])
 	if err != nil {
 		return xerrors.Errorf("cannot create cipher: %w", err)
 	}
@@ -523,10 +523,10 @@ func (d *KeyData) updatePassphrase(payload, oldKey []byte, passphrase string, kd
 			Memory: int(params.MemoryKiB),
 			CPUs:   int(params.Threads)},
 		Encryption:       passphraseEncryption,
-		KeySize:          passphraseDerivedKeyLen,
+		KeySize:          passphraseEncryptionKeyLen,
 		EncryptedPayload: make([]byte, len(payload))}
 
-	stream := cipher.NewCFBEncrypter(c, key[passphraseDerivedKeyLen:])
+	stream := cipher.NewCFBEncrypter(c, key[passphraseEncryptionKeyLen:])
 	stream.XORKeyStream(d.data.PassphraseProtectedPayload.EncryptedPayload, payload)
 
 	return nil
@@ -543,10 +543,15 @@ func (d *KeyData) openWithPassphrase(passphrase string, kdf KDF) (payload []byte
 		return nil, nil, fmt.Errorf("unexpected KDF type \"%s\"", data.KDF.Type)
 	}
 	if data.Encryption != passphraseEncryption {
-		// Only AES-256-CFB is supported
+		// Only AES-CFB is supported
 		return nil, nil, fmt.Errorf("unexpected encryption algorithm \"%s\"", data.Encryption)
 	}
+	if data.KeySize > 32 {
+		// The key size can't be larger than 32 with the supported cipher
+		return nil, nil, fmt.Errorf("invalid key size (%d bytes)", data.KeySize)
+	}
 
+	// Derive both the key and IV from the passphrase in a single pass.
 	keyLen := data.KeySize + aes.BlockSize
 
 	params := &KDFCostParams{
@@ -563,11 +568,11 @@ func (d *KeyData) openWithPassphrase(passphrase string, kdf KDF) (payload []byte
 
 	payload = make([]byte, len(data.EncryptedPayload))
 
-	c, err := aes.NewCipher(key[:passphraseDerivedKeyLen])
+	c, err := aes.NewCipher(key[:data.KeySize])
 	if err != nil {
 		return nil, nil, xerrors.Errorf("cannot create cipher: %w", err)
 	}
-	stream := cipher.NewCFBDecrypter(c, key[passphraseDerivedKeyLen:])
+	stream := cipher.NewCFBDecrypter(c, key[data.KeySize:])
 	stream.XORKeyStream(payload, data.EncryptedPayload)
 
 	return payload, key, nil


### PR DESCRIPTION
The passphrase derived encryption key size is stored in the key data when a passphrase is set but is then not used consistently after that. It's used to calculate the length of key material to derive from the passphrase, but then the compiled in constant key length is used to index into the returned bytes in order to separate the encryption key from the IV. This will cause a panic if the saved key data is modified to reduce the value of the key size.

This also renames the passphraseDerivdKeyLen constant - it's not the correct description as the actual derived key length is one block size larger than this.