### PR TITLE
tpm2: implement deterministic ECDSA key generation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,7 @@ jobs:
       matrix:
         goversion:
           - 1.18
-          # TODO: enable stable, right now tests fails there
-          # - stable
+          - stable
     steps:
     - name: Set up Go ${{ matrix.goversion }}
       uses: actions/setup-go@v4

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package crypto
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }

--- a/internal/crypto/ecdsa.go
+++ b/internal/crypto/ecdsa.go
@@ -29,7 +29,12 @@ import (
 var one = new(big.Int).SetInt64(1)
 
 // GenerateECDSAKey generates a new elliptic key pair using the method described by
-// FIPS186-4 section B.4.1.
+// FIPS186-4 section B.4.1. This method is deterministic (given the same sequence of
+// random bytes, it will generate the same key) and is not sensitive to changes in the
+// standard library between go releases. This is required because the tpm2 package needs
+// to be able to deterministically derive keys from a sequence of bytes. The method
+// used to generate keys using crypto/ecdsa package changed in go1.20 to one that is
+// non-deterministic.
 func GenerateECDSAKey(curve elliptic.Curve, rand io.Reader) (*ecdsa.PrivateKey, error) {
 	params := curve.Params()
 

--- a/internal/crypto/ecdsa.go
+++ b/internal/crypto/ecdsa.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"io"
+	"math/big"
+)
+
+var one = new(big.Int).SetInt64(1)
+
+// GenerateECDSAKey generates a new elliptic key pair using the method described by
+// FIPS186-4 section B.4.1.
+func GenerateECDSAKey(curve elliptic.Curve, rand io.Reader) (*ecdsa.PrivateKey, error) {
+	params := curve.Params()
+
+	// 1. N=len(n)
+	N := params.N.BitLen() / 8
+
+	// 4. Obtain a string of N+64 bits from an RBG
+	//
+	//  For P-521, this is N+63 bits because of the rounding error, but the original
+	//  crypto/ecdsa had this quirk as well and this function has to be compabible with
+	//  that.
+	b := make([]byte, N+8)
+	_, err := io.ReadFull(rand, b)
+	if err != nil {
+		return nil, err
+	}
+
+	// 5. Convert to integer c
+	c := new(big.Int).SetBytes(b)
+
+	// 6. d = (c*mod(n-1))+1
+	nMinusOne := new(big.Int).Sub(params.N, one)
+	c.Mod(c, nMinusOne)
+	d := new(big.Int).Add(c, one)
+
+	priv := new(ecdsa.PrivateKey)
+	priv.PublicKey.Curve = curve
+	priv.D = d
+
+	// 7. Q=dG
+	priv.PublicKey.X, priv.PublicKey.Y = curve.ScalarBaseMult(d.Bytes())
+
+	return priv, nil
+}

--- a/internal/crypto/ecdsa.go
+++ b/internal/crypto/ecdsa.go
@@ -44,7 +44,7 @@ func GenerateECDSAKey(curve elliptic.Curve, rand io.Reader) (*ecdsa.PrivateKey, 
 	// 4. Obtain a string of N+64 bits from an RBG
 	//
 	//  For P-521, this is N+63 bits because of the rounding error, but the original
-	//  crypto/ecdsa had this quirk as well and this function has to be compabible with
+	//  crypto/ecdsa had this quirk as well and this function has to be compatible with
 	//  that.
 	b := make([]byte, N+8)
 	_, err := io.ReadFull(rand, b)

--- a/internal/crypto/ecdsa_1_19_test.go
+++ b/internal/crypto/ecdsa_1_19_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+//go:build !go1.20
+// +build !go1.20
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package crypto_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot/internal/crypto"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+type ecdsa1_19Suite struct{}
+
+var _ = Suite(&ecdsa1_19Suite{})
+
+func (s *ecdsa1_19Suite) TestGenerateECDSAKey(c *C) {
+	rand := testutil.DecodeHexString(c, "26be875535d98e705cbd60c34f068985fc808e0b83ad1c8ac467ec8294b622a39657d3b9207ba865")
+
+	key1, err := GenerateECDSAKey(elliptic.P256(), bytes.NewReader(rand))
+	c.Assert(err, IsNil)
+
+	key2, err := ecdsa.GenerateKey(elliptic.P256(), bytes.NewReader(rand))
+	c.Assert(err, IsNil)
+
+	c.Check(key1.Equal(key2), testutil.IsTrue)
+}

--- a/internal/crypto/ecdsa_test.go
+++ b/internal/crypto/ecdsa_test.go
@@ -42,9 +42,6 @@ func (s *ecdsaSuite) TestGenerateECDSAKey(c *C) {
 	c.Check(key.X.Bytes(), DeepEquals, testutil.DecodeHexString(c, "918457cb51bde6efaa14eb028cfab900c02778ac7978ab2d6c9d451f1cf153ea"))
 	c.Check(key.Y.Bytes(), DeepEquals, testutil.DecodeHexString(c, "08a18bb52b3cb984ef71e76d449f8c6c98ad1b5e3702089ad63a02b25f232812"))
 	c.Check(elliptic.P256().IsOnCurve(key.X, key.Y), testutil.IsTrue)
-	c.Logf("d=%x", key.D)
-	c.Logf("x=%x", key.X)
-	c.Logf("y=%x", key.Y)
 }
 
 func (s *ecdsaSuite) TestGenerateECDSAKeyDifferentRandomBytes(c *C) {
@@ -56,9 +53,6 @@ func (s *ecdsaSuite) TestGenerateECDSAKeyDifferentRandomBytes(c *C) {
 	c.Check(key.X.Bytes(), DeepEquals, testutil.DecodeHexString(c, "9ef4c92f4db77ebc84299c73832da6188e6b1c1d852218c70509ceac0d8a8613"))
 	c.Check(key.Y.Bytes(), DeepEquals, testutil.DecodeHexString(c, "cf7345866f20b51bb21a01f68f18c7f95c70d3555a8eddeafe572794e0306118"))
 	c.Check(elliptic.P256().IsOnCurve(key.X, key.Y), testutil.IsTrue)
-	c.Logf("d=%x", key.D)
-	c.Logf("x=%x", key.X)
-	c.Logf("y=%x", key.Y)
 }
 
 func (s *ecdsaSuite) TestGenerateECDSAKeyDifferentCurve(c *C) {
@@ -69,7 +63,4 @@ func (s *ecdsaSuite) TestGenerateECDSAKeyDifferentCurve(c *C) {
 	c.Check(key.X.Bytes(), DeepEquals, testutil.DecodeHexString(c, "01eb7185ee58a503f743581c1ceea4a40b367c7cbe5a81aae539280921b008defa7a2427e070f4b6ca4c383e2f844e7e48fd8da64c59a9d052c29f0c75fbe3c77aa4"))
 	c.Check(key.Y.Bytes(), DeepEquals, testutil.DecodeHexString(c, "01a8a21ba6ff4ad05c70d1b29a37e11bdfa8092d434b982b80341c3e229f7479431422b1b9d45ca0354b32211b083d8a31ab55a4d4d01a8be1e75a0e02526d4656c4"))
 	c.Check(elliptic.P521().IsOnCurve(key.X, key.Y), testutil.IsTrue)
-	c.Logf("d=%x", key.D)
-	c.Logf("x=%x", key.X)
-	c.Logf("y=%x", key.Y)
 }

--- a/internal/crypto/ecdsa_test.go
+++ b/internal/crypto/ecdsa_test.go
@@ -1,0 +1,75 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package crypto_test
+
+import (
+	"bytes"
+	"crypto/elliptic"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot/internal/crypto"
+	"github.com/snapcore/secboot/internal/testutil"
+)
+
+type ecdsaSuite struct{}
+
+var _ = Suite(&ecdsaSuite{})
+
+func (s *ecdsaSuite) TestGenerateECDSAKey(c *C) {
+	rand := testutil.DecodeHexString(c, "26be875535d98e705cbd60c34f068985fc808e0b83ad1c8ac467ec8294b622a39657d3b9207ba865")
+
+	key, err := GenerateECDSAKey(elliptic.P256(), bytes.NewReader(rand))
+	c.Assert(err, IsNil)
+	c.Check(key.D.Bytes(), DeepEquals, testutil.DecodeHexString(c, "9296ef32f26e73c106a834e0415fa32ee2a6dc84d4359431ad4abd21dea061d6"))
+	c.Check(key.X.Bytes(), DeepEquals, testutil.DecodeHexString(c, "918457cb51bde6efaa14eb028cfab900c02778ac7978ab2d6c9d451f1cf153ea"))
+	c.Check(key.Y.Bytes(), DeepEquals, testutil.DecodeHexString(c, "08a18bb52b3cb984ef71e76d449f8c6c98ad1b5e3702089ad63a02b25f232812"))
+	c.Check(elliptic.P256().IsOnCurve(key.X, key.Y), testutil.IsTrue)
+	c.Logf("d=%x", key.D)
+	c.Logf("x=%x", key.X)
+	c.Logf("y=%x", key.Y)
+}
+
+func (s *ecdsaSuite) TestGenerateECDSAKeyDifferentRandomBytes(c *C) {
+	rand := testutil.DecodeHexString(c, "9a79e8343e4848e428a1f680bd1fb44d9e8c32e80794a197f6f96958dbda15fbc9083ce3ba8f56df")
+
+	key, err := GenerateECDSAKey(elliptic.P256(), bytes.NewReader(rand))
+	c.Assert(err, IsNil)
+	c.Check(key.D.Bytes(), DeepEquals, testutil.DecodeHexString(c, "66ea3f63e45d8335c70933cb9bb429b04ed877c35a6b7d5a5252e96f507f8760"))
+	c.Check(key.X.Bytes(), DeepEquals, testutil.DecodeHexString(c, "9ef4c92f4db77ebc84299c73832da6188e6b1c1d852218c70509ceac0d8a8613"))
+	c.Check(key.Y.Bytes(), DeepEquals, testutil.DecodeHexString(c, "cf7345866f20b51bb21a01f68f18c7f95c70d3555a8eddeafe572794e0306118"))
+	c.Check(elliptic.P256().IsOnCurve(key.X, key.Y), testutil.IsTrue)
+	c.Logf("d=%x", key.D)
+	c.Logf("x=%x", key.X)
+	c.Logf("y=%x", key.Y)
+}
+
+func (s *ecdsaSuite) TestGenerateECDSAKeyDifferentCurve(c *C) {
+	rand := testutil.DecodeHexString(c, "cd0f04ff79ad3c799d200113c090d7c84d1a71f12e9fa52a710813a52dcea456819aa394fc1c969148ab1406c2ce9c6e020656bb842314fe377bb3d12079a70cb3188483f974d5c151")
+	key, err := GenerateECDSAKey(elliptic.P521(), bytes.NewReader(rand))
+	c.Assert(err, IsNil)
+	c.Check(key.D.Bytes(), DeepEquals, testutil.DecodeHexString(c, "019d200113c090d7c84d1a71f12e9fa52a710813a52dcea45683e129e27b964638d954c64c5232245fa8a4bae23fe9cc940e188531ec10ad43b213203c9d1f315f72"))
+	c.Check(key.X.Bytes(), DeepEquals, testutil.DecodeHexString(c, "01eb7185ee58a503f743581c1ceea4a40b367c7cbe5a81aae539280921b008defa7a2427e070f4b6ca4c383e2f844e7e48fd8da64c59a9d052c29f0c75fbe3c77aa4"))
+	c.Check(key.Y.Bytes(), DeepEquals, testutil.DecodeHexString(c, "01a8a21ba6ff4ad05c70d1b29a37e11bdfa8092d434b982b80341c3e229f7479431422b1b9d45ca0354b32211b083d8a31ab55a4d4d01a8be1e75a0e02526d4656c4"))
+	c.Check(elliptic.P521().IsOnCurve(key.X, key.Y), testutil.IsTrue)
+	c.Logf("d=%x", key.D)
+	c.Logf("x=%x", key.X)
+	c.Logf("y=%x", key.Y)
+}

--- a/tpm2/policy_v3.go
+++ b/tpm2/policy_v3.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/snapcore/secboot"
+	internal_crypto "github.com/snapcore/secboot/internal/crypto"
 )
 
 func computeV3PcrPolicyRefFromCounterName(name tpm2.Name) tpm2.Nonce {
@@ -54,7 +55,7 @@ func computeV3PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyNa
 // is used as an input key to derive various context-specific keys, such as this one.
 func deriveV3PolicyAuthKey(alg crypto.Hash, auxKey secboot.AuxiliaryKey) (*ecdsa.PrivateKey, error) {
 	r := hkdf.Expand(func() hash.Hash { return alg.New() }, auxKey, []byte("TPM2-POLICY-AUTH"))
-	return ecdsa.GenerateKey(elliptic.P256(), r)
+	return internal_crypto.GenerateECDSAKey(elliptic.P256(), r)
 }
 
 // staticPolicyData_v3 represents version 3 of the metadata for executing a


### PR DESCRIPTION
go 1.20 changed the behaviour of ecdsa.GenerateKey so that it no longer produces the same key given the same sequence of random bytes, and so that it is no longer even deterministic.

Work around this by reimplementing the ECDSA key generation based on FIPS186-4 section B.4.1.