### PR TITLE
luks2: use "aes-cbc-essiv:sha256" on 32bit arm HW

### DIFF
--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -55,8 +55,6 @@ var (
 
 	features     Features
 	featuresOnce sync.Once
-
-	keySize = 64
 )
 
 // Features indicates the set of features supported by this package,
@@ -209,7 +207,7 @@ type FormatOptions struct {
 	KDFOptions KDFOptions
 }
 
-func (options *FormatOptions) validate() error {
+func (options *FormatOptions) validate(cipher string) error {
 	if (options.MetadataKiBSize != 0 || options.KeyslotsAreaKiBSize != 0) &&
 		DetectCryptsetupFeatures()&FeatureHeaderSizeSetting == 0 {
 		return ErrMissingCryptsetupFeature
@@ -232,7 +230,7 @@ func (options *FormatOptions) validate() error {
 	if options.KeyslotsAreaKiBSize != 0 {
 		// Verify that the size is sufficient for a single keyslot, not more than 128MiB
 		// and a multiple of 4KiB.
-		if options.KeyslotsAreaKiBSize < (keySize*4000)/1024 ||
+		if options.KeyslotsAreaKiBSize < (keySize(cipher)*4000)/1024 ||
 			options.KeyslotsAreaKiBSize > 128*1024 || options.KeyslotsAreaKiBSize%4 != 0 {
 			return fmt.Errorf("cannot set keyslots area size to %v KiB", options.KeyslotsAreaKiBSize)
 		}
@@ -265,17 +263,30 @@ var runtimeGOARCH = runtime.GOARCH
 // Note that this is a simple approach, we could run "cryptsetup
 // benchmark" but that seems over engineered (and easy enough to
 // switch if we need in the future).
-func selectCipherAndKeysize() (string, int) {
+func selectCipher() string {
 	switch runtimeGOARCH {
 	case "arm":
 		// On many 32bit ARM SoCs there is a CAAM module that
 		// can accelerate cryptographic operations which
 		// ~doubles the speed. It does not support XTS though
 		// so we use CBC mode here.
-		return "aes-cbc-essiv:sha256", keySize * 4
+		return "aes-cbc-essiv:sha256"
 	default:
 		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)
-		return "aes-xts-plain64", keySize * 8
+		return "aes-xts-plain64"
+	}
+}
+
+// keySize returns the size of the key in bytes for the given encryption
+// algorithm. It will panic if an unsupported cipher is passed in.
+func keySize(cipher string) int {
+	switch cipher {
+	case "aes-xts-plain64":
+		return 64
+	case "aes-cbc-essiv:sha256":
+		return 32
+	default:
+		panic(fmt.Sprintf("internal error: unknown keysize for cipher %v", cipher))
 	}
 }
 
@@ -294,11 +305,12 @@ func Format(devicePath, label string, key []byte, opts *FormatOptions) error {
 		opts = &defaultOpts
 	}
 
-	if err := opts.validate(); err != nil {
+	cipher := selectCipher()
+	if err := opts.validate(cipher); err != nil {
 		return err
 	}
 
-	cipher, ksize := selectCipherAndKeysize()
+	ksize := keySize(cipher)
 	args := []string{
 		// batch processing, no password verification for formatting an existing LUKS container
 		"-q",
@@ -309,7 +321,7 @@ func Format(devicePath, label string, key []byte, opts *FormatOptions) error {
 		// read the key from stdin
 		"--key-file", "-",
 
-		"--cipher", cipher, "--key-size", strconv.Itoa(ksize),
+		"--cipher", cipher, "--key-size", strconv.Itoa(ksize * 8),
 		// set LUKS2 label
 		"--label", label}
 

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -268,8 +268,10 @@ var runtimeGOARCH = runtime.GOARCH
 func selectCipherAndKeysize() (string, int) {
 	switch runtimeGOARCH {
 	case "arm":
-		// on 32bit arm CPUs xts cannot be accerlated in HW so
-		// cbc is used
+		// On many 32bit ARM SoCs there is a CAAM module that
+		// can accelerate cryptographic operations which
+		// ~doubles the speed. It does not support XTS though
+		// so we use CBC mode here.
 		return "aes-cbc-essiv:sha256", keySize * 4
 	default:
 		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -183,13 +183,19 @@ func (s *cryptsetupSuite) TestFormatOptionsValidateBadMetadataSize(c *C) {
 }
 
 func (s *cryptsetupSuite) TestFormatOptionsValidateBadKeyslotsAreaSize(c *C) {
+	// minimum size of a keyslot is keysize*4000 in KiB
+	// (250 KiB for 64bit keys, 125 for 32bit keys)
+	minSize := (KeySize(SelectCipher()) * 4000) / 1024
 	for _, opts := range []FormatOptions{
-		{KeyslotsAreaKiBSize: 128},
+		// smaller than the minimum
+		{KeyslotsAreaKiBSize: minSize},
+		// must be multiply of 1024
 		{KeyslotsAreaKiBSize: (4 * 1024) + 1},
+		// can't be more than 128KiB
 		{KeyslotsAreaKiBSize: 256 * 1024},
 	} {
 		c.Check(Format("/dev/null", "", make([]byte, 32), &opts), ErrorMatches,
-			fmt.Sprintf("cannot set keyslots area size to %v KiB", opts.KeyslotsAreaKiBSize))
+			fmt.Sprintf("cannot set keyslots area size to %v KiB", opts.KeyslotsAreaKiBSize), Commentf("%v", opts))
 	}
 }
 

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -59,6 +59,9 @@ func (s *cryptsetupSuiteBase) SetUpTest(c *C) {
 
 	s.cryptsetup = snapd_testutil.MockCommand(c, "cryptsetup", fmt.Sprintf(cryptsetupWrapperTpl, cryptsetup))
 	s.AddCleanup(s.cryptsetup.Restore)
+
+	// cryptsetup parameters are arch specific
+	s.AddCleanup(MockRuntimeGOARCH("amd64"))
 }
 
 type cryptsetupSuite struct {
@@ -1008,4 +1011,19 @@ func (s *cryptsetupSuite) TestSetSlotPriority3(c *C) {
 	s.testSetSlotPriority(c, &testSetSlotPriorityData{
 		slotId:   1,
 		priority: SlotPriorityIgnore})
+}
+
+func (s *cryptsetupSuite) TestSelectCipherAndKeysizeDefault(c *C) {
+	cipher, keysize := SelectCipherAndKeysize()
+	c.Check(cipher, Equals, "aes-xts-plain64")
+	c.Check(keysize, Equals, 512)
+}
+
+func (s *cryptsetupSuite) TestSelectCipherAndKeysizeArm(c *C) {
+	restore := MockRuntimeGOARCH("arm")
+	defer restore()
+
+	cipher, keysize := SelectCipherAndKeysize()
+	c.Check(cipher, Equals, "aes-cbc-essiv:sha256")
+	c.Check(keysize, Equals, 256)
 }

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -1016,7 +1016,24 @@ func (s *cryptsetupSuite) TestSetSlotPriority3(c *C) {
 		priority: SlotPriorityIgnore})
 }
 
-func (s *cryptsetupSuite) TestSelectCipherAndKeysize(c *C) {
+var _ = Suite(&cryptsetupSuiteARM{})
+
+type cryptsetupSuiteARM struct {
+	cryptsetupSuite
+}
+
+func (s *cryptsetupSuiteARM) SetUpTest(c *C) {
+	s.cryptsetupSuite.SetUpTest(c)
+	s.AddCleanup(MockRuntimeGOARCH("arm"))
+}
+
+var _ = Suite(&cipherSuite{})
+
+type cipherSuite struct {
+	snapd_testutil.BaseTest
+}
+
+func (s *cipherSuite) TestSelectCipherAndKeysize(c *C) {
 	for _, tc := range []struct {
 		arch string
 
@@ -1041,15 +1058,4 @@ func (s *cryptsetupSuite) TestSelectCipherAndKeysize(c *C) {
 		c.Check(cipher, Equals, tc.expectedCipher)
 		c.Check(keysize, Equals, tc.expectedKeysize)
 	}
-}
-
-var _ = Suite(&cryptsetupSuiteARM{})
-
-type cryptsetupSuiteARM struct {
-	cryptsetupSuite
-}
-
-func (s *cryptsetupSuiteARM) SetUpTest(c *C) {
-	s.cryptsetupSuite.SetUpTest(c)
-	s.AddCleanup(MockRuntimeGOARCH("arm"))
 }

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 var (
-	AcquireSharedLock = acquireSharedLock
+	AcquireSharedLock      = acquireSharedLock
+	SelectCipherAndKeysize = selectCipherAndKeysize
 )
 
 func (o *FormatOptions) Validate() error {
@@ -88,4 +89,12 @@ func MockStderr(w io.Writer) (restore func()) {
 
 func ResetCryptsetupFeatures() {
 	featuresOnce = sync.Once{}
+}
+
+func MockRuntimeGOARCH(arch string) (restore func()) {
+	oldRuntimeGOARCH := runtimeGOARCH
+	runtimeGOARCH = arch
+	return func() {
+		runtimeGOARCH = oldRuntimeGOARCH
+	}
 }

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -28,12 +28,13 @@ import (
 )
 
 var (
-	AcquireSharedLock      = acquireSharedLock
-	SelectCipherAndKeysize = selectCipherAndKeysize
+	AcquireSharedLock = acquireSharedLock
+	SelectCipher      = selectCipher
+	KeySize           = keySize
 )
 
-func (o *FormatOptions) Validate() error {
-	return o.validate()
+func (o *FormatOptions) Validate(cipher string) error {
+	return o.validate(cipher)
 }
 
 func MockDataDeviceInfo(stMock *unix.Stat_t) (restore func()) {


### PR DESCRIPTION
Most hardware should use aes-xts-plain64 for LUKS2 but on 32bit arm the XTS mode cannot be accelerated by the hardware which leads to very poor perfomance (less than half compared to cbc mode). Therefore this commit switches the default on 32bit ARM to aes-cbc-essiv:sha256.

Note that this is a simple approach, we could run "cryptsetup benchmark" but that seems over engineered (and easy enough to switch if we need in the future).