### PR TITLE
efi: updates to ImageLoadEvent

### DIFF
--- a/efi/bootmanager_policy.go
+++ b/efi/bootmanager_policy.go
@@ -44,26 +44,26 @@ func computePeImageDigest(alg tpm2.HashAlgorithmId, image Image) (tpm2.Digest, e
 	return efi.ComputePeImageDigest(alg.GetHash(), r, r.Size())
 }
 
-// bmLoadEvent binds together a ImageLoadEvent and the branch that the event needs to be applied to.
+// bmLoadEvent binds together a ImageLoadActivity and the branch that the event needs to be applied to.
 type bmLoadEvent struct {
-	event  ImageLoadEvent
-	branch *secboot_tpm2.PCRProtectionProfileBranch
+	activity ImageLoadActivity
+	branch   *secboot_tpm2.PCRProtectionProfileBranch
 }
 
-func newBmLoadEvents(branch *secboot_tpm2.PCRProtectionProfileBranch, events ...ImageLoadEvent) (out []*bmLoadEvent) {
-	if len(events) == 0 {
+func newBmLoadEvents(branch *secboot_tpm2.PCRProtectionProfileBranch, activities ...ImageLoadActivity) (out []*bmLoadEvent) {
+	if len(activities) == 0 {
 		return nil
 	}
 
 	bp := branch.AddBranchPoint()
-	for _, event := range events {
-		out = append(out, &bmLoadEvent{event: event, branch: bp.AddBranch()})
+	for _, activity := range activities {
+		out = append(out, &bmLoadEvent{activity: activity, branch: bp.AddBranch()})
 	}
 	return out
 }
 
 func (e *bmLoadEvent) fork() []*bmLoadEvent {
-	return newBmLoadEvents(e.branch, e.event.next()...)
+	return newBmLoadEvents(e.branch, e.activity.next()...)
 }
 
 // BootManagerProfileParams provide the arguments to AddBootManagerProfile.
@@ -74,7 +74,7 @@ type BootManagerProfileParams struct {
 	PCRAlgorithm tpm2.HashAlgorithmId
 
 	// LoadSequences is a list of EFI image load sequences for which to compute PCR digests for.
-	LoadSequences []ImageLoadEvent
+	LoadSequences []ImageLoadActivity
 
 	// Environment is an optional parameter that allows the caller to provide
 	// a custom EFI environment. If not set, the host's normal environment will
@@ -94,9 +94,9 @@ type BootManagerProfileParams struct {
 // possible to update these in a way that is atomic (if any of them are changed, a new PCR profile can only be generated after
 // performing a reboot).
 //
-// The sequences of binaries for which to generate a PCR profile for is supplied via the LoadSequences field of params. Note that
-// this function does not use the Source field of EFIImageLoadEvent. Each bootloader stage in each load sequence must perform a
-// measurement of any subsequent stage to PCR 4 in the same format as the events measured by the UEFI boot manager.
+// The sequences of binaries for which to generate a PCR profile for is supplied via the LoadSequences field of params. Each
+// bootloader stage in each load sequence must perform a measurement of any subsequent stage to PCR 4 in the same format as the
+// events measured by the UEFI boot manager.
 //
 // Section 2.3.4.5 of the "TCG PC Client Platform Firmware Profile Specification" specifies that EFI applications that load additional
 // pre-OS environment code must measure this to PCR 4 using the EV_COMPACT_HASH event type. This function does not support EFI
@@ -147,7 +147,7 @@ func AddBootManagerProfile(branch *secboot_tpm2.PCRProtectionProfileBranch, para
 		e := loadEvents[0]
 		loadEvents = loadEvents[1:]
 
-		digest, err := computePeImageDigest(params.PCRAlgorithm, e.event.source())
+		digest, err := computePeImageDigest(params.PCRAlgorithm, e.activity.source())
 		if err != nil {
 			return err
 		}

--- a/efi/bootmanager_policy_test.go
+++ b/efi/bootmanager_policy_test.go
@@ -90,11 +90,11 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileClassic(c *C) {
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
 					),
 				),
 			},
@@ -122,14 +122,14 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileUC20(c *C) {
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
-							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+							NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+							NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
 						),
 					),
 				),
@@ -172,10 +172,10 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileWithInitialProfile(c *
 			AddPCRValue(tpm2.HashAlgorithmSHA256, 7, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar")),
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
 					),
 				),
 			},
@@ -198,15 +198,15 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileClassic2(c *C) {
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
 					),
 				),
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
 					),
 				),
 			},
