### PR TITLE
luks2: use "aes-cbc-essiv:sha256" on 32bit arm HW (uc22)

### DIFF
--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -148,6 +149,27 @@ type FormatOptions struct {
 	InlineCryptoEngine bool
 }
 
+var runtimeGOARCH = runtime.GOARCH
+
+// selectCipher will return the cipher to use. This is aes-xts-plain64
+// everywhere except on armhf (32bit arm) hardware where the XTS mode
+// cannot be accelerated by the hardware.
+//
+// Note that this is a simple approach, we could run "cryptsetup
+// benchmark" but that seems over engineered (and easy enough to
+// switch if we need in the future).
+func selectCipherAndKeysize() (string, int) {
+	switch runtimeGOARCH {
+	case "arm":
+		// on 32bit arm CPUs xts cannot be accerlated in HW so
+		// cbc is used
+		return "aes-cbc-essiv:sha256", keySize * 4
+	default:
+		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)
+		return "aes-xts-plain64", keySize * 8
+	}
+}
+
 // Format will initialize a LUKS2 container with the specified options and set the primary key to the
 // supplied key. The label for the new container will be set to the supplied label. This can only be
 // called on a device that is not mapped.
@@ -163,6 +185,7 @@ func Format(devicePath, label string, key []byte, opts *FormatOptions) error {
 		opts = &defaultOpts
 	}
 
+	cipher, ksize := selectCipherAndKeysize()
 	args := []string{
 		// batch processing, no password verification for formatting an existing LUKS container
 		"-q",
@@ -172,8 +195,8 @@ func Format(devicePath, label string, key []byte, opts *FormatOptions) error {
 		"--type", "luks2",
 		// read the key from stdin
 		"--key-file", "-",
-		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)
-		"--cipher", "aes-xts-plain64", "--key-size", strconv.Itoa(keySize * 8),
+
+		"--cipher", cipher, "--key-size", strconv.Itoa(ksize),
 		// set LUKS2 label
 		"--label", label}
 

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -161,8 +161,10 @@ var runtimeGOARCH = runtime.GOARCH
 func selectCipherAndKeysize() (string, int) {
 	switch runtimeGOARCH {
 	case "arm":
-		// on 32bit arm CPUs xts cannot be accerlated in HW so
-		// cbc is used
+		// On many 32bit ARM SoCs there is a CAAM module that
+		// can accelerate cryptographic operations which
+		// ~doubles the speed. It does not support XTS though
+		// so we use CBC mode here.
 		return "aes-cbc-essiv:sha256", keySize * 4
 	default:
 		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -52,6 +52,9 @@ func (s *cryptsetupSuite) SetUpTest(c *C) {
 	s.AddCleanup(pathstest.MockRunDir(c.MkDir()))
 
 	s.AddCleanup(luks2test.WrapCryptsetup(c))
+
+	// cryptsetup parameters are arch specific
+	s.AddCleanup(MockRuntimeGOARCH("amd64"))
 }
 
 func (s *cryptsetupSuite) checkLUKS2Passphrase(c *C, path string, key []byte) {
@@ -672,4 +675,19 @@ func (s *cryptsetupSuite) TestSetSlotPriority3(c *C) {
 	s.testSetSlotPriority(c, &testSetSlotPriorityData{
 		slotId:   1,
 		priority: SlotPriorityIgnore})
+}
+
+func (s *cryptsetupSuite) TestSelectCipherAndKeysizeDefault(c *C) {
+	cipher, keysize := SelectCipherAndKeysize()
+	c.Check(cipher, Equals, "aes-xts-plain64")
+	c.Check(keysize, Equals, 512)
+}
+
+func (s *cryptsetupSuite) TestSelectCipherAndKeysizeArm(c *C) {
+	restore := MockRuntimeGOARCH("arm")
+	defer restore()
+
+	cipher, keysize := SelectCipherAndKeysize()
+	c.Check(cipher, Equals, "aes-cbc-essiv:sha256")
+	c.Check(keysize, Equals, 256)
 }

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -681,7 +681,24 @@ func (s *cryptsetupSuite) TestSetSlotPriority3(c *C) {
 		priority: SlotPriorityIgnore})
 }
 
-func (s *cryptsetupSuite) TestSelectCipherAndKeysize(c *C) {
+var _ = Suite(&cryptsetupSuiteARM{})
+
+type cryptsetupSuiteARM struct {
+	cryptsetupSuite
+}
+
+func (s *cryptsetupSuiteARM) SetUpTest(c *C) {
+	s.cryptsetupSuite.SetUpTest(c)
+	s.AddCleanup(MockRuntimeGOARCH("arm"))
+}
+
+var _ = Suite(&cipherSuite{})
+
+type cipherSuite struct {
+	snapd_testutil.BaseTest
+}
+
+func (s *cipherSuite) TestSelectCipherAndKeysize(c *C) {
 	for _, tc := range []struct {
 		arch string
 
@@ -706,15 +723,4 @@ func (s *cryptsetupSuite) TestSelectCipherAndKeysize(c *C) {
 		c.Check(cipher, Equals, tc.expectedCipher)
 		c.Check(keysize, Equals, tc.expectedKeysize)
 	}
-}
-
-var _ = Suite(&cryptsetupSuiteARM{})
-
-type cryptsetupSuiteARM struct {
-	cryptsetupSuite
-}
-
-func (s *cryptsetupSuiteARM) SetUpTest(c *C) {
-	s.cryptsetupSuite.SetUpTest(c)
-	s.AddCleanup(MockRuntimeGOARCH("arm"))
 }

--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -74,6 +74,7 @@ type testFormatData struct {
 func (s *cryptsetupSuite) testFormat(c *C, data *testFormatData) {
 	devicePath := luks2test.CreateEmptyDiskImage(c, 20)
 
+	cipher, keysize := SelectCipherAndKeysize()
 	c.Check(Format(devicePath, data.label, data.key, data.options), IsNil)
 
 	options := data.options

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -27,8 +27,9 @@ import (
 )
 
 var (
-	AcquireSharedLock      = acquireSharedLock
-	SelectCipherAndKeysize = selectCipherAndKeysize
+	AcquireSharedLock = acquireSharedLock
+	SelectCipher      = selectCipher
+	KeySize           = keySize
 )
 
 func MockDataDeviceInfo(stMock *unix.Stat_t) (restore func()) {

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 var (
-	AcquireSharedLock = acquireSharedLock
+	AcquireSharedLock      = acquireSharedLock
+	SelectCipherAndKeysize = selectCipherAndKeysize
 )
 
 func MockDataDeviceInfo(stMock *unix.Stat_t) (restore func()) {
@@ -78,5 +79,13 @@ func MockStderr(w io.Writer) (restore func()) {
 	stderr = w
 	return func() {
 		stderr = origStderr
+	}
+}
+
+func MockRuntimeGOARCH(arch string) (restore func()) {
+	oldRuntimeGOARCH := runtimeGOARCH
+	runtimeGOARCH = arch
+	return func() {
+		runtimeGOARCH = oldRuntimeGOARCH
 	}
 }


### PR DESCRIPTION
This is a backport of the aes-cbc selection on arm (https://github.com/snapcore/secboot/pull/252) to the uc22 branch.