### PR TITLE
Update github.com/canonical/go-efilib dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GOPATH: ${{ github.workspace }}
+      GO111MODULE: off
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.18
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: 1.18
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/efi/secureboot.go
+++ b/efi/secureboot.go
@@ -112,7 +112,7 @@ SignatureLoop:
 					continue
 				}
 
-				if sig.CanBeVerifiedBy(ca) {
+				if sig.CertLikelyTrustAnchor(ca) {
 					authority = &secureBootAuthority{
 						Source:    db.Name,
 						Signature: l.Signatures[0]}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,60 +3,60 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "HmqA0tGyjjTP4eNshHgLzvZE5nQ=",
+			"checksumSHA1": "69XKT5+ehKVM6yXXAeNEKNKWeCs=",
 			"path": "github.com/canonical/go-efilib",
-			"revision": "f378010c82c2c3bc0fbbf64063f40131e325ad0e",
-			"revisionTime": "2022-11-28T21:23:35Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cc90cbed9430e4d9690c713d8860bfe8c914f98f",
+			"revisionTime": "2023-05-22T10:38:12Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
 		},
 		{
 			"checksumSHA1": "w0EI7UJmvC1OS1fFXdr0CAGIFgY=",
 			"path": "github.com/canonical/go-efilib/internal/ioerr",
-			"revision": "f378010c82c2c3bc0fbbf64063f40131e325ad0e",
-			"revisionTime": "2022-11-28T21:23:35Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cc90cbed9430e4d9690c713d8860bfe8c914f98f",
+			"revisionTime": "2023-05-22T10:38:12Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
 		},
 		{
 			"checksumSHA1": "ZZ+AMnkeZSvNfi7M5LnY0xhVWFk=",
 			"path": "github.com/canonical/go-efilib/internal/pe1.14",
-			"revision": "f378010c82c2c3bc0fbbf64063f40131e325ad0e",
-			"revisionTime": "2022-11-28T21:23:35Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cc90cbed9430e4d9690c713d8860bfe8c914f98f",
+			"revisionTime": "2023-05-22T10:38:12Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
 		},
 		{
-			"checksumSHA1": "jXh4p8309Xvi1Hkxe6MUaTaVdZI=",
+			"checksumSHA1": "yJdTMVIZY1q5yqhloWLG/dgfFoA=",
 			"path": "github.com/canonical/go-efilib/internal/pkcs7",
-			"revision": "f378010c82c2c3bc0fbbf64063f40131e325ad0e",
-			"revisionTime": "2022-11-28T21:23:35Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cc90cbed9430e4d9690c713d8860bfe8c914f98f",
+			"revisionTime": "2023-05-22T10:38:12Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
 		},
 		{
 			"checksumSHA1": "+lQG86tmJPldFp6+p4uHG2cJuXo=",
 			"path": "github.com/canonical/go-efilib/internal/uefi",
-			"revision": "f378010c82c2c3bc0fbbf64063f40131e325ad0e",
-			"revisionTime": "2022-11-28T21:23:35Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cc90cbed9430e4d9690c713d8860bfe8c914f98f",
+			"revisionTime": "2023-05-22T10:38:12Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
 		},
 		{
 			"checksumSHA1": "5SMPpBSP3f+zupAYgPMdZJPCQdc=",
 			"path": "github.com/canonical/go-efilib/internal/unix",
-			"revision": "f378010c82c2c3bc0fbbf64063f40131e325ad0e",
-			"revisionTime": "2022-11-28T21:23:35Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cc90cbed9430e4d9690c713d8860bfe8c914f98f",
+			"revisionTime": "2023-05-22T10:38:12Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
 		},
 		{
 			"checksumSHA1": "R9jsX60WDTcKp5XNn97mas6ThXw=",
 			"path": "github.com/canonical/go-efilib/mbr",
-			"revision": "f378010c82c2c3bc0fbbf64063f40131e325ad0e",
-			"revisionTime": "2022-11-28T21:23:35Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cc90cbed9430e4d9690c713d8860bfe8c914f98f",
+			"revisionTime": "2023-05-22T10:38:12Z",
+			"version": "v0.9.4",
+			"versionExact": "v0.9.4"
 		},
 		{
 			"checksumSHA1": "5zGeHDBvsYpgEyZ91hgSF0zLxyU=",


### PR DESCRIPTION
This addresses an issue where some valid signed variable update
payloads could fail to parse correctly because although the UEFI
spec permits signatures with the PKCS#7 SignedData wrapped in an
optional outer ContentInfo structure, go-efilib didn't recognize
signatures in the wrapped case. I discovered this when creating
mock signatures for unit tests in secboot.

This also bumps secboot's go requirement to 1.18 to match snapd,
as go-efilib is pulling in the latest version of x/cryptobyte which
has dependencies that require this as well now.