@@ -234,11 +234,11 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileWithMissingEFIActionEv
 		eventLogPath: "testdata/eventlog_sb_no_efi_action.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
 					),
 				),
 			},
@@ -268,11 +268,11 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileWithCustomEFIEnv(c *C)
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
 					),
 				),
 			},

--- a/efi/bootmanager_policy_test.go
+++ b/efi/bootmanager_policy_test.go
@@ -90,23 +90,13 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileClassic(c *C) {
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -132,34 +122,17 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileUC20(c *C) {
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-								},
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-									Next: []*ImageLoadEvent{
-										{
-											Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-										},
-										{
-											Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+						),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -199,20 +172,12 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileWithInitialProfile(c *
 			AddPCRValue(tpm2.HashAlgorithmSHA256, 7, tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar")),
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -233,33 +198,17 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileClassic2(c *C) {
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
-				{
-					Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+					),
+				),
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -285,23 +234,13 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileWithMissingEFIActionEv
 		eventLogPath: "testdata/eventlog_sb_no_efi_action.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -329,23 +268,13 @@ func (s *bootManagerPolicySuite) TestAddBootManagerProfileWithCustomEFIEnv(c *C)
 		eventLogPath: "testdata/eventlog_sb.bin",
 		params: &BootManagerProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-								{
-									Image: FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1"))).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1"))),
+					),
+				),
 			},
 			Environment: &mockEFIEnvironment{"", "testdata/eventlog_sb_no_efi_action.bin"},
 		},

