### PR TITLE
efi,tpm2: Make use of updated PCRProtectionProfile APIs

### DIFF
--- a/efi/bootmanager_policy_test.go
+++ b/efi/bootmanager_policy_test.go
@@ -58,7 +58,7 @@ func (s *bootManagerPolicySuite) testAddBootManagerProfile(c *C, data *testAddBo
 	branch := data.branch
 	switch {
 	case profile == nil:
-		c.Assert(data.branch, IsNil)
+		c.Assert(branch, IsNil)
 		profile = secboot_tpm2.NewPCRProtectionProfile()
 		branch = profile.RootBranch()
 	case branch == nil:

--- a/efi/bootmanager_policy_test.go
+++ b/efi/bootmanager_policy_test.go
@@ -40,7 +40,8 @@ var _ = Suite(&bootManagerPolicySuite{})
 
 type testAddBootManagerProfileData struct {
 	eventLogPath string
-	initial      *secboot_tpm2.PCRProtectionProfile
+	profile      *secboot_tpm2.PCRProtectionProfile
+	branch       *secboot_tpm2.PCRProtectionProfileBranch
 	params       *BootManagerProfileParams
 	values       []tpm2.PCRValues
 }
@@ -53,10 +54,17 @@ func (s *bootManagerPolicySuite) testAddBootManagerProfile(c *C, data *testAddBo
 	restoreEventLogPath := MockEventLogPath(data.eventLogPath)
 	defer restoreEventLogPath()
 
-	profile := data.initial
-	if profile == nil {
+	profile := data.profile
+	branch := data.branch
+	switch {
+	case profile == nil:
+		c.Assert(data.branch, IsNil)
 		profile = secboot_tpm2.NewPCRProtectionProfile()
+		branch = profile.RootBranch()
+	case branch == nil:
+		branch = profile.RootBranch()
 	}
+
 	expectedPcrs, _, _ := profile.ComputePCRDigests(nil, tpm2.HashAlgorithmSHA256)
 	expectedPcrs = expectedPcrs.Merge(tpm2.PCRSelectionList{{Hash: data.params.PCRAlgorithm, Select: []int{4}}})
 	var expectedDigests tpm2.DigestList
@@ -65,7 +73,7 @@ func (s *bootManagerPolicySuite) testAddBootManagerProfile(c *C, data *testAddBo
 		expectedDigests = append(expectedDigests, d)
 	}
 
-	c.Assert(AddBootManagerProfile(profile, data.params), IsNil)
+	c.Assert(AddBootManagerProfile(branch, data.params), IsNil)
 	pcrs, digests, err := profile.ComputePCRDigests(nil, tpm2.HashAlgorithmSHA256)
 	c.Assert(err, IsNil)
 	c.Check(pcrs.Equal(expectedPcrs), Equals, true)
@@ -181,9 +189,12 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileUC20(c *C) {
 
 func (s *bootManagerPolicySuite) TestAddBootManagerProfileWithInitialProfile(c *C) {
 	// Test with a PCRProtectionProfile that already has some values in it.
+	profile := secboot_tpm2.NewPCRProtectionProfile()
+
 	s.testAddBootManagerProfile(c, &testAddBootManagerProfileData{
 		eventLogPath: "testdata/eventlog_sb.bin",
-		initial: secboot_tpm2.NewPCRProtectionProfile().
+		profile:      profile,
+		branch: profile.RootBranch().
 			AddPCRValue(tpm2.HashAlgorithmSHA256, 4, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo")).
 			AddPCRValue(tpm2.HashAlgorithmSHA256, 7, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar")),
 		params: &BootManagerProfileParams{

--- a/efi/sdstub_policy_test.go
+++ b/efi/sdstub_policy_test.go
@@ -47,7 +47,7 @@ func (s *sdstubPolicySuite) testAddSystemdStubProfile(c *C, data *testAddSystemd
 	branch := data.branch
 	switch {
 	case profile == nil:
-		c.Assert(data.branch, IsNil)
+		c.Assert(branch, IsNil)
 		profile = secboot_tpm2.NewPCRProtectionProfile()
 		branch = profile.RootBranch()
 	case branch == nil:

--- a/efi/sdstub_policy_test.go
+++ b/efi/sdstub_policy_test.go
@@ -36,16 +36,24 @@ type sdstubPolicySuite struct{}
 var _ = Suite(&sdstubPolicySuite{})
 
 type testAddSystemdStubProfileData struct {
-	initial *secboot_tpm2.PCRProtectionProfile
+	profile *secboot_tpm2.PCRProtectionProfile
+	branch  *secboot_tpm2.PCRProtectionProfileBranch
 	params  SystemdStubProfileParams
 	values  []tpm2.PCRValues
 }
 
 func (s *sdstubPolicySuite) testAddSystemdStubProfile(c *C, data *testAddSystemdStubProfileData) {
-	profile := data.initial
-	if profile == nil {
+	profile := data.profile
+	branch := data.branch
+	switch {
+	case profile == nil:
+		c.Assert(data.branch, IsNil)
 		profile = secboot_tpm2.NewPCRProtectionProfile()
+		branch = profile.RootBranch()
+	case branch == nil:
+		branch = profile.RootBranch()
 	}
+
 	expectedPcrs, _, _ := profile.ComputePCRDigests(nil, tpm2.HashAlgorithmSHA256)
 	expectedPcrs = expectedPcrs.Merge(tpm2.PCRSelectionList{{Hash: data.params.PCRAlgorithm, Select: []int{data.params.PCRIndex}}})
 	var expectedDigests tpm2.DigestList
@@ -54,7 +62,7 @@ func (s *sdstubPolicySuite) testAddSystemdStubProfile(c *C, data *testAddSystemd
 		expectedDigests = append(expectedDigests, d)
 	}
 
-	c.Check(AddSystemdStubProfile(profile, &data.params), IsNil)
+	c.Check(AddSystemdStubProfile(branch, &data.params), IsNil)
 
 	pcrs, digests, err := profile.ComputePCRDigests(nil, tpm2.HashAlgorithmSHA256)
 	c.Check(err, IsNil)
@@ -134,12 +142,13 @@ func (s *sdstubPolicySuite) TestAddSystemdStubProfileClassic(c *C) {
 }
 
 func (s *sdstubPolicySuite) TestAddSystemdStubProfileWithInitialProfile(c *C) {
+	profile := secboot_tpm2.NewPCRProtectionProfile()
+
 	s.testAddSystemdStubProfile(c, &testAddSystemdStubProfileData{
-		initial: func() *secboot_tpm2.PCRProtectionProfile {
-			return secboot_tpm2.NewPCRProtectionProfile().
-				AddPCRValue(tpm2.HashAlgorithmSHA256, 7, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo")).
-				AddPCRValue(tpm2.HashAlgorithmSHA256, 8, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar"))
-		}(),
+		profile: profile,
+		branch: profile.RootBranch().
+			AddPCRValue(tpm2.HashAlgorithmSHA256, 7, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo")).
+			AddPCRValue(tpm2.HashAlgorithmSHA256, 8, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar")),
 		params: SystemdStubProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
 			PCRIndex:     8,

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -28,7 +28,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mssim"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
@@ -111,7 +111,7 @@ func computePCRProtectionProfile(env secboot_efi.HostEnvironment) (*secboot_tpm2
 		},
 	}
 
-	if err := secboot_efi.AddSystemdStubProfile(profile, &sdefisParams); err != nil {
+	if err := secboot_efi.AddSystemdStubProfile(profile.RootBranch(), &sdefisParams); err != nil {
 		return nil, xerrors.Errorf("cannot add systemd EFI stub profile: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func computePCRProtectionProfile(env secboot_efi.HostEnvironment) (*secboot_tpm2
 		Models:       []secboot.SnapModel{model.(secboot.SnapModel)},
 	}
 
-	if err := secboot_tpm2.AddSnapModelProfile(profile, &smParams); err != nil {
+	if err := secboot_tpm2.AddSnapModelProfile(profile.RootBranch(), &smParams); err != nil {
 		return nil, xerrors.Errorf("cannot add snap model profile: %w", err)
 	}
 


### PR DESCRIPTION
This updates most code (with the exception of efi/secureboot_policy.go)
to make use of the newer PCRProtectionProfile APIs.