### PR TITLE
efi: Fix a potential grub matching bug

### DIFF
--- a/efi/efi_test.go
+++ b/efi/efi_test.go
@@ -324,13 +324,13 @@ func newMockUbuntuShimImage15_7(c *C) *mockImage {
 func newMockUbuntuGrubImage1(c *C) *mockImage {
 	return newMockImage().
 		appendSignatures(efitest.ReadWinCertificateAuthenticodeDetached(c, grubUbuntuSig1)).
-		addSection(".mods", nil)
+		addSection("mods", nil)
 }
 
 func newMockUbuntuGrubImage2(c *C) *mockImage {
 	return newMockImage().
 		appendSignatures(efitest.ReadWinCertificateAuthenticodeDetached(c, grubUbuntuSig2)).
-		addSection(".mods", nil).
+		addSection("mods", nil).
 		withSbat([]SbatComponent{
 			{Name: "grub"},
 			{Name: "grub.ubuntu"},
@@ -340,7 +340,7 @@ func newMockUbuntuGrubImage2(c *C) *mockImage {
 func newMockUbuntuGrubImage3(c *C) *mockImage {
 	return newMockImage().
 		appendSignatures(efitest.ReadWinCertificateAuthenticodeDetached(c, grubUbuntuSig3)).
-		addSection(".mods", nil).
+		addSection("mods", nil).
 		withSbat([]SbatComponent{
 			{Name: "grub"},
 			{Name: "grub.ubuntu"},

--- a/efi/image_rules_defs.go
+++ b/efi/image_rules_defs.go
@@ -136,7 +136,7 @@ func makeMicrosoftUEFICASecureBootNamespaceRules() *secureBootNamespaceRules {
 					sbatComponentExists("grub.ubuntu"),
 				),
 				imageMatchesAll(
-					imageSectionExists(".mods"),
+					imageSectionExists("mods"),
 					imageSignedByOrganization("Canonical Ltd."),
 				),
 			),
@@ -149,7 +149,7 @@ func makeMicrosoftUEFICASecureBootNamespaceRules() *secureBootNamespaceRules {
 					sbatSectionExists,
 					sbatComponentExists("grub"),
 				),
-				imageSectionExists(".mods"),
+				imageSectionExists("mods"),
 			),
 			newGrubLoadHandler,
 		),
@@ -186,7 +186,7 @@ func makeFallbackImageRules() *imageRules {
 		// Grub
 		newImageRule(
 			"grub",
-			imageSectionExists(".mods"),
+			imageSectionExists("mods"),
 			newGrubLoadHandler,
 		),
 		// TODO: add rules for Ubuntu Core UKI and Ubuntu grub that are not part of


### PR DESCRIPTION
Grub's module section has the name "mods" rather than ".mods"