### PR TITLE
luks2: run luksKillSlot in batch mode

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -822,10 +822,9 @@ func ListLUKS2ContainerRecoveryKeyNames(devicePath string) ([]string, error) {
 }
 
 // DeleteLUKS2ContainerKey deletes the keyslot with the specified name from the
-// LUKS2 container at the specified path. An existing key associated with a different
-// keyslot must be supplied. This will return an error if the container only has a
-// single keyslot remaining.
-func DeleteLUKS2ContainerKey(devicePath, keyslotName string, existingKey DiskUnlockKey) error {
+// LUKS2 container at the specified path. This will return an error if the container
+// only has a single keyslot remaining.
+func DeleteLUKS2ContainerKey(devicePath, keyslotName string) error {
 	view, err := newLUKSView(devicePath, luks2.LockModeBlocking)
 	if err != nil {
 		return xerrors.Errorf("cannot obtain LUKS header view: %w", err)
@@ -847,7 +846,7 @@ func DeleteLUKS2ContainerKey(devicePath, keyslotName string, existingKey DiskUnl
 	removeOrphanedTokens(devicePath, view)
 
 	slot := token.Keyslots()[0]
-	if err := luks2KillSlot(devicePath, slot, existingKey); err != nil {
+	if err := luks2KillSlot(devicePath, slot); err != nil {
 		return xerrors.Errorf("cannot kill existing slot %d: %w", slot, err)
 	}
 

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -333,7 +333,7 @@ func (l *mockLUKS2) importToken(devicePath string, token luks2.Token, options *l
 	return nil
 }
 
-func (l *mockLUKS2) killSlot(devicePath string, slot int, key []byte) error {
+func (l *mockLUKS2) killSlot(devicePath string, slot int) error {
 	l.operations = append(l.operations, fmt.Sprint("KillSlot(", devicePath, ",", slot, ")"))
 
 	if slot < 0 {
@@ -347,26 +347,6 @@ func (l *mockLUKS2) killSlot(devicePath string, slot int, key []byte) error {
 
 	if _, exists := dev.keyslots[slot]; !exists {
 		return errors.New("no slot")
-	}
-
-	if len(dev.keyslots) == 1 {
-		if !bytes.Equal(key, dev.keyslots[slot]) {
-			return errors.New("invalid key")
-		}
-	} else {
-		found := false
-		for i, k := range dev.keyslots {
-			if i == slot {
-				continue
-			}
-			if bytes.Equal(key, k) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return errors.New("invalid key")
-		}
 	}
 
 	delete(dev.keyslots, slot)
@@ -3178,7 +3158,6 @@ type testDeleteLUKS2ContainerKeyData struct {
 	devicePath  string
 	dev         *mockLUKS2Container
 	keyslotName string
-	existingKey []byte
 	slot        int
 	tokenId     int
 }
@@ -3186,7 +3165,7 @@ type testDeleteLUKS2ContainerKeyData struct {
 func (s *cryptSuite) testDeleteLUKS2ContainerKey(c *C, data *testDeleteLUKS2ContainerKeyData) {
 	s.luks2.devices[data.devicePath] = data.dev
 
-	c.Check(DeleteLUKS2ContainerKey(data.devicePath, data.keyslotName, data.existingKey), IsNil)
+	c.Check(DeleteLUKS2ContainerKey(data.devicePath, data.keyslotName), IsNil)
 
 	c.Check(s.luks2.operations, DeepEquals, []string{
 		"newLUKSView(" + data.devicePath + ",0)",
@@ -3196,8 +3175,6 @@ func (s *cryptSuite) testDeleteLUKS2ContainerKey(c *C, data *testDeleteLUKS2Cont
 }
 
 func (s *cryptSuite) TestDeleteLUKS2ContainerKey(c *C) {
-	existingKey := s.newPrimaryKey()
-
 	s.testDeleteLUKS2ContainerKey(c, &testDeleteLUKS2ContainerKeyData{
 		devicePath: "/dev/sda1",
 		dev: &mockLUKS2Container{
@@ -3212,20 +3189,17 @@ func (s *cryptSuite) TestDeleteLUKS2ContainerKey(c *C) {
 						TokenName:    "default-recovery"}},
 			},
 			keyslots: map[int][]byte{
-				0: existingKey,
+				0: nil,
 				1: nil,
 			},
 		},
 		keyslotName: "default-recovery",
-		existingKey: existingKey,
 		slot:        1,
 		tokenId:     1,
 	})
 }
 
 func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentPath(c *C) {
-	existingKey := s.newPrimaryKey()
-
 	s.testDeleteLUKS2ContainerKey(c, &testDeleteLUKS2ContainerKeyData{
 		devicePath: "/dev/nvme0n1p1",
 		dev: &mockLUKS2Container{
@@ -3240,20 +3214,17 @@ func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentPath(c *C) {
 						TokenName:    "default-recovery"}},
 			},
 			keyslots: map[int][]byte{
-				0: existingKey,
+				0: nil,
 				1: nil,
 			},
 		},
 		keyslotName: "default-recovery",
-		existingKey: existingKey,
 		slot:        1,
 		tokenId:     1,
 	})
 }
 
 func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentName(c *C) {
-	existingKey := s.newPrimaryKey()
-
 	s.testDeleteLUKS2ContainerKey(c, &testDeleteLUKS2ContainerKeyData{
 		devicePath: "/dev/sda1",
 		dev: &mockLUKS2Container{
@@ -3268,20 +3239,17 @@ func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentName(c *C) {
 						TokenName:    "foo"}},
 			},
 			keyslots: map[int][]byte{
-				0: existingKey,
+				0: nil,
 				1: nil,
 			},
 		},
 		keyslotName: "foo",
-		existingKey: existingKey,
 		slot:        1,
 		tokenId:     1,
 	})
 }
 
 func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentKeyslot(c *C) {
-	existingKey := s.newPrimaryKey()
-
 	s.testDeleteLUKS2ContainerKey(c, &testDeleteLUKS2ContainerKeyData{
 		devicePath: "/dev/sda1",
 		dev: &mockLUKS2Container{
@@ -3296,20 +3264,17 @@ func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentKeyslot(c *C) {
 						TokenName:    "default-recovery"}},
 			},
 			keyslots: map[int][]byte{
-				0: existingKey,
+				0: nil,
 				2: nil,
 			},
 		},
 		keyslotName: "default-recovery",
-		existingKey: existingKey,
 		slot:        2,
 		tokenId:     1,
 	})
 }
 
 func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentTokenId(c *C) {
-	existingKey := s.newPrimaryKey()
-
 	s.testDeleteLUKS2ContainerKey(c, &testDeleteLUKS2ContainerKeyData{
 		devicePath: "/dev/sda1",
 		dev: &mockLUKS2Container{
@@ -3324,20 +3289,17 @@ func (s *cryptSuite) TestDeleteLUKS2ContainerKeyDifferentTokenId(c *C) {
 						TokenName:    "default-recovery"}},
 			},
 			keyslots: map[int][]byte{
-				0: existingKey,
+				0: nil,
 				1: nil,
 			},
 		},
 		keyslotName: "default-recovery",
-		existingKey: existingKey,
 		slot:        1,
 		tokenId:     4,
 	})
 }
 
 func (s *cryptSuite) TestDeleteLUKS2ContainerKeyLastSlot(c *C) {
-	existingKey := s.newPrimaryKey()
-
 	s.luks2.devices["/dev/sda1"] = &mockLUKS2Container{
 		tokens: map[int]luks2.Token{
 			0: &luksview.KeyDataToken{
@@ -3345,10 +3307,10 @@ func (s *cryptSuite) TestDeleteLUKS2ContainerKeyLastSlot(c *C) {
 					TokenKeyslot: 0,
 					TokenName:    "default"}},
 		},
-		keyslots: map[int][]byte{0: existingKey},
+		keyslots: map[int][]byte{0: nil},
 	}
 
-	c.Check(DeleteLUKS2ContainerKey("/dev/sda1", "default", existingKey), ErrorMatches, "cannot kill last remaining slot")
+	c.Check(DeleteLUKS2ContainerKey("/dev/sda1", "default"), ErrorMatches, "cannot kill last remaining slot")
 }
 
 type testRenameLUKS2ContainerKeyData struct {
@@ -3905,10 +3867,7 @@ func (s *cryptSuiteUnmockedExpensive) TestListLUKS2ContainerKeyName(c *C) {
 }
 
 type testDeleteLUKS2ContainerKeyUnmockedData struct {
-	key                   DiskUnlockKey
-	recoveryKey           RecoveryKey
 	name                  string
-	existingKey           DiskUnlockKey
 	expectedUnlockNames   []string
 	expectedRecoveryNames []string
 	expectedToken         luks2.Token
@@ -3917,13 +3876,14 @@ type testDeleteLUKS2ContainerKeyUnmockedData struct {
 func (s *cryptSuiteUnmocked) testDeleteLUKS2ContainerKey(c *C, data *testDeleteLUKS2ContainerKeyUnmockedData) {
 	path := luks2test.CreateEmptyDiskImage(c, 20)
 
-	c.Check(InitializeLUKS2Container(path, "data", data.key, nil), IsNil)
+	key := s.newPrimaryKey()
+	c.Check(InitializeLUKS2Container(path, "data", key, nil), IsNil)
 
 	var recoveryKey RecoveryKey
 	rand.Read(recoveryKey[:])
-	c.Check(AddLUKS2ContainerRecoveryKey(path, "", data.key, data.recoveryKey, &KDFOptions{MemoryKiB: 32, ForceIterations: 4}), IsNil)
+	c.Check(AddLUKS2ContainerRecoveryKey(path, "", key, recoveryKey, &KDFOptions{MemoryKiB: 32, ForceIterations: 4}), IsNil)
 
-	c.Check(DeleteLUKS2ContainerKey(path, data.name, data.existingKey), IsNil)
+	c.Check(DeleteLUKS2ContainerKey(path, data.name), IsNil)
 
 	names, err := ListLUKS2ContainerUnlockKeyNames(path)
 	c.Check(err, IsNil)
@@ -3951,14 +3911,8 @@ func (s *cryptSuiteUnmocked) testDeleteLUKS2ContainerKey(c *C, data *testDeleteL
 }
 
 func (s *cryptSuiteUnmocked) TestDeleteLUKS2ContainerKey1(c *C) {
-	key := s.newPrimaryKey()
-	recoveryKey := s.newRecoveryKey()
-
 	s.testDeleteLUKS2ContainerKey(c, &testDeleteLUKS2ContainerKeyUnmockedData{
-		key:                   key,
-		recoveryKey:           recoveryKey,
 		name:                  "default",
-		existingKey:           DiskUnlockKey(recoveryKey[:]),
 		expectedRecoveryNames: []string{"default-recovery"},
 		expectedToken: &luksview.RecoveryToken{
 			TokenBase: luksview.TokenBase{
@@ -3967,14 +3921,8 @@ func (s *cryptSuiteUnmocked) TestDeleteLUKS2ContainerKey1(c *C) {
 }
 
 func (s *cryptSuiteUnmocked) TestDeleteLUKS2ContainerKey2(c *C) {
-	key := s.newPrimaryKey()
-	recoveryKey := s.newRecoveryKey()
-
 	s.testDeleteLUKS2ContainerKey(c, &testDeleteLUKS2ContainerKeyUnmockedData{
-		key:                 key,
-		recoveryKey:         recoveryKey,
 		name:                "default-recovery",
-		existingKey:         key,
 		expectedUnlockNames: []string{"default"},
 		expectedToken: &luksview.KeyDataToken{
 			TokenBase: luksview.TokenBase{

--- a/export_test.go
+++ b/export_test.go
@@ -70,7 +70,7 @@ func MockLUKS2ImportToken(fn func(string, luks2.Token, *luks2.ImportTokenOptions
 	}
 }
 
-func MockLUKS2KillSlot(fn func(string, int, []byte) error) (restore func()) {
+func MockLUKS2KillSlot(fn func(string, int) error) (restore func()) {
 	origKillSlot := luks2KillSlot
 	luks2KillSlot = fn
 	return func() {

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -436,12 +436,11 @@ func RemoveToken(devicePath string, id int) error {
 }
 
 // KillSlot erases the keyslot with the supplied slot number from the specified LUKS2 container.
-// Note that a valid key for a remaining keyslot must be supplied.
 //
-// WARNING: This function will remove the last keyslot if the key associated with it
-// is supplied, which will make the encrypted data permanently inaccessible.
-func KillSlot(devicePath string, slot int, key []byte) error {
-	return cryptsetupCmd(bytes.NewReader(key), "luksKillSlot", "--type", "luks2", "--key-file", "-", devicePath, strconv.Itoa(slot))
+// WARNING: This function will remove the last keyslot if there is only one left,
+// which will make the encrypted data permanently inaccessible.
+func KillSlot(devicePath string, slot int) error {
+	return cryptsetupCmd(nil, "luksKillSlot", "--batch-mode", "--type", "luks2", devicePath, strconv.Itoa(slot))
 }
 
 // SetSlotPriority sets the priority of the keyslot with the supplied slot number on

--- a/internal/luksview/tokens_test.go
+++ b/internal/luksview/tokens_test.go
@@ -147,7 +147,7 @@ func (s *tokenSuite) TestDecodeOrphanedRecoveryToken(c *C) {
 			TokenName:    "recovery",
 			TokenKeyslot: 0}}
 	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
-	c.Check(luks2.KillSlot(path, 0, make([]byte, 32)), IsNil)
+	c.Check(luks2.KillSlot(path, 0), IsNil)
 
 	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
 	c.Assert(err, IsNil)
@@ -304,7 +304,7 @@ func (s *tokenSuite) TestDecodeOrphanedKeyDataToken(c *C) {
 			TokenName:    "bar",
 			TokenKeyslot: 0}}
 	c.Check(luks2.ImportToken(path, createToken, nil), IsNil)
-	c.Check(luks2.KillSlot(path, 0, make([]byte, 32)), IsNil)
+	c.Check(luks2.KillSlot(path, 0), IsNil)
 
 	header, err := luks2.ReadHeader(path, luks2.LockModeNonBlocking)
 	c.Assert(err, IsNil)

--- a/internal/luksview/view_test.go
+++ b/internal/luksview/view_test.go
@@ -249,7 +249,7 @@ func (s *viewSuite) TestViewReread(c *C) {
 			TokenName:    "foo",
 			TokenKeyslot: 2}}
 	c.Check(luks2.ImportToken(path, token2, nil), IsNil)
-	c.Check(luks2.KillSlot(path, 2, make([]byte, 32)), IsNil)
+	c.Check(luks2.KillSlot(path, 2), IsNil)
 
 	c.Check(view.Reread(), IsNil)
 


### PR DESCRIPTION
We currently don't run luksKillSlot in batch mode, which means that
we need to supply an existing key in order to delete a keyslot.
Cryptsetup requires this to be for another keyslot unless the last
keyslot is being deleted, so it doesn't provide any protections to
prevent deletion of the last keyslot. It is intended to ensure that
a user who deletes a keyslot still knows a passphrase for another
keyslot.

The fdemanager service will have an endpoint to delete a keyslot, but
the API does not require an unlock key because unlock keys aren't
something users will generally interact with. In this case, the service
will grab the key used to unlock the device on the current boot from
the kernel and pass this to secboot, so not running luksKillSlot in
batch mode actually doesn't offer any safety barriers. Secboot already
has its own check to prevent deletion of the last keyslot, something
which luksKillSlot doesn't prevent on its own anyway - it prompts the
user when stdin is a tty, but that's not the case for us.