### PR TITLE
efi: allow the case of minor version not present

### DIFF
--- a/efi/export_test.go
+++ b/efi/export_test.go
@@ -35,6 +35,7 @@ var (
 	ComputeDbUpdate    = computeDbUpdate
 	DefaultEnv         = defaultEnv
 	NewShimImageHandle = newShimImageHandle
+	GetShimVersion     = getShimVersion
 )
 
 // Alias some unexported types for testing. These are required in order to pass these between functions in tests, or to access

--- a/efi/secureboot_policy_test.go
+++ b/efi/secureboot_policy_test.go
@@ -1654,8 +1654,11 @@ func (s *securebootPolicySuite) TestGetShimVersion(c *C) {
 	}{
 		{"", "empty .data.ident section", 0, 0},
 		{"UEFI SHIM", "cannot determine version - missing from .data.ident section", 0, 0},
+		{"UEFI SHIM\n$Version: $", "cannot determine version - missing from .data.ident section", 0, 0},
 		{"UEFI SHIM\n$Version: 15.4 $", "", 15, 4},
 		{"UEFI SHIM\n$Version: 15 $", "", 15, 0},
+		// should never happen on real systems but we allow it
+		{"UEFI SHIM\n$Version: 15. $", "", 15, 0},
 	} {
 		r := bytes.NewReader([]byte(tc.inp))
 

--- a/efi/secureboot_policy_test.go
+++ b/efi/secureboot_policy_test.go
@@ -1644,3 +1644,28 @@ func (s *securebootPolicySuite) TestAddSecureBootPolicyDualSignedShim2(c *C) {
 		},
 	})
 }
+
+func (s *securebootPolicySuite) TestGetShimVersion(c *C) {
+	for _, tc := range []struct {
+		inp               string
+		expectedErr       string
+		expectedShimMajor uint
+		expectedShimMinor uint
+	}{
+		{"", "empty .data.ident section", 0, 0},
+		{"UEFI SHIM", "cannot determine version - missing from .data.ident section", 0, 0},
+		{"UEFI SHIM\n$Version: 15.4 $", "", 15, 4},
+		{"UEFI SHIM\n$Version: 15 $", "", 15, 0},
+	} {
+		r := bytes.NewReader([]byte(tc.inp))
+
+		shimVer, err := GetShimVersion(r)
+		if tc.expectedErr != "" {
+			c.Check(err, ErrorMatches, tc.expectedErr)
+		} else {
+			c.Assert(err, IsNil)
+			c.Check(shimVer.Major, Equals, tc.expectedShimMajor)
+			c.Check(shimVer.Minor, Equals, tc.expectedShimMinor)
+		}
+	}
+}


### PR DESCRIPTION
So `$Version: 15 $` is fine in the .data.ident section.