--- a/efi/export_test.go
+++ b/efi/export_test.go
@@ -51,12 +51,12 @@ func (s *ShimImageHandle) ReadVendorCert() ([]byte, error) {
 type SigDbUpdateQuirkMode = sigDbUpdateQuirkMode
 
 // Helper functions
-func ImageLoadEventNextImages(event ImageLoadEvent) []ImageLoadEvent {
-	return event.next()
+func ImageLoadActivityNext(activity ImageLoadActivity) []ImageLoadActivity {
+	return activity.next()
 }
 
-func ImageLoadEventParams(event ImageLoadEvent) imageLoadParamsSet {
-	return event.params()
+func ImageLoadActivityParams(activity ImageLoadActivity) imageLoadParamsSet {
+	return activity.params()
 }
 
 func MockEFIVarsPath(path string) (restore func()) {

--- a/efi/export_test.go
+++ b/efi/export_test.go
@@ -20,7 +20,7 @@
 package efi
 
 import (
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 	"github.com/snapcore/secboot/internal/testutil"
 )
 
@@ -39,6 +39,9 @@ var (
 
 // Alias some unexported types for testing. These are required in order to pass these between functions in tests, or to access
 // unexported members of some unexported types.
+type ImageLoadParamsSet = imageLoadParamsSet
+type LoadParams = loadParams
+
 type ShimImageHandle = shimImageHandle
 
 func (s *ShimImageHandle) ReadVendorCert() ([]byte, error) {
@@ -48,6 +51,14 @@ func (s *ShimImageHandle) ReadVendorCert() ([]byte, error) {
 type SigDbUpdateQuirkMode = sigDbUpdateQuirkMode
 
 // Helper functions
+func ImageLoadEventNextImages(event ImageLoadEvent) []ImageLoadEvent {
+	return event.next()
+}
+
+func ImageLoadEventParams(event ImageLoadEvent) imageLoadParamsSet {
+	return event.params()
+}
+
 func MockEFIVarsPath(path string) (restore func()) {
 	origPath := efiVarsPath
 	efiVarsPath = path

--- a/efi/image_test.go
+++ b/efi/image_test.go
@@ -1,0 +1,261 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package efi_test
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/snapcore/secboot"
+	"github.com/snapcore/snapd/snap"
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot/efi"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+type mockSnapImageReader struct{}
+
+func (mockSnapImageReader) ReadAt(p []byte, off int64) (int, error) { return 0, nil }
+func (mockSnapImageReader) Close() error                            { return nil }
+func (mockSnapImageReader) Size() int64                             { return 0 }
+
+type mockSnapContainer struct {
+	r   mockSnapImageReader
+	err error
+}
+
+func (*mockSnapContainer) Size() (int64, error) { return 0, nil }
+
+func (c *mockSnapContainer) RandomAccessFile(relative string) (interface {
+	io.ReaderAt
+	io.Closer
+	Size() int64
+}, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &c.r, nil
+}
+
+func (*mockSnapContainer) ReadFile(relative string) ([]byte, error)             { return nil, nil }
+func (*mockSnapContainer) Walk(relative string, walkFn filepath.WalkFunc) error { return nil }
+func (*mockSnapContainer) ListDir(path string) ([]string, error)                { return nil, nil }
+func (*mockSnapContainer) Install(targetPath, mountDir string, opts *snap.InstallOptions) (bool, error) {
+	return false, nil
+}
+func (*mockSnapContainer) Unpack(src, dst string) error { return nil }
+
+type imageSuite struct{}
+
+var _ = Suite(&imageSuite{})
+
+func (s *imageSuite) TestNewSnapFileImage1(c *C) {
+	container := new(mockSnapContainer)
+	image := NewSnapFileImage(container, "foo")
+	c.Check(image, DeepEquals, &SnapFileImage{Container: container, FileName: "foo"})
+}
+
+func (s *imageSuite) TestNewSnapFileImage2(c *C) {
+	container := new(mockSnapContainer)
+	image := NewSnapFileImage(container, "bar")
+	c.Check(image, DeepEquals, &SnapFileImage{Container: container, FileName: "bar"})
+}
+
+func (s *imageSuite) TestSnapFileImageOpen(c *C) {
+	container := new(mockSnapContainer)
+	image := NewSnapFileImage(container, "foo")
+	r, err := image.Open()
+	c.Check(err, IsNil)
+	c.Check(r, Equals, &container.r)
+}
+
+func (s *imageSuite) TestSnapFileImageOpenError(c *C) {
+	container := &mockSnapContainer{err: errors.New("some error")}
+	image := NewSnapFileImage(container, "foo")
+	_, err := image.Open()
+	c.Check(err, Equals, container.err)
+}
+
+func (s *imageSuite) TestNewFileImage1(c *C) {
+	image := NewFileImage("/foo")
+	c.Check(image, Equals, FileImage("/foo"))
+}
+
+func (s *imageSuite) TestNewFileImage2(c *C) {
+	image := NewFileImage("/bar")
+	c.Check(image, Equals, FileImage("/bar"))
+}
+
+func (s *imageSuite) TestFileImageOpen(c *C) {
+	contents := []byte("some file contents")
+
+	dir := c.MkDir()
+	c.Check(ioutil.WriteFile(filepath.Join(dir, "foo"), contents, 0644), IsNil)
+
+	image := NewFileImage(filepath.Join(dir, "foo"))
+	r, err := image.Open()
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	c.Check(r.Size(), Equals, int64(18))
+	data, err := ioutil.ReadAll(io.NewSectionReader(r, 0, 1<<63-1))
+	c.Check(data, DeepEquals, contents)
+}
+
+func (s *imageSuite) TestKernelCommandlineParams(c *C) {
+	event := NewImageLoadEvent(nil, KernelCommandlineParams(
+		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run",
+		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover"))
+	params := ImageLoadEventParams(event).Resolve(new(LoadParams))
+	c.Check(params, DeepEquals, []LoadParams{
+		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"},
+		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover"}})
+}
+
+func (s *imageSuite) TestKernelCommandlineParamsInherited(c *C) {
+	model := testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+		"authority-id": "fake-brand",
+		"series":       "16",
+		"brand-id":     "fake-brand",
+		"model":        "fake-model",
+		"grade":        "secured",
+	}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")
+
+	event := NewImageLoadEvent(nil, KernelCommandlineParams(
+		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover",
+		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"))
+	params := ImageLoadEventParams(event).Resolve(&LoadParams{SnapModel: model})
+	c.Check(params, DeepEquals, []LoadParams{
+		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover", SnapModel: model},
+		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run", SnapModel: model}})
+}
+
+func (s *imageSuite) TestKernelCommandlineParamsOverride(c *C) {
+	event := NewImageLoadEvent(nil, KernelCommandlineParams(
+		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"))
+	params := ImageLoadEventParams(event).Resolve(&LoadParams{KernelCommandline: "foo"})
+	c.Check(params, DeepEquals, []LoadParams{
+		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"}})
+}
+
+func (s *imageSuite) TestSnapModelParams(c *C) {
+	models := []secboot.SnapModel{
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	event := NewImageLoadEvent(nil, SnapModelParams(models...))
+	params := ImageLoadEventParams(event).Resolve(new(LoadParams))
+	c.Check(params, DeepEquals, []LoadParams{{SnapModel: models[0]}, {SnapModel: models[1]}})
+}
+
+func (s *imageSuite) TestSnapModelParamsInherited(c *C) {
+	models := []secboot.SnapModel{
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	event := NewImageLoadEvent(nil, SnapModelParams(models...))
+	params := ImageLoadEventParams(event).Resolve(&LoadParams{KernelCommandline: "foo"})
+	c.Check(params, DeepEquals, []LoadParams{
+		{KernelCommandline: "foo", SnapModel: models[0]},
+		{KernelCommandline: "foo", SnapModel: models[1]}})
+}
+
+func (s *imageSuite) TestSnapModelParamsOverride(c *C) {
+	model := testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+		"authority-id": "fake-brand",
+		"series":       "16",
+		"brand-id":     "fake-brand",
+		"model":        "fake-model",
+		"grade":        "secured",
+	}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")
+	event := NewImageLoadEvent(nil, SnapModelParams(model))
+	params := ImageLoadEventParams(event).Resolve(&LoadParams{
+		SnapModel: testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")})
+	c.Check(params, DeepEquals, []LoadParams{{SnapModel: model}})
+}
+
+func (s *imageSuite) TestImageLoadParamSetResolveMultiple(c *C) {
+	models := []secboot.SnapModel{
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "fake-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"),
+		testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+			"authority-id": "fake-brand",
+			"series":       "16",
+			"brand-id":     "fake-brand",
+			"model":        "other-model",
+			"grade":        "secured",
+		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
+	cmdlines := []string{
+		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run",
+		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover"}
+	event := NewImageLoadEvent(nil,
+		KernelCommandlineParams(cmdlines...),
+		SnapModelParams(models...))
+	params := ImageLoadEventParams(event).Resolve(new(LoadParams))
+	c.Check(params, DeepEquals, []LoadParams{
+		{KernelCommandline: cmdlines[0], SnapModel: models[0]},
+		{KernelCommandline: cmdlines[1], SnapModel: models[0]},
+		{KernelCommandline: cmdlines[0], SnapModel: models[1]},
+		{KernelCommandline: cmdlines[1], SnapModel: models[1]},
+	})
+}
+
+func (s *imageSuite) TestImageLoadEventNext(c *C) {
+	events := []ImageLoadEvent{NewImageLoadEvent(nil), NewImageLoadEvent(nil)}
+	event := NewImageLoadEvent(nil)
+	c.Check(event.Next(events...), Equals, event)
+	c.Check(ImageLoadEventNextImages(event), DeepEquals, events)
+}

--- a/efi/image_test.go
+++ b/efi/image_test.go
@@ -123,10 +123,10 @@ func (s *imageSuite) TestFileImageOpen(c *C) {
 }
 
 func (s *imageSuite) TestKernelCommandlineParams(c *C) {
-	event := NewImageLoadEvent(nil, KernelCommandlineParams(
+	activity := NewImageLoadActivity(nil, KernelCommandlineParams(
 		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run",
 		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover"))
-	params := ImageLoadEventParams(event).Resolve(new(LoadParams))
+	params := ImageLoadActivityParams(activity).Resolve(new(LoadParams))
 	c.Check(params, DeepEquals, []LoadParams{
 		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"},
 		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover"}})
@@ -141,19 +141,19 @@ func (s *imageSuite) TestKernelCommandlineParamsInherited(c *C) {
 		"grade":        "secured",
 	}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")
 
-	event := NewImageLoadEvent(nil, KernelCommandlineParams(
+	activity := NewImageLoadActivity(nil, KernelCommandlineParams(
 		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover",
 		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"))
-	params := ImageLoadEventParams(event).Resolve(&LoadParams{SnapModel: model})
+	params := ImageLoadActivityParams(activity).Resolve(&LoadParams{SnapModel: model})
 	c.Check(params, DeepEquals, []LoadParams{
 		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover", SnapModel: model},
 		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run", SnapModel: model}})
 }
 
 func (s *imageSuite) TestKernelCommandlineParamsOverride(c *C) {
-	event := NewImageLoadEvent(nil, KernelCommandlineParams(
+	activity := NewImageLoadActivity(nil, KernelCommandlineParams(
 		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"))
-	params := ImageLoadEventParams(event).Resolve(&LoadParams{KernelCommandline: "foo"})
+	params := ImageLoadActivityParams(activity).Resolve(&LoadParams{KernelCommandline: "foo"})
 	c.Check(params, DeepEquals, []LoadParams{
 		{KernelCommandline: "console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run"}})
 }
@@ -174,8 +174,8 @@ func (s *imageSuite) TestSnapModelParams(c *C) {
 			"model":        "other-model",
 			"grade":        "secured",
 		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
-	event := NewImageLoadEvent(nil, SnapModelParams(models...))
-	params := ImageLoadEventParams(event).Resolve(new(LoadParams))
+	activity := NewImageLoadActivity(nil, SnapModelParams(models...))
+	params := ImageLoadActivityParams(activity).Resolve(new(LoadParams))
 	c.Check(params, DeepEquals, []LoadParams{{SnapModel: models[0]}, {SnapModel: models[1]}})
 }
 
@@ -195,8 +195,8 @@ func (s *imageSuite) TestSnapModelParamsInherited(c *C) {
 			"model":        "fake-model",
 			"grade":        "secured",
 		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
-	event := NewImageLoadEvent(nil, SnapModelParams(models...))
-	params := ImageLoadEventParams(event).Resolve(&LoadParams{KernelCommandline: "foo"})
+	activity := NewImageLoadActivity(nil, SnapModelParams(models...))
+	params := ImageLoadActivityParams(activity).Resolve(&LoadParams{KernelCommandline: "foo"})
 	c.Check(params, DeepEquals, []LoadParams{
 		{KernelCommandline: "foo", SnapModel: models[0]},
 		{KernelCommandline: "foo", SnapModel: models[1]}})
@@ -210,8 +210,8 @@ func (s *imageSuite) TestSnapModelParamsOverride(c *C) {
 		"model":        "fake-model",
 		"grade":        "secured",
 	}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")
-	event := NewImageLoadEvent(nil, SnapModelParams(model))
-	params := ImageLoadEventParams(event).Resolve(&LoadParams{
+	activity := NewImageLoadActivity(nil, SnapModelParams(model))
+	params := ImageLoadActivityParams(activity).Resolve(&LoadParams{
 		SnapModel: testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
 			"authority-id": "fake-brand",
 			"series":       "16",
@@ -241,10 +241,10 @@ func (s *imageSuite) TestImageLoadParamSetResolveMultiple(c *C) {
 	cmdlines := []string{
 		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run",
 		"console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover"}
-	event := NewImageLoadEvent(nil,
+	activity := NewImageLoadActivity(nil,
 		KernelCommandlineParams(cmdlines...),
 		SnapModelParams(models...))
-	params := ImageLoadEventParams(event).Resolve(new(LoadParams))
+	params := ImageLoadActivityParams(activity).Resolve(new(LoadParams))
 	c.Check(params, DeepEquals, []LoadParams{
 		{KernelCommandline: cmdlines[0], SnapModel: models[0]},
 		{KernelCommandline: cmdlines[1], SnapModel: models[0]},
@@ -253,9 +253,9 @@ func (s *imageSuite) TestImageLoadParamSetResolveMultiple(c *C) {
 	})
 }
 
-func (s *imageSuite) TestImageLoadEventNext(c *C) {
-	events := []ImageLoadEvent{NewImageLoadEvent(nil), NewImageLoadEvent(nil)}
-	event := NewImageLoadEvent(nil)
-	c.Check(event.Next(events...), Equals, event)
-	c.Check(ImageLoadEventNextImages(event), DeepEquals, events)
+func (s *imageSuite) TestImageLoadActivityLoads(c *C) {
+	activities := []ImageLoadActivity{NewImageLoadActivity(nil), NewImageLoadActivity(nil)}
+	activity := NewImageLoadActivity(nil)
+	c.Check(activity.Loads(activities...), Equals, activity)
+	c.Check(ImageLoadActivityNext(activity), DeepEquals, activities)
 }

--- a/efi/secureboot_policy_test.go
+++ b/efi/secureboot_policy_test.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/util"
 
@@ -301,27 +301,13 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileClassic(c *C) {
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -342,23 +328,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileNoSBAT(c *C) {
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -383,41 +358,17 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileUC20(c *C) {
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-								},
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-									Next: []*ImageLoadEvent{
-										{
-											Source: Shim,
-											Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-										},
-										{
-											Source: Shim,
-											Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
+						),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -437,23 +388,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileInvalidGrubSignatu
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+					),
+				),
 			},
 		},
 		errMatch: "cannot compute secure boot policy profile: no bootable paths with current EFI signature database",
@@ -467,23 +407,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileNoKernelSignature(
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi")), Shim),
+					),
+				),
 			},
 		},
 		errMatch: "cannot compute secure boot policy profile: cannot process OS load event for testdata/amd64/mockkernel1.efi: cannot compute load verification event: no Authenticode signatures",
@@ -500,23 +429,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileShimVerificationDi
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		errMatch: "cannot compute secure boot policy profile: the current boot was performed with validation disabled in Shim",
@@ -532,23 +450,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileSecureBootDisabled
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		errMatch: "cannot compute secure boot policy profile: the current boot was performed with secure boot disabled in firmware",
@@ -562,23 +469,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAllAuthenticatedWi
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -603,23 +499,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticatedWithD
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -638,23 +523,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticateWithDb
 		efivars:      "testdata/efivars_mock1_plus_shim_vendor_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -676,23 +550,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticateWithDb
 		efivars:      "testdata/efivars_mock1_plus_shim_vendor_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -718,23 +581,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticateWithDb
 		efivars:      "testdata/efivars_mock1_plus_shim_vendor_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -755,23 +607,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithMultipleDbCert
 		efivars:      "testdata/efivars_ms_plus_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -792,23 +633,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithDbxUpdate(c *C
 		efivars:      "testdata/efivars_ms_plus_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 			SignatureDbUpdateKeystores: []string{"testdata/update_uefi.org_2016-08-08"},
 		},
@@ -835,23 +665,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithTwoDbxUpdates(
 		efivars:      "testdata/efivars_ms_plus_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 			SignatureDbUpdateKeystores: []string{
 				"testdata/update_uefi.org_2020-10-12",
@@ -890,23 +709,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileTestDbxUpdateDedup
 		efivars:      "testdata/efivars_ms_plus_mock1_and_2016_dbx_update",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 			SignatureDbUpdateKeystores: []string{"testdata/update_modified_uefi.org_2016-08-08"},
 		},
@@ -939,23 +747,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDellEmbeddedBoxPC3
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -979,23 +776,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileToInitialProfile(c
 		}(),
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1017,23 +803,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithCustomEnv(c *C
 		efivars:      "testdata/efivars_ms",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 			Environment: &mockEFIEnvironment{"testdata/efivars_mock1", "testdata/eventlog_sb.bin"},
 		},
@@ -1055,39 +830,17 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileUpgrageToSBATShim(
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1112,39 +865,17 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDbCARotation(c *C)
 		efivars:      "testdata/efivars_mock1_plus_extra_db_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1171,39 +902,17 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDbCARotation2(c *C
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 			SignatureDbUpdateKeystores: []string{"testdata/update_mock1"},
 		},
@@ -1237,41 +946,17 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDbCARotation3(c *C
 		efivars:      "testdata/efivars_mock1_plus_extra_db_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")),
-								},
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")),
-								},
-							},
-						},
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.2.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")),
-								},
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")), Shim),
+					),
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.2.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1305,23 +990,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShimBaseline1(c
 		efivars:      "testdata/efivars_mock1_plus_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1340,23 +1014,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShimBaseline2(c
 		efivars:      "testdata/efivars_mock1_plus_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1375,23 +1038,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShimBaseline3(c
 		efivars:      "testdata/efivars_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1414,23 +1066,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShim1(c *C) {
 		efivars:      "testdata/efivars_mock1_plus_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{
@@ -1452,23 +1093,12 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShim2(c *C) {
 		efivars:      "testdata/efivars_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []*ImageLoadEvent{
-				{
-					Source: Firmware,
-					Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")),
-					Next: []*ImageLoadEvent{
-						{
-							Source: Shim,
-							Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")),
-							Next: []*ImageLoadEvent{
-								{
-									Source: Shim,
-									Image:  FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")),
-								},
-							},
-						},
-					},
-				},
+			LoadSequences: []ImageLoadEvent{
+				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")), Firmware).Next(
+					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
+						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+					),
+				),
 			},
 		},
 		values: []tpm2.PCRValues{

--- a/efi/secureboot_policy_test.go
+++ b/efi/secureboot_policy_test.go
@@ -301,11 +301,11 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileClassic(c *C) {
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -328,10 +328,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileNoSBAT(c *C) {
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -358,14 +358,14 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileUC20(c *C) {
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
-							NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+							NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+							NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel2.efi.signed.shim.1")), Shim),
 						),
 					),
 				),
@@ -388,10 +388,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileInvalidGrubSignatu
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1"))).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1"))),
 					),
 				),
 			},
@@ -407,10 +407,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileNoKernelSignature(
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi")), Shim),
 					),
 				),
 			},
@@ -429,10 +429,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileShimVerificationDi
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -450,10 +450,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileSecureBootDisabled
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -469,10 +469,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAllAuthenticatedWi
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
 					),
 				),
 			},
@@ -499,10 +499,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticatedWithD
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -523,10 +523,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticateWithDb
 		efivars:      "testdata/efivars_mock1_plus_shim_vendor_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat_no_vendor_cert.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -550,10 +550,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticateWithDb
 		efivars:      "testdata/efivars_mock1_plus_shim_vendor_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -581,10 +581,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileAuthenticateWithDb
 		efivars:      "testdata/efivars_mock1_plus_shim_vendor_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -607,10 +607,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithMultipleDbCert
 		efivars:      "testdata/efivars_ms_plus_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -633,10 +633,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithDbxUpdate(c *C
 		efivars:      "testdata/efivars_ms_plus_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -665,10 +665,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithTwoDbxUpdates(
 		efivars:      "testdata/efivars_ms_plus_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -709,10 +709,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileTestDbxUpdateDedup
 		efivars:      "testdata/efivars_ms_plus_mock1_and_2016_dbx_update",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -747,10 +747,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDellEmbeddedBoxPC3
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -776,10 +776,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileToInitialProfile(c
 		}(),
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -803,10 +803,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileWithCustomEnv(c *C
 		efivars:      "testdata/efivars_ms",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -830,15 +830,15 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileUpgrageToSBATShim(
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_no_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -865,15 +865,15 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDbCARotation(c *C)
 		efivars:      "testdata/efivars_mock1_plus_extra_db_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -902,15 +902,15 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDbCARotation2(c *C
 		efivars:      "testdata/efivars_mock1",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.2.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -946,15 +946,15 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyProfileDbCARotation3(c *C
 		efivars:      "testdata/efivars_mock1_plus_extra_db_ca",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.1.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")), Shim),
 					),
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.2.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")), Shim),
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.1.2.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.1.1")), Shim),
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.1.2.1")), Shim),
 					),
 				),
 			},
@@ -990,10 +990,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShimBaseline1(c
 		efivars:      "testdata/efivars_mock1_plus_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -1014,10 +1014,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShimBaseline2(c
 		efivars:      "testdata/efivars_mock1_plus_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -1038,10 +1038,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShimBaseline3(c
 		efivars:      "testdata/efivars_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -1066,10 +1066,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShim1(c *C) {
 		efivars:      "testdata/efivars_mock1_plus_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},
@@ -1093,10 +1093,10 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShim2(c *C) {
 		efivars:      "testdata/efivars_mock2",
 		params: SecureBootPolicyProfileParams{
 			PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-			LoadSequences: []ImageLoadEvent{
-				NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")), Firmware).Next(
-					NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Next(
-						NewImageLoadEvent(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
+			LoadSequences: []ImageLoadActivity{
+				NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockshim_sbat.efi.signed.2.1.1+1.1.1")), Firmware).Loads(
+					NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockgrub1.efi.signed.shim.1")), Shim).Loads(
+						NewImageLoadActivity(FileImage(filepath.Join("testdata", runtime.GOARCH, "mockkernel1.efi.signed.shim.1")), Shim),
 					),
 				),
 			},

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -77,10 +77,10 @@ func computePCRProtectionProfile(env secboot_efi.HostEnvironment) (*secboot_tpm2
 
 	sbpParams := secboot_efi.SecureBootPolicyProfileParams{
 		PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-		LoadSequences: []secboot_efi.ImageLoadEvent{
-			secboot_efi.NewImageLoadEvent(secboot_efi.FileImage("efi/testdata/mockshim1.efi.signed.1"), secboot_efi.Firmware).Next(
-				secboot_efi.NewImageLoadEvent(secboot_efi.FileImage("efi/testdata/mockgrub1.efi.signed.shim"), secboot_efi.Shim).Next(
-					secboot_efi.NewImageLoadEvent(secboot_efi.FileImage("efi/testdata/mockkernel1.efi.signed.shim"), secboot_efi.Shim),
+		LoadSequences: []secboot_efi.ImageLoadActivity{
+			secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockshim1.efi.signed.1"), secboot_efi.Firmware).Next(
+				secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockgrub1.efi.signed.shim"), secboot_efi.Shim).Next(
+					secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockkernel1.efi.signed.shim"), secboot_efi.Shim),
 				),
 			),
 		},

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -78,8 +78,8 @@ func computePCRProtectionProfile(env secboot_efi.HostEnvironment) (*secboot_tpm2
 	sbpParams := secboot_efi.SecureBootPolicyProfileParams{
 		PCRAlgorithm: tpm2.HashAlgorithmSHA256,
 		LoadSequences: []secboot_efi.ImageLoadActivity{
-			secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockshim1.efi.signed.1"), secboot_efi.Firmware).Next(
-				secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockgrub1.efi.signed.shim"), secboot_efi.Shim).Next(
+			secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockshim1.efi.signed.1"), secboot_efi.Firmware).Loads(
+				secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockgrub1.efi.signed.shim"), secboot_efi.Shim).Loads(
 					secboot_efi.NewImageLoadActivity(secboot_efi.FileImage("efi/testdata/mockkernel1.efi.signed.shim"), secboot_efi.Shim),
 				),
 			),

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -77,23 +77,12 @@ func computePCRProtectionProfile(env secboot_efi.HostEnvironment) (*secboot_tpm2
 
 	sbpParams := secboot_efi.SecureBootPolicyProfileParams{
 		PCRAlgorithm: tpm2.HashAlgorithmSHA256,
-		LoadSequences: []*secboot_efi.ImageLoadEvent{
-			{
-				Source: secboot_efi.Firmware,
-				Image:  secboot_efi.FileImage("efi/testdata/mockshim1.efi.signed.1"),
-				Next: []*secboot_efi.ImageLoadEvent{
-					{
-						Source: secboot_efi.Shim,
-						Image:  secboot_efi.FileImage("efi/testdata/mockgrub1.efi.signed.shim"),
-						Next: []*secboot_efi.ImageLoadEvent{
-							{
-								Source: secboot_efi.Shim,
-								Image:  secboot_efi.FileImage("efi/testdata/mockkernel1.efi.signed.shim"),
-							},
-						},
-					},
-				},
-			},
+		LoadSequences: []secboot_efi.ImageLoadEvent{
+			secboot_efi.NewImageLoadEvent(secboot_efi.FileImage("efi/testdata/mockshim1.efi.signed.1"), secboot_efi.Firmware).Next(
+				secboot_efi.NewImageLoadEvent(secboot_efi.FileImage("efi/testdata/mockgrub1.efi.signed.shim"), secboot_efi.Shim).Next(
+					secboot_efi.NewImageLoadEvent(secboot_efi.FileImage("efi/testdata/mockkernel1.efi.signed.shim"), secboot_efi.Shim),
+				),
+			),
 		},
 		Environment: env,
 	}


### PR DESCRIPTION
This is the start of a series of changes that significantly refactor the code in the efi package. These changes will:
- Make the code more modular and maintainable.
- Add support for applying secure boot revocations, including updating shim.
- Replace the existing AddSecureBootPolicyProfile and AddBootManagerCodeProfile APIs with a single API that will add an entire profile. This will also replace the need to use the existing AddSystemdStubProfile and tpm2.AddSnapModelProfile APIs.

This last one requires the ability to specify external parameters that are not part of an executable binary, which is partly what this PR adds. Note that this does add some APIs that aren't used yet. It also implements ImageLoadEventSource as one of these new parameters, which is a bit strange - this is temporary because it's going to be removed entirely in a future PR, but it needs to stay for now to keep the existing code working.