### PR TITLE
Rename KeyCreationData to KeyCreationParams

### DIFF
--- a/keydata.go
+++ b/keydata.go
@@ -151,9 +151,9 @@ const (
 	AuthModePassphrase AuthMode = 1 << iota
 )
 
-// KeyCreationParams provides parameters required to create a new KeyData object.
+// KeyParams provides parameters required to create a new KeyData object.
 // It should be produced by a platform implementation.
-type KeyCreationParams struct {
+type KeyParams struct {
 	// Handle contains metadata required by the platform in order to recover
 	// this key. It is opaque to this go package. It should be a value that can
 	// be encoded to JSON using go's encoding/json package, which could be
@@ -877,11 +877,11 @@ func ReadKeyData(r KeyDataReader) (*KeyData, error) {
 	return d, nil
 }
 
-// NewKeyData creates a new KeyData object using the supplied KeyCreationParams, which
+// NewKeyData creates a new KeyData object using the supplied KeyParams, which
 // should be created by a platform-specific package, containing a payload encrypted by
 // the platform's secure device and the associated handle required for subsequent
 // recovery of the keys.
-func NewKeyData(params *KeyCreationParams) (*KeyData, error) {
+func NewKeyData(params *KeyParams) (*KeyData, error) {
 	encodedHandle, err := json.Marshal(params.Handle)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot encode platform handle: %w", err)

--- a/keydata_luks_test.go
+++ b/keydata_luks_test.go
@@ -54,7 +54,7 @@ func (s *keyDataLuksSuite) SetUpTest(c *C) {
 
 var _ = Suite(&keyDataLuksSuite{})
 
-func (s *keyDataLuksSuite) checkKeyDataJSONFromLUKSToken(c *C, path string, id int, keyslot int, name string, priority int, creationData *KeyCreationData, nmodels int) {
+func (s *keyDataLuksSuite) checkKeyDataJSONFromLUKSToken(c *C, path string, id int, keyslot int, name string, priority int, creationData *KeyCreationParams, nmodels int) {
 	t, exists := s.luks2.devices[path].tokens[id]
 	c.Assert(exists, testutil.IsTrue)
 

--- a/keydata_luks_test.go
+++ b/keydata_luks_test.go
@@ -54,7 +54,7 @@ func (s *keyDataLuksSuite) SetUpTest(c *C) {
 
 var _ = Suite(&keyDataLuksSuite{})
 
-func (s *keyDataLuksSuite) checkKeyDataJSONFromLUKSToken(c *C, path string, id int, keyslot int, name string, priority int, creationData *KeyCreationParams, nmodels int) {
+func (s *keyDataLuksSuite) checkKeyDataJSONFromLUKSToken(c *C, path string, id int, keyslot int, name string, priority int, creationParams *KeyParams, nmodels int) {
 	t, exists := s.luks2.devices[path].tokens[id]
 	c.Assert(exists, testutil.IsTrue)
 
@@ -78,7 +78,7 @@ func (s *keyDataLuksSuite) checkKeyDataJSONFromLUKSToken(c *C, path string, id i
 	keyData, ok := token.Params["ubuntu_fde_data"].(map[string]interface{})
 	c.Assert(ok, testutil.IsTrue)
 
-	s.checkKeyDataJSONDecodedAuthModeNone(c, keyData, creationData, nmodels)
+	s.checkKeyDataJSONDecodedAuthModeNone(c, keyData, creationParams, nmodels)
 }
 
 type testKeyDataLuksWriterData struct {

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -254,7 +254,7 @@ func (s *keyDataTestBase) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKey, Aux
 	return key, auxKey
 }
 
-func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey AuxiliaryKey, modelAuthHash crypto.Hash) (out *KeyCreationParams) {
+func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey AuxiliaryKey, modelAuthHash crypto.Hash) (out *KeyParams) {
 	payload := MarshalKeys(key, auxKey)
 
 	k := make([]byte, 48)
@@ -272,7 +272,7 @@ func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey Auxili
 	c.Assert(err, IsNil)
 	stream := cipher.NewCFBEncrypter(b, handle.IV)
 
-	out = &KeyCreationParams{
+	out = &KeyParams{
 		PlatformName:      mockPlatformName,
 		Handle:            &handle,
 		EncryptedPayload:  make([]byte, len(payload)),
@@ -282,7 +282,7 @@ func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey Auxili
 	return
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{}, creationParams *KeyCreationParams, nmodels int) {
+func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{}, creationParams *KeyParams, nmodels int) {
 	c.Check(j["platform_name"], Equals, creationParams.PlatformName)
 
 	expectedHandle, ok := creationParams.Handle.(*mockPlatformKeyDataHandle)
@@ -351,7 +351,7 @@ func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{},
 	c.Check(digest, HasLen, h.Size())
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModeNone(c *C, j map[string]interface{}, creationParams *KeyCreationParams, nmodels int) {
+func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModeNone(c *C, j map[string]interface{}, creationParams *KeyParams, nmodels int) {
 	s.checkKeyDataJSONCommon(c, j, creationParams, nmodels)
 
 	str, ok := j["encrypted_payload"].(string)
@@ -363,7 +363,7 @@ func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModeNone(c *C, j map[string
 	c.Check(j, Not(testutil.HasKey), "passphrase_protected_payload")
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Reader, creationParams *KeyCreationParams, nmodels int) {
+func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Reader, creationParams *KeyParams, nmodels int) {
 	var j map[string]interface{}
 
 	d := json.NewDecoder(r)
@@ -372,7 +372,7 @@ func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Read
 	s.checkKeyDataJSONDecodedAuthModeNone(c, j, creationParams, nmodels)
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[string]interface{}, creationParams *KeyCreationParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[string]interface{}, creationParams *KeyParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
 	if kdfOpts == nil {
 		var def KDFOptions
 		kdfOpts = &def
@@ -436,7 +436,7 @@ func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[
 	c.Check(payload, DeepEquals, creationParams.EncryptedPayload)
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r io.Reader, creationParams *KeyCreationParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r io.Reader, creationParams *KeyParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
 	var j map[string]interface{}
 
 	d := json.NewDecoder(r)
@@ -451,14 +451,14 @@ type keyDataSuite struct {
 
 var _ = Suite(&keyDataSuite{})
 
-func (s *keyDataSuite) checkKeyDataJSONAuthModeNone(c *C, keyData *KeyData, creationParams *KeyCreationParams, nmodels int) {
+func (s *keyDataSuite) checkKeyDataJSONAuthModeNone(c *C, keyData *KeyData, creationParams *KeyParams, nmodels int) {
 	w := makeMockKeyDataWriter()
 	c.Check(keyData.WriteAtomic(w), IsNil)
 
 	s.checkKeyDataJSONFromReaderAuthModeNone(c, w.Reader(), creationParams, nmodels)
 }
 
-func (s *keyDataSuite) checkKeyDataJSONAuthModePassphrase(c *C, keyData *KeyData, creationParams *KeyCreationParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+func (s *keyDataSuite) checkKeyDataJSONAuthModePassphrase(c *C, keyData *KeyData, creationParams *KeyParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
 	w := makeMockKeyDataWriter()
 	c.Check(keyData.WriteAtomic(w), IsNil)
 
@@ -1059,7 +1059,7 @@ func (s *keyDataSuite) TestSetAuthorizedSnapModelsWithWrongKey(c *C) {
 
 type testWriteAtomicData struct {
 	keyData *KeyData
-	params  *KeyCreationParams
+	params  *KeyParams
 	nmodels int
 }
 

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -254,7 +254,7 @@ func (s *keyDataTestBase) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKey, Aux
 	return key, auxKey
 }
 
-func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey AuxiliaryKey, modelAuthHash crypto.Hash) (out *KeyCreationData) {
+func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey AuxiliaryKey, modelAuthHash crypto.Hash) (out *KeyCreationParams) {
 	payload := MarshalKeys(key, auxKey)
 
 	k := make([]byte, 48)
@@ -272,7 +272,7 @@ func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey Auxili
 	c.Assert(err, IsNil)
 	stream := cipher.NewCFBEncrypter(b, handle.IV)
 
-	out = &KeyCreationData{
+	out = &KeyCreationParams{
 		PlatformName:      mockPlatformName,
 		Handle:            &handle,
 		EncryptedPayload:  make([]byte, len(payload)),
@@ -282,10 +282,10 @@ func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey Auxili
 	return
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{}, creationData *KeyCreationData, nmodels int) {
-	c.Check(j["platform_name"], Equals, creationData.PlatformName)
+func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{}, creationParams *KeyCreationParams, nmodels int) {
+	c.Check(j["platform_name"], Equals, creationParams.PlatformName)
 
-	expectedHandle, ok := creationData.Handle.(*mockPlatformKeyDataHandle)
+	expectedHandle, ok := creationParams.Handle.(*mockPlatformKeyDataHandle)
 	c.Assert(ok, testutil.IsTrue)
 
 	handleBytes, err := json.Marshal(j["platform_handle"])
@@ -301,7 +301,7 @@ func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{},
 	c.Assert(ok, testutil.IsTrue)
 
 	h := toHash(c, m["alg"])
-	c.Check(h, Equals, creationData.SnapModelAuthHash)
+	c.Check(h, Equals, creationParams.SnapModelAuthHash)
 
 	c.Check(m, testutil.HasKey, "hmacs")
 	if nmodels == 0 {
@@ -323,7 +323,7 @@ func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{},
 	c.Assert(ok, testutil.IsTrue)
 
 	h = toHash(c, m1["alg"])
-	c.Check(h, Equals, creationData.SnapModelAuthHash)
+	c.Check(h, Equals, creationParams.SnapModelAuthHash)
 
 	str, ok := m1["salt"].(string)
 	c.Check(ok, testutil.IsTrue)
@@ -335,7 +335,7 @@ func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{},
 	c.Assert(ok, testutil.IsTrue)
 
 	h = toHash(c, m2["alg"])
-	c.Check(h, Equals, creationData.SnapModelAuthHash)
+	c.Check(h, Equals, creationParams.SnapModelAuthHash)
 
 	str, ok = m2["salt"].(string)
 	c.Check(ok, testutil.IsTrue)
@@ -351,28 +351,28 @@ func (s *keyDataTestBase) checkKeyDataJSONCommon(c *C, j map[string]interface{},
 	c.Check(digest, HasLen, h.Size())
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModeNone(c *C, j map[string]interface{}, creationData *KeyCreationData, nmodels int) {
-	s.checkKeyDataJSONCommon(c, j, creationData, nmodels)
+func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModeNone(c *C, j map[string]interface{}, creationParams *KeyCreationParams, nmodels int) {
+	s.checkKeyDataJSONCommon(c, j, creationParams, nmodels)
 
 	str, ok := j["encrypted_payload"].(string)
 	c.Check(ok, testutil.IsTrue)
 	encryptedPayload, err := base64.StdEncoding.DecodeString(str)
 	c.Check(err, IsNil)
-	c.Check(encryptedPayload, DeepEquals, creationData.EncryptedPayload)
+	c.Check(encryptedPayload, DeepEquals, creationParams.EncryptedPayload)
 
 	c.Check(j, Not(testutil.HasKey), "passphrase_protected_payload")
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Reader, creationData *KeyCreationData, nmodels int) {
+func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModeNone(c *C, r io.Reader, creationParams *KeyCreationParams, nmodels int) {
 	var j map[string]interface{}
 
 	d := json.NewDecoder(r)
 	c.Check(d.Decode(&j), IsNil)
 
-	s.checkKeyDataJSONDecodedAuthModeNone(c, j, creationData, nmodels)
+	s.checkKeyDataJSONDecodedAuthModeNone(c, j, creationParams, nmodels)
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[string]interface{}, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[string]interface{}, creationParams *KeyCreationParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
 	if kdfOpts == nil {
 		var def KDFOptions
 		kdfOpts = &def
@@ -382,7 +382,7 @@ func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[
 	costParams, err := kdfOpts.DeriveCostParams(0, &kdf)
 	c.Assert(err, IsNil)
 
-	s.checkKeyDataJSONCommon(c, j, creationData, nmodels)
+	s.checkKeyDataJSONCommon(c, j, creationParams, nmodels)
 
 	c.Check(j, Not(testutil.HasKey), "encrypted_payload")
 
@@ -433,16 +433,16 @@ func (s *keyDataTestBase) checkKeyDataJSONDecodedAuthModePassphrase(c *C, j map[
 	stream := cipher.NewCFBDecrypter(b, key[32:])
 	payload := make([]byte, len(encryptedPayload))
 	stream.XORKeyStream(payload, encryptedPayload)
-	c.Check(payload, DeepEquals, creationData.EncryptedPayload)
+	c.Check(payload, DeepEquals, creationParams.EncryptedPayload)
 }
 
-func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r io.Reader, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+func (s *keyDataTestBase) checkKeyDataJSONFromReaderAuthModePassphrase(c *C, r io.Reader, creationParams *KeyCreationParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
 	var j map[string]interface{}
 
 	d := json.NewDecoder(r)
 	c.Check(d.Decode(&j), IsNil)
 
-	s.checkKeyDataJSONDecodedAuthModePassphrase(c, j, creationData, nmodels, passphrase, kdfOpts)
+	s.checkKeyDataJSONDecodedAuthModePassphrase(c, j, creationParams, nmodels, passphrase, kdfOpts)
 }
 
 type keyDataSuite struct {
@@ -451,18 +451,18 @@ type keyDataSuite struct {
 
 var _ = Suite(&keyDataSuite{})
 
-func (s *keyDataSuite) checkKeyDataJSONAuthModeNone(c *C, keyData *KeyData, creationData *KeyCreationData, nmodels int) {
+func (s *keyDataSuite) checkKeyDataJSONAuthModeNone(c *C, keyData *KeyData, creationParams *KeyCreationParams, nmodels int) {
 	w := makeMockKeyDataWriter()
 	c.Check(keyData.WriteAtomic(w), IsNil)
 
-	s.checkKeyDataJSONFromReaderAuthModeNone(c, w.Reader(), creationData, nmodels)
+	s.checkKeyDataJSONFromReaderAuthModeNone(c, w.Reader(), creationParams, nmodels)
 }
 
-func (s *keyDataSuite) checkKeyDataJSONAuthModePassphrase(c *C, keyData *KeyData, creationData *KeyCreationData, nmodels int, passphrase string, kdfOpts *KDFOptions) {
+func (s *keyDataSuite) checkKeyDataJSONAuthModePassphrase(c *C, keyData *KeyData, creationParams *KeyCreationParams, nmodels int, passphrase string, kdfOpts *KDFOptions) {
 	w := makeMockKeyDataWriter()
 	c.Check(keyData.WriteAtomic(w), IsNil)
 
-	s.checkKeyDataJSONFromReaderAuthModePassphrase(c, w.Reader(), creationData, nmodels, passphrase, kdfOpts)
+	s.checkKeyDataJSONFromReaderAuthModePassphrase(c, w.Reader(), creationParams, nmodels, passphrase, kdfOpts)
 }
 
 type testKeyPayloadData struct {
@@ -1058,16 +1058,16 @@ func (s *keyDataSuite) TestSetAuthorizedSnapModelsWithWrongKey(c *C) {
 }
 
 type testWriteAtomicData struct {
-	keyData      *KeyData
-	creationData *KeyCreationData
-	nmodels      int
+	keyData *KeyData
+	params  *KeyCreationParams
+	nmodels int
 }
 
 func (s *keyDataSuite) testWriteAtomic(c *C, data *testWriteAtomicData) {
 	w := makeMockKeyDataWriter()
 	c.Check(data.keyData.WriteAtomic(w), IsNil)
 
-	s.checkKeyDataJSONFromReaderAuthModeNone(c, w.Reader(), data.creationData, data.nmodels)
+	s.checkKeyDataJSONFromReaderAuthModeNone(c, w.Reader(), data.params, data.nmodels)
 }
 
 func (s *keyDataSuite) TestWriteAtomic1(c *C) {
@@ -1078,8 +1078,8 @@ func (s *keyDataSuite) TestWriteAtomic1(c *C) {
 	c.Assert(err, IsNil)
 
 	s.testWriteAtomic(c, &testWriteAtomicData{
-		keyData:      keyData,
-		creationData: protected})
+		keyData: keyData,
+		params:  protected})
 }
 
 func (s *keyDataSuite) TestWriteAtomic2(c *C) {
@@ -1090,8 +1090,8 @@ func (s *keyDataSuite) TestWriteAtomic2(c *C) {
 	c.Assert(err, IsNil)
 
 	s.testWriteAtomic(c, &testWriteAtomicData{
-		keyData:      keyData,
-		creationData: protected})
+		keyData: keyData,
+		params:  protected})
 }
 
 func (s *keyDataSuite) TestWriteAtomic3(c *C) {
@@ -1113,9 +1113,9 @@ func (s *keyDataSuite) TestWriteAtomic3(c *C) {
 	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
 
 	s.testWriteAtomic(c, &testWriteAtomicData{
-		keyData:      keyData,
-		creationData: protected,
-		nmodels:      len(models)})
+		keyData: keyData,
+		params:  protected,
+		nmodels: len(models)})
 }
 
 func (s *keyDataSuite) TestWriteAtomic4(c *C) {
@@ -1144,9 +1144,9 @@ func (s *keyDataSuite) TestWriteAtomic4(c *C) {
 	c.Check(keyData.SetAuthorizedSnapModels(auxKey, models...), IsNil)
 
 	s.testWriteAtomic(c, &testWriteAtomicData{
-		keyData:      keyData,
-		creationData: protected,
-		nmodels:      len(models)})
+		keyData: keyData,
+		params:  protected,
+		nmodels: len(models)})
 }
 
 type testReadKeyDataData struct {

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -124,7 +124,7 @@ func NewKeyDataFromSealedKeyObjectFile(path string) (*secboot.KeyData, error) {
 		return nil, err
 	}
 
-	params := secboot.KeyCreationParams{
+	params := secboot.KeyParams{
 		Handle:            json.RawMessage(handle),
 		PlatformName:      legacyPlatformName,
 		AuxiliaryKey:      make([]byte, 32), // Not used, but must be the expected size

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -124,14 +124,14 @@ func NewKeyDataFromSealedKeyObjectFile(path string) (*secboot.KeyData, error) {
 		return nil, err
 	}
 
-	creationData := secboot.KeyCreationData{
+	params := secboot.KeyCreationParams{
 		Handle:            json.RawMessage(handle),
 		PlatformName:      legacyPlatformName,
 		AuxiliaryKey:      make([]byte, 32), // Not used, but must be the expected size
 		SnapModelAuthHash: crypto.SHA256,    // Not used, but just set it a valid alg
 	}
 
-	return secboot.NewKeyData(&creationData)
+	return secboot.NewKeyData(&params)
 }
 
 func init() {


### PR DESCRIPTION
"Creation data" is a bit of an overloaded term when using a TPM, because it specifically refers to data that can be used to prove the creation environment of a TPM object. I'm going to add support to the tpm2 package for saving the creation data to facilitate subsequent attestation of the state of the initial install environment, so rename this struct to avoid confusion.

The PR I've proposed to add a new ProtectKeyWithTPM API (https://github.com/snapcore/secboot/pull/202) also uses "params" in this context, so it's consistent with that.