### PR TITLE
[3/3] Keydata v3 TPM platform changes

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -20,8 +20,6 @@
 package secboot
 
 import (
-	"bytes"
-	"encoding/binary"
 	"io"
 
 	"github.com/snapcore/secboot/internal/luks2"
@@ -149,15 +147,4 @@ func MockHashAlgAvailable() (restore func()) {
 
 func (d *KeyData) DerivePassphraseKeys(passphrase string, kdf KDF) (key, iv, auth []byte, err error) {
 	return d.derivePassphraseKeys(passphrase, kdf)
-}
-
-// MarshalV1Keys serializes the supplied disk unlock key and auxiliary key in
-// the v1 format that is ready to be encrypted by a platform's secure device.
-func MarshalV1Keys(key DiskUnlockKey, auxKey PrimaryKey) []byte {
-	w := new(bytes.Buffer)
-	binary.Write(w, binary.BigEndian, uint16(len(key)))
-	w.Write(key)
-	binary.Write(w, binary.BigEndian, uint16(len(auxKey)))
-	w.Write(auxKey)
-	return w.Bytes()
 }

--- a/export_test.go
+++ b/export_test.go
@@ -31,7 +31,6 @@ import (
 var (
 	UnmarshalV1KeyPayload  = unmarshalV1KeyPayload
 	UnmarshalProtectedKeys = unmarshalProtectedKeys
-	KeyDataGeneration      = keyDataGeneration
 )
 
 type ProtectedKeys = protectedKeys
@@ -131,10 +130,10 @@ func MockStderr(w io.Writer) (restore func()) {
 }
 
 func MockKeyDataGeneration(n int) (restore func()) {
-	orig := keyDataGeneration
-	keyDataGeneration = n
+	orig := KeyDataGeneration
+	KeyDataGeneration = n
 	return func() {
-		keyDataGeneration = orig
+		KeyDataGeneration = orig
 	}
 }
 

--- a/keydata.go
+++ b/keydata.go
@@ -48,12 +48,12 @@ const (
 )
 
 var (
-	keyDataGeneration int = 2
-	sha1Oid               = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
-	sha224Oid             = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 4}
-	sha256Oid             = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
-	sha384Oid             = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
-	sha512Oid             = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
+	KeyDataGeneration = 2
+	sha1Oid           = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
+	sha224Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 4}
+	sha256Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
+	sha384Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
+	sha512Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
 )
 
 // ErrNoPlatformHandlerRegistered is returned from KeyData methods if no
@@ -715,7 +715,7 @@ func NewKeyData(params *KeyParams) (*KeyData, error) {
 
 	kd := &KeyData{
 		data: keyData{
-			Generation:       keyDataGeneration,
+			Generation:       KeyDataGeneration,
 			PlatformName:     params.PlatformName,
 			Role:             params.Role,
 			PlatformHandle:   json.RawMessage(encodedHandle),

--- a/keydata.go
+++ b/keydata.go
@@ -20,13 +20,11 @@
 package secboot
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/asn1"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -843,15 +841,4 @@ func MakeDiskUnlockKey(rand io.Reader, alg crypto.Hash, primaryKey PrimaryKey) (
 	}
 
 	return pk.unlockKey(alg), cleartextPayload, nil
-}
-
-// MarshalKeys serializes the supplied disk unlock key and auxiliary key in
-// to a format that is ready to be encrypted by a platform's secure device.
-func MarshalKeys(key DiskUnlockKey, auxKey PrimaryKey) []byte {
-	w := new(bytes.Buffer)
-	binary.Write(w, binary.BigEndian, uint16(len(key)))
-	w.Write(key)
-	binary.Write(w, binary.BigEndian, uint16(len(auxKey)))
-	w.Write(auxKey)
-	return w.Bytes()
 }

--- a/keydata.go
+++ b/keydata.go
@@ -46,22 +46,29 @@ const (
 )
 
 var (
-	KeyDataGeneration = 2
-	sha1Oid           = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
-	sha224Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 4}
-	sha256Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
-	sha384Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
-	sha512Oid         = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
+	sha1Oid   = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
+	sha224Oid = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 4}
+	sha256Oid = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
+	sha384Oid = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
+	sha512Oid = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
 )
 
-// ErrNoPlatformHandlerRegistered is returned from KeyData methods if no
-// appropriate platform handler is registered using the
-// RegisterPlatformKeyDataHandler API.
-var ErrNoPlatformHandlerRegistered = errors.New("no appropriate platform handler is registered")
+var (
+	// KeyDataGeneration describes the generation number of new keys created by NewKeyData.
+	// This will be supplied via PlatformKeyDataHandler and should generally be
+	// authenticated by the platform code in order to protect against future key format
+	// changes that might have security relevant implications.
+	KeyDataGeneration = 2
 
-// ErrInvalidPassphrase is returned from KeyData methods that require
-// knowledge of a passphrase is the supplied passphrase is incorrect.
-var ErrInvalidPassphrase = errors.New("the supplied passphrase is incorrect")
+	// ErrNoPlatformHandlerRegistered is returned from KeyData methods if no
+	// appropriate platform handler is registered using the
+	// RegisterPlatformKeyDataHandler API.
+	ErrNoPlatformHandlerRegistered = errors.New("no appropriate platform handler is registered")
+
+	// ErrInvalidPassphrase is returned from KeyData methods that require
+	// knowledge of a passphrase is the supplied passphrase is incorrect.
+	ErrInvalidPassphrase = errors.New("the supplied passphrase is incorrect")
+)
 
 // InvalidKeyDataError is returned from KeyData methods if the key data
 // is invalid in some way.

--- a/keydata_legacy_test.go
+++ b/keydata_legacy_test.go
@@ -42,7 +42,7 @@ func (s *keyDataLegacyTestBase) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKe
 }
 
 func (s *keyDataLegacyTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey PrimaryKey, kdfAlg crypto.Hash, modelAuthHash crypto.Hash) (out *KeyParams) {
-	payload := MarshalKeys(key, auxKey)
+	payload := MarshalV1Keys(key, auxKey)
 
 	k := make([]byte, 48)
 	_, err := rand.Read(k)
@@ -83,7 +83,7 @@ type testLegacyKeyPayloadData struct {
 }
 
 func (s *keyDataLegacySuite) testKeyPayload(c *C, data *testLegacyKeyPayloadData) {
-	payload := MarshalKeys(data.key, data.auxKey)
+	payload := MarshalV1Keys(data.key, data.auxKey)
 
 	key, auxKey, err := UnmarshalV1KeyPayload(payload)
 	c.Check(err, IsNil)
@@ -127,7 +127,7 @@ func (s *keyDataLegacySuite) TestLegacyKeyPayloadUnmarshalInvalid1(c *C) {
 }
 
 func (s *keyDataLegacySuite) TestLegacyKeyPayloadUnmarshalInvalid2(c *C) {
-	payload := MarshalKeys(make(DiskUnlockKey, 32), make(PrimaryKey, 32))
+	payload := MarshalV1Keys(make(DiskUnlockKey, 32), make(PrimaryKey, 32))
 	payload = append(payload, 0xff)
 
 	key, auxKey, err := UnmarshalV1KeyPayload(payload)

--- a/keydata_legacy_test.go
+++ b/keydata_legacy_test.go
@@ -1,16 +1,29 @@
 package secboot_test
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
+	"encoding/binary"
 	"hash"
 	"math/rand"
 
 	. "github.com/snapcore/secboot"
 	. "gopkg.in/check.v1"
 )
+
+// marshalV1Keys serializes the supplied disk unlock key and auxiliary key in
+// the v1 format that is ready to be encrypted by a platform's secure device.
+func marshalV1Keys(key DiskUnlockKey, auxKey PrimaryKey) []byte {
+	w := new(bytes.Buffer)
+	binary.Write(w, binary.BigEndian, uint16(len(key)))
+	w.Write(key)
+	binary.Write(w, binary.BigEndian, uint16(len(auxKey)))
+	w.Write(auxKey)
+	return w.Bytes()
+}
 
 type keyDataLegacyTestBase struct {
 	keyDataTestBase
@@ -42,7 +55,7 @@ func (s *keyDataLegacyTestBase) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKe
 }
 
 func (s *keyDataLegacyTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey PrimaryKey, kdfAlg crypto.Hash, modelAuthHash crypto.Hash) (out *KeyParams) {
-	payload := MarshalV1Keys(key, auxKey)
+	payload := marshalV1Keys(key, auxKey)
 
 	k := make([]byte, 48)
 	_, err := rand.Read(k)
@@ -83,7 +96,7 @@ type testLegacyKeyPayloadData struct {
 }
 
 func (s *keyDataLegacySuite) testKeyPayload(c *C, data *testLegacyKeyPayloadData) {
-	payload := MarshalV1Keys(data.key, data.auxKey)
+	payload := marshalV1Keys(data.key, data.auxKey)
 
 	key, auxKey, err := UnmarshalV1KeyPayload(payload)
 	c.Check(err, IsNil)
@@ -127,7 +140,7 @@ func (s *keyDataLegacySuite) TestLegacyKeyPayloadUnmarshalInvalid1(c *C) {
 }
 
 func (s *keyDataLegacySuite) TestLegacyKeyPayloadUnmarshalInvalid2(c *C) {
-	payload := MarshalV1Keys(make(DiskUnlockKey, 32), make(PrimaryKey, 32))
+	payload := marshalV1Keys(make(DiskUnlockKey, 32), make(PrimaryKey, 32))
 	payload = append(payload, 0xff)
 
 	key, auxKey, err := UnmarshalV1KeyPayload(payload)

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -1328,7 +1328,7 @@ func (s *keyDataSuite) TestLegacyKeyPayloadUnmarshalInvalid1(c *C) {
 }
 
 func (s *keyDataSuite) TestLegacyKeyPayloadUnmarshalInvalid2(c *C) {
-	payload := MarshalV1Keys(make(DiskUnlockKey, 32), make(PrimaryKey, 32))
+	payload := marshalV1Keys(make(DiskUnlockKey, 32), make(PrimaryKey, 32))
 	payload = append(payload, 0xff)
 
 	key, auxKey, err := UnmarshalV1KeyPayload(payload)

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -20,11 +20,7 @@
 package tpm2
 
 import (
-	"errors"
-
 	"github.com/canonical/go-tpm2"
-	"golang.org/x/crypto/cryptobyte"
-	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 
 	"github.com/snapcore/secboot"
 )
@@ -267,27 +263,4 @@ func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authKey secboot.P
 	}
 
 	return k.Validate(tpm, authKey, session)
-}
-
-type protectedKeys struct {
-	Primary secboot.PrimaryKey
-	Unique  []byte
-}
-
-func UnmarshalProtectedKeys(data []byte) (*protectedKeys, error) {
-	s := cryptobyte.String(data)
-	if !s.ReadASN1(&s, cryptobyte_asn1.SEQUENCE) {
-		return nil, errors.New("malformed input")
-	}
-
-	pk := new(protectedKeys)
-
-	if !s.ReadASN1Bytes((*[]byte)(&pk.Primary), cryptobyte_asn1.OCTET_STRING) {
-		return nil, errors.New("malformed primary key")
-	}
-	if !s.ReadASN1Bytes(&pk.Unique, cryptobyte_asn1.OCTET_STRING) {
-		return nil, errors.New("malformed unique key")
-	}
-
-	return pk, nil
 }

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -31,8 +31,9 @@ import (
 
 // Export constants for testing
 const (
-	LockNVHandle      = lockNVHandle
-	SrkTemplateHandle = srkTemplateHandle
+	LockNVHandle          = lockNVHandle
+	ResetPcrPolicyVersion = resetPcrPolicyVersion
+	SrkTemplateHandle     = srkTemplateHandle
 )
 
 // Export variables and unexported functions for testing
@@ -87,6 +88,7 @@ func NewSealedObjectKeySealer(tpm *Connection) keySealer {
 	return &sealedObjectKeySealer{tpm}
 }
 
+type PcrPolicyVersionOption = pcrPolicyVersionOption
 type PolicyDataError = policyDataError
 type PolicyOrData_v0 = policyOrData_v0
 
@@ -226,7 +228,7 @@ func MockSecbootNewKeyDataWithPassphrase(fn func(*secboot.KeyWithPassphraseParam
 	}
 }
 
-func MockSkdbUpdatePCRProtectionPolicyNoValidate(fn func(*sealedKeyDataBase, *tpm2.TPMContext, secboot.PrimaryKey, *tpm2.NVPublic, *PCRProtectionProfile, bool, tpm2.SessionContext) error) (restore func()) {
+func MockSkdbUpdatePCRProtectionPolicyNoValidate(fn func(*sealedKeyDataBase, *tpm2.TPMContext, secboot.PrimaryKey, *tpm2.NVPublic, *PCRProtectionProfile, PcrPolicyVersionOption, tpm2.SessionContext) error) (restore func()) {
 	orig := skdbUpdatePCRProtectionPolicyNoValidate
 	skdbUpdatePCRProtectionPolicyNoValidate = fn
 	return func() {

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -43,7 +43,7 @@ var (
 	EnsurePcrPolicyCounter                  = ensurePcrPolicyCounter
 	ComputeV1PcrPolicyRefFromCounterName    = computeV1PcrPolicyRefFromCounterName
 	ComputeV3PcrPolicyCounterAuthPolicies   = computeV3PcrPolicyCounterAuthPolicies
-	ComputeV3PcrPolicyRefFromCounterName    = computeV3PcrPolicyRefFromCounterName
+	ComputeV3PcrPolicyRef                   = computeV3PcrPolicyRef
 	ComputeSnapModelDigest                  = computeSnapModelDigest
 	DeriveV3PolicyAuthKey                   = deriveV3PolicyAuthKey
 	ErrSessionDigestNotFound                = errSessionDigestNotFound

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -123,12 +123,14 @@ type PcrPolicyData_v3 = pcrPolicyData_v3
 
 type PcrPolicyParams = pcrPolicyParams
 
-func NewPcrPolicyParams(key secboot.PrimaryKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name) *PcrPolicyParams {
+func NewPcrPolicyParams(key secboot.PrimaryKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name, policySequence uint64) *PcrPolicyParams {
 	return &PcrPolicyParams{
 		key:               key,
 		pcrs:              pcrs,
 		pcrDigests:        pcrDigests,
-		policyCounterName: policyCounterName}
+		policyCounterName: policyCounterName,
+		policySequence:    policySequence,
+	}
 }
 
 type PlatformKeyDataHandler = platformKeyDataHandler

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -76,7 +76,7 @@ type keyData interface {
 	// ValidateData performs consistency checks on the key data,
 	// returning a validated context for the PCR policy counter, if
 	// one is defined.
-	ValidateData(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.ResourceContext, error)
+	ValidateData(tpm *tpm2.TPMContext, role []byte, session tpm2.SessionContext) (tpm2.ResourceContext, error)
 
 	// Write serializes the key data to w
 	Write(w io.Writer) error
@@ -161,7 +161,7 @@ func (k *sealedKeyDataBase) load(tpm *tpm2.TPMContext, parent tpm2.ResourceConte
 }
 
 // validateData performs correctness checks on this object.
-func (k *sealedKeyDataBase) validateData(tpm *tpm2.TPMContext, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
+func (k *sealedKeyDataBase) validateData(tpm *tpm2.TPMContext, role string, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
 	sealedKeyTemplate := makeImportableSealedKeyTemplate()
 
 	// Perform some initial checks on the sealed data object's public area to
@@ -190,7 +190,7 @@ func (k *sealedKeyDataBase) validateData(tpm *tpm2.TPMContext, session tpm2.Sess
 	tpm.FlushContext(keyContext)
 
 	// Version specific validation.
-	pcrPolicyCounter, err := k.data.ValidateData(tpm, session)
+	pcrPolicyCounter, err := k.data.ValidateData(tpm, []byte(role), session)
 	if err != nil {
 		return nil, err
 	}

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -83,6 +83,10 @@ type keyData interface {
 
 	// Policy corresponds to the authorization policy for this key data.
 	Policy() keyDataPolicy
+
+	// Decrypt performs authenticated decryption of the encrypted payload and the associated data.
+	// This is relevant only for keydata versions 3 and later.
+	Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error)
 }
 
 func readKeyData(r io.Reader, version uint32) (keyData, error) {

--- a/tpm2/keydata.go
+++ b/tpm2/keydata.go
@@ -86,7 +86,7 @@ type keyData interface {
 
 	// Decrypt performs authenticated decryption of the encrypted payload and the associated data.
 	// This is relevant only for keydata versions 3 and later.
-	Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error)
+	Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error)
 }
 
 func readKeyData(r io.Reader, version uint32) (keyData, error) {

--- a/tpm2/keydata_v0.go
+++ b/tpm2/keydata_v0.go
@@ -28,6 +28,7 @@ import (
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
 	"github.com/canonical/go-tpm2/util"
+	"github.com/snapcore/secboot"
 
 	"golang.org/x/xerrors"
 )
@@ -199,4 +200,8 @@ func (d *keyData_v0) Write(w io.Writer) error {
 
 func (d *keyData_v0) Policy() keyDataPolicy {
 	return d.PolicyData
+}
+
+func (d *keyData_v0) Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v0.go
+++ b/tpm2/keydata_v0.go
@@ -101,7 +101,11 @@ func (_ *keyData_v0) Imported(_ tpm2.Private) {
 	panic("not supported")
 }
 
-func (d *keyData_v0) ValidateData(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
+func (d *keyData_v0) ValidateData(tpm *tpm2.TPMContext, role []byte, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
+	if len(role) > 0 {
+		return nil, errors.New("unexpected role")
+	}
+
 	// Obtain the name of the legacy lock NV index.
 	lockNV, err := tpm.CreateResourceContextFromTPM(lockNVHandle, session.IncludeAttrs(tpm2.AttrAudit))
 	if err != nil {

--- a/tpm2/keydata_v0.go
+++ b/tpm2/keydata_v0.go
@@ -206,6 +206,6 @@ func (d *keyData_v0) Policy() keyDataPolicy {
 	return d.PolicyData
 }
 
-func (d *keyData_v0) Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+func (d *keyData_v0) Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
 	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v0_test.go
+++ b/tpm2/keydata_v0_test.go
@@ -124,7 +124,7 @@ func (s *keyDataV0Suite) TestValidateOK1(c *C) {
 	data, expectedPcrPolicyCounter := s.newMockKeyData(c, s.NextAvailableHandle(c, 0x01800000))
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, session)
+	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, IsNil)
 	c.Check(pcrPolicyCounter.Name(), DeepEquals, expectedPcrPolicyCounter.Name())
 }
@@ -133,7 +133,7 @@ func (s *keyDataV0Suite) TestValidateOK2(c *C) {
 	data, expectedPcrPolicyCounter := s.newMockKeyData(c, s.NextAvailableHandle(c, 0x018ff000))
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, session)
+	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, IsNil)
 	c.Check(pcrPolicyCounter.Name(), DeepEquals, expectedPcrPolicyCounter.Name())
 }
@@ -146,7 +146,7 @@ func (s *keyDataV0Suite) TestValidateNoLockIndex(c *C) {
 	c.Check(s.TPM().NVUndefineSpace(s.TPM().OwnerHandleContext(), index, nil), IsNil)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err = data.ValidateData(s.TPM().TPMContext, session)
+	_, err = data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "lock NV index is unavailable")
 }
@@ -157,7 +157,7 @@ func (s *keyDataV0Suite) TestValidateInvalidAuthPublicKeyNameAlg(c *C) {
 	data.(*KeyData_v0).PolicyData.StaticData.AuthPublicKey.NameAlg = tpm2.HashAlgorithmNull
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "cannot compute name of dynamic authorization policy key: unsupported name algorithm or algorithm not linked into binary: TPM_ALG_NULL")
 }
@@ -168,7 +168,7 @@ func (s *keyDataV0Suite) TestValidateInvalidAuthPublicKeyType(c *C) {
 	data.(*KeyData_v0).PolicyData.StaticData.AuthPublicKey.Type = tpm2.ObjectTypeECC
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "public area of dynamic authorization policy signing key has the wrong type")
 }
@@ -182,7 +182,7 @@ func (s *keyDataV0Suite) TestValidateInvalidAuthPublicKeyScheme(c *C) {
 			RSASSA: &tpm2.SigSchemeRSASSA{HashAlg: tpm2.HashAlgorithmSHA256}}}
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "dynamic authorization policy signing key has unexpected scheme")
 }
@@ -193,7 +193,7 @@ func (s *keyDataV0Suite) TestValidateInvalidPolicyCounterHandle(c *C) {
 	data.(*KeyData_v0).PolicyData.StaticData.PCRPolicyCounterHandle = 0x81000000
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter handle is invalid")
 }
@@ -206,7 +206,7 @@ func (s *keyDataV0Suite) TestValidateNoPolicyCounter(c *C) {
 	c.Check(s.TPM().NVUndefineSpace(s.TPM().OwnerHandleContext(), index, nil), IsNil)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err = data.ValidateData(s.TPM().TPMContext, session)
+	_, err = data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter is unavailable")
 }
@@ -217,7 +217,7 @@ func (s *keyDataV0Suite) TestValidateInvalidSealedObjectNameAlg(c *C) {
 	data.Public().NameAlg = tpm2.HashAlgorithmNull
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "cannot determine if static authorization policy matches sealed key object: algorithm unavailable")
 }
@@ -230,7 +230,7 @@ func (s *keyDataV0Suite) TestValidateWrongAuthKey(c *C) {
 	data.(*KeyData_v0).PolicyData.StaticData.AuthPublicKey = util.NewExternalRSAPublicKeyWithDefaults(templates.KeyUsageSign, &authKey.PublicKey)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err = data.ValidateData(s.TPM().TPMContext, session)
+	_, err = data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
@@ -251,7 +251,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounter(c *C) {
 	s.NVDefineSpace(c, tpm2.HandleOwner, nil, &nvPub)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err = data.ValidateData(s.TPM().TPMContext, session)
+	_, err = data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
@@ -271,7 +271,7 @@ func (s *keyDataV0Suite) TestValidateWrongLockIndex(c *C) {
 	s.NVDefineSpace(c, tpm2.HandleOwner, nil, &nvPub)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err = data.ValidateData(s.TPM().TPMContext, session)
+	_, err = data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")
 }
@@ -282,7 +282,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounterAuthPolicies1(c *C) {
 	data.(*KeyData_v0).PolicyData.StaticData.PCRPolicyCounterAuthPolicies = data.(*KeyData_v0).PolicyData.StaticData.PCRPolicyCounterAuthPolicies[1:]
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "unexpected number of OR policy digests for PCR policy counter")
 }
@@ -293,7 +293,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounterAuthPolicies2(c *C) {
 	copy(data.(*KeyData_v0).PolicyData.StaticData.PCRPolicyCounterAuthPolicies[1], make([]byte, 32))
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "unexpected OR policy digest for PCR policy counter")
 }
@@ -304,7 +304,7 @@ func (s *keyDataV0Suite) TestValidateWrongPolicyCounterAuthPolicies3(c *C) {
 	copy(data.(*KeyData_v0).PolicyData.StaticData.PCRPolicyCounterAuthPolicies[0], make([]byte, 32))
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, testutil.ConvertibleTo, KeyDataError{})
 	c.Check(err, ErrorMatches, "PCR policy counter has unexpected authorization policy")
 }
@@ -318,4 +318,11 @@ func (s *keyDataV0Suite) TestSerialization(c *C) {
 	data2, err := ReadKeyDataV0(buf)
 	c.Assert(err, IsNil)
 	c.Check(data2, DeepEquals, data1)
+}
+
+func (s *keyDataV0Suite) TestValidateInvalidRoleSupplied(c *C) {
+	data, _ := s.newMockKeyData(c, s.NextAvailableHandle(c, 0x01800000))
+
+	_, err := data.ValidateData(s.TPM().TPMContext, []byte("foo"), nil)
+	c.Check(err, ErrorMatches, "unexpected role")
 }

--- a/tpm2/keydata_v0_test.go
+++ b/tpm2/keydata_v0_test.go
@@ -74,11 +74,11 @@ func (s *keyDataV0Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 
 	template := tpm2_testutil.NewSealedObjectTemplate()
 
-	policyData, policy := s.newMockKeyDataPolicy(c, template.NameAlg, authKeyPublic, policyCounter, count, policyCounterPolicies)
+	policyData, policy := s.newMockKeyDataPolicy(c, template.NameAlg, authKeyPublic, policyCounter, policyCounterPolicies)
 	template.AuthPolicy = policy
 
 	policyData.(*KeyDataPolicy_v0).PCRData = &PcrPolicyData_v0{
-		PolicySequence:   policyData.PCRPolicySequence(),
+		PolicySequence:   count,
 		AuthorizedPolicy: make(tpm2.Digest, 32),
 		AuthorizedPolicySignature: &tpm2.Signature{
 			SigAlg: tpm2.SigSchemeAlgRSAPSS,

--- a/tpm2/keydata_v1.go
+++ b/tpm2/keydata_v1.go
@@ -68,7 +68,11 @@ func (_ *keyData_v1) Imported(_ tpm2.Private) {
 	panic("not supported")
 }
 
-func (d *keyData_v1) ValidateData(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
+func (d *keyData_v1) ValidateData(tpm *tpm2.TPMContext, role []byte, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
+	if len(role) > 0 {
+		return nil, errors.New("unexpected role")
+	}
+
 	// Validate the type and scheme of the dynamic authorization policy signing key.
 	authPublicKey := d.PolicyData.StaticData.AuthPublicKey
 	authKeyName, err := authPublicKey.ComputeName()

--- a/tpm2/keydata_v1.go
+++ b/tpm2/keydata_v1.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
 	"github.com/canonical/go-tpm2/util"
+	"github.com/snapcore/secboot"
 
 	"golang.org/x/xerrors"
 )
@@ -125,4 +126,8 @@ func (d *keyData_v1) Write(w io.Writer) error {
 
 func (d *keyData_v1) Policy() keyDataPolicy {
 	return d.PolicyData
+}
+
+func (d *keyData_v1) Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v1.go
+++ b/tpm2/keydata_v1.go
@@ -132,6 +132,6 @@ func (d *keyData_v1) Policy() keyDataPolicy {
 	return d.PolicyData
 }
 
-func (d *keyData_v1) Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+func (d *keyData_v1) Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
 	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v2.go
+++ b/tpm2/keydata_v2.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
+	"github.com/snapcore/secboot"
 )
 
 // keyData_v2 represents version 2 of keyData.
@@ -109,4 +110,8 @@ func (d *keyData_v2) Write(w io.Writer) error {
 
 func (d *keyData_v2) Policy() keyDataPolicy {
 	return d.PolicyData
+}
+
+func (d *keyData_v2) Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+	return nil, errors.New("not supported")
 }

--- a/tpm2/keydata_v2.go
+++ b/tpm2/keydata_v2.go
@@ -89,11 +89,11 @@ func (d *keyData_v2) Imported(priv tpm2.Private) {
 	d.KeyImportSymSeed = nil
 }
 
-func (d *keyData_v2) ValidateData(tpm *tpm2.TPMContext, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
+func (d *keyData_v2) ValidateData(tpm *tpm2.TPMContext, role []byte, session tpm2.SessionContext) (tpm2.ResourceContext, error) {
 	if d.KeyImportSymSeed != nil {
 		return nil, errors.New("cannot validate importable key data")
 	}
-	return d.AsV1().ValidateData(tpm, session)
+	return d.AsV1().ValidateData(tpm, role, session)
 }
 
 func (d *keyData_v2) Write(w io.Writer) error {

--- a/tpm2/keydata_v2_test.go
+++ b/tpm2/keydata_v2_test.go
@@ -192,7 +192,7 @@ func (s *keyDataV2Suite) TestValidateImportable(c *C) {
 	data := s.newMockImportableKeyData(c)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	_, err := data.ValidateData(s.TPM().TPMContext, session)
+	_, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, ErrorMatches, "cannot validate importable key data")
 }
 
@@ -200,7 +200,7 @@ func (s *keyDataV2Suite) TestValidateOK1(c *C) {
 	data, _ := s.newMockKeyData(c, tpm2.HandleNull)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, session)
+	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, IsNil)
 	c.Check(pcrPolicyCounter, IsNil)
 }
@@ -209,7 +209,7 @@ func (s *keyDataV2Suite) TestValidateOK2(c *C) {
 	data, pcrPolicyCounterName := s.newMockKeyData(c, s.NextAvailableHandle(c, 0x01800000))
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, session)
+	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, IsNil)
 	c.Check(pcrPolicyCounter.Name(), DeepEquals, pcrPolicyCounterName)
 }
@@ -218,7 +218,7 @@ func (s *keyDataV2Suite) TestValidateOK3(c *C) {
 	data, pcrPolicyCounterName := s.newMockKeyData(c, s.NextAvailableHandle(c, 0x0180ff00))
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, session)
+	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, IsNil)
 	c.Check(pcrPolicyCounter.Name(), DeepEquals, pcrPolicyCounterName)
 }
@@ -232,7 +232,7 @@ func (s *keyDataV2Suite) TestValidateImportedOK(c *C) {
 	data.Imported(priv)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypeHMAC, nil, tpm2.HashAlgorithmSHA256).WithAttrs(tpm2.AttrContinueSession)
-	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, session)
+	pcrPolicyCounter, err := data.ValidateData(s.TPM().TPMContext, nil, session)
 	c.Check(err, IsNil)
 	c.Check(pcrPolicyCounter, IsNil)
 }
@@ -281,4 +281,11 @@ func (s *keyDataV2Suite) TestReadNonImportableAsV2Fails(c *C) {
 		"... tpm2.keyDataPolicy_v1 field StaticData\n"+
 		"... tpm2.keyData_v2 field PolicyData\n"+
 		"=== END STACK ===\n")
+}
+
+func (s *keyDataV2Suite) TestValidateInvalidRoleSupplied(c *C) {
+	data, _ := s.newMockKeyData(c, s.NextAvailableHandle(c, 0x01800000))
+
+	_, err := data.ValidateData(s.TPM().TPMContext, []byte("foo"), nil)
+	c.Check(err, ErrorMatches, "unexpected role")
 }

--- a/tpm2/keydata_v3.go
+++ b/tpm2/keydata_v3.go
@@ -35,13 +35,13 @@ import (
 )
 
 type additionalData_v3 struct {
-	BaseVersion uint32
-	KDFAlg      tpm2.HashAlgorithmId
-	AuthMode    secboot.AuthMode
+	Generation uint32
+	KDFAlg     tpm2.HashAlgorithmId
+	AuthMode   secboot.AuthMode
 }
 
 func (d additionalData_v3) Marshal(w io.Writer) error {
-	_, err := mu.MarshalToWriter(w, uint32(3), d.BaseVersion, d.KDFAlg, d.AuthMode)
+	_, err := mu.MarshalToWriter(w, uint32(3), d.Generation, d.KDFAlg, d.AuthMode)
 	return err
 }
 
@@ -165,16 +165,16 @@ func (d *keyData_v3) Policy() keyDataPolicy {
 	return d.PolicyData
 }
 
-func (d *keyData_v3) Decrypt(key, payload []byte, baseVersion uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
+func (d *keyData_v3) Decrypt(key, payload []byte, generation uint32, kdfAlg tpm2.HashAlgorithmId, authMode secboot.AuthMode) ([]byte, error) {
 	// We only support AES-256-GCM with a 12-byte nonce, so we expect 44 bytes here
 	if len(key) != 32+12 {
 		return nil, errors.New("invalid symmetric key size")
 	}
 
 	aad, err := mu.MarshalToBytes(&additionalData_v3{
-		BaseVersion: baseVersion,
-		KDFAlg:      kdfAlg,
-		AuthMode:    authMode,
+		Generation: generation,
+		KDFAlg:     kdfAlg,
+		AuthMode:   authMode,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create AAD: %w", err)

--- a/tpm2/keydata_v3.go
+++ b/tpm2/keydata_v3.go
@@ -145,7 +145,9 @@ func (d *keyData_v3) ValidateData(tpm *tpm2.TPMContext, role []byte, session tpm
 	}
 	trial := util.ComputeAuthPolicy(d.KeyPublic.NameAlg)
 	trial.PolicyAuthorize(d.PolicyData.StaticData.PCRPolicyRef, authKeyName)
-	trial.PolicyAuthValue()
+	if d.PolicyData.StaticData.RequireAuthValue {
+		trial.PolicyAuthValue()
+	}
 
 	if !bytes.Equal(trial.GetDigest(), d.KeyPublic.AuthPolicy) {
 		return nil, keyDataError{errors.New("the sealed key object's authorization policy is inconsistent with the associated metadata or persistent TPM resources")}

--- a/tpm2/keydata_v3.go
+++ b/tpm2/keydata_v3.go
@@ -41,7 +41,9 @@ type additionalData_v3 struct {
 }
 
 func (d additionalData_v3) Marshal(w io.Writer) error {
-	_, err := mu.MarshalToWriter(w, uint32(3), d.Generation, d.KDFAlg, d.AuthMode)
+	_, err := mu.MarshalToWriter(w,
+		uint32(3), // The TPM2 platform keydata version
+		d.Generation, d.KDFAlg, d.AuthMode)
 	return err
 }
 

--- a/tpm2/platform.go
+++ b/tpm2/platform.go
@@ -148,7 +148,7 @@ func (h *platformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, ol
 	}
 
 	// Validate the initial key data
-	_, err = k.validateData(tpm.TPMContext, tpm.HmacSession())
+	_, err = k.validateData(tpm.TPMContext, data.Role, tpm.HmacSession())
 	switch {
 	case isKeyDataError(err):
 		return nil, &secboot.PlatformHandlerError{
@@ -201,7 +201,7 @@ func (h *platformKeyDataHandler) ChangeAuthKey(data *secboot.PlatformKeyData, ol
 
 	// Validate the modified key. There's no reason for this to fail, but do it anyway. We haven't made
 	// any persistent changes yet and still have an opportunity to back out.
-	if _, err = k.validateData(tpm.TPMContext, tpm.HmacSession()); err != nil {
+	if _, err = k.validateData(tpm.TPMContext, data.Role, tpm.HmacSession()); err != nil {
 		return nil, xerrors.Errorf("cannot validate key data after auth value change: %w", err)
 	}
 

--- a/tpm2/platform.go
+++ b/tpm2/platform.go
@@ -39,10 +39,10 @@ const platformName = "tpm2"
 type platformKeyDataHandler struct{}
 
 func (h *platformKeyDataHandler) recoverKeysCommon(data *secboot.PlatformKeyData, encryptedPayload, authKey []byte) ([]byte, error) {
-	if data.Version < 0 || int64(data.Version) > math.MaxUint32 {
+	if data.Generation < 0 || int64(data.Generation) > math.MaxUint32 {
 		return nil, &secboot.PlatformHandlerError{
 			Type: secboot.PlatformHandlerErrorInvalidData,
-			Err:  fmt.Errorf("invalid base key data version: %d", data.Version)}
+			Err:  fmt.Errorf("invalid key data generation: %d", data.Generation)}
 	}
 
 	kdfAlg, err := hashAlgorithmIdFromCryptoHash(data.KDFAlg)
@@ -102,7 +102,7 @@ func (h *platformKeyDataHandler) recoverKeysCommon(data *secboot.PlatformKeyData
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
 	}
 
-	payload, err := k.data.Decrypt(symKey, encryptedPayload, uint32(data.Version), kdfAlg, data.AuthMode)
+	payload, err := k.data.Decrypt(symKey, encryptedPayload, uint32(data.Generation), kdfAlg, data.AuthMode)
 	if err != nil {
 		return nil, &secboot.PlatformHandlerError{
 			Type: secboot.PlatformHandlerErrorInvalidData,

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -423,7 +423,7 @@ func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingRevokedPolicy(c *C) {
 		c.Assert(err, IsNil)
 
 		// Increment NV counter
-		c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, nil, true), IsNil)
+		c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, nil, NewPCRPolicyVersion), IsNil)
 		c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), primaryKey), IsNil)
 	})
 	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -197,7 +197,7 @@ func (s *platformSuite) testRecoverKeys(c *C, params *ProtectKeyParams) {
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
 
 	platformKeyData := &secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),
@@ -253,7 +253,7 @@ func (s *platformSuite) testRecoverKeysNoValidSRK(c *C, prepareSrk func()) {
 
 	var handler PlatformKeyDataHandler
 	payload, err := handler.RecoverKeys(&secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256)},
 		s.lastEncryptedPayload)
@@ -307,7 +307,7 @@ func (s *platformSuite) testRecoverKeysImportable(c *C, params *ProtectKeyParams
 
 	var handler PlatformKeyDataHandler
 	payload, err := handler.RecoverKeys(&secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256)},
 		s.lastEncryptedPayload)
@@ -356,7 +356,7 @@ func (s *platformSuite) TestRecoverKeysNoTPMConnection(c *C) {
 
 	var handler PlatformKeyDataHandler
 	_, err = handler.RecoverKeys(&secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256)},
 		s.lastEncryptedPayload)
@@ -381,7 +381,7 @@ func (s *platformSuite) testRecoverKeysUnsealErrorHandling(c *C, prepare func(*s
 
 	var handler PlatformKeyDataHandler
 	_, err = handler.RecoverKeys(&secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		AuthMode:      secboot.AuthModeNone,
 		Role:          "",
 		KDFAlg:        crypto.Hash(crypto.SHA256),
@@ -502,7 +502,7 @@ func (s *platformSuite) TestRecoverKeysWithAuthKey(c *C) {
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
 
 	platformKeyData := &secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),
@@ -513,7 +513,7 @@ func (s *platformSuite) TestRecoverKeysWithAuthKey(c *C) {
 	c.Check(err, IsNil)
 
 	newPlatformKeyData := &secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: newHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),
@@ -579,7 +579,7 @@ func (s *platformSuite) TestRecoverKeysWithIncorrectAuthKey(c *C) {
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
 
 	platformKeyData := &secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),
@@ -590,7 +590,7 @@ func (s *platformSuite) TestRecoverKeysWithIncorrectAuthKey(c *C) {
 	c.Check(err, IsNil)
 
 	newPlatformKeyData := &secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: newHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		// AuthMode:      k.AuthMode(),
@@ -651,7 +651,7 @@ func (s *platformSuite) TestChangeAuthKeyWithIncorrectAuthKey(c *C) {
 	c.Check(k.UnmarshalPlatformHandle(&platformHandle), IsNil)
 
 	platformKeyData := &secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: platformHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),
@@ -662,7 +662,7 @@ func (s *platformSuite) TestChangeAuthKeyWithIncorrectAuthKey(c *C) {
 	c.Check(err, IsNil)
 
 	newPlatformKeyData := &secboot.PlatformKeyData{
-		Version:       k.Version(),
+		Generation:    k.Generation(),
 		EncodedHandle: newHandle,
 		KDFAlg:        crypto.Hash(crypto.SHA256),
 		AuthMode:      k.AuthMode(),

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -467,7 +467,7 @@ func (s *platformSuite) TestRecoverKeysWithAuthKey(c *C) {
 			indexName = pcrPolicyCounterPub.Name()
 		}
 
-		pcrPolicyRef := ComputeV3PcrPolicyRefFromCounterName(key.NameAlg, []byte(role), indexName)
+		pcrPolicyRef := ComputeV3PcrPolicyRef(key.NameAlg, []byte(role), indexName)
 
 		trial := util.ComputeAuthPolicy(alg)
 		trial.PolicyAuthorize(pcrPolicyRef, key.Name())
@@ -544,7 +544,7 @@ func (s *platformSuite) TestRecoverKeysWithIncorrectAuthKey(c *C) {
 			indexName = pcrPolicyCounterPub.Name()
 		}
 
-		pcrPolicyRef := ComputeV3PcrPolicyRefFromCounterName(key.NameAlg, []byte(role), indexName)
+		pcrPolicyRef := ComputeV3PcrPolicyRef(key.NameAlg, []byte(role), indexName)
 
 		trial := util.ComputeAuthPolicy(alg)
 		trial.PolicyAuthorize(pcrPolicyRef, key.Name())
@@ -616,7 +616,7 @@ func (s *platformSuite) TestChangeAuthKeyWithIncorrectAuthKey(c *C) {
 			indexName = pcrPolicyCounterPub.Name()
 		}
 
-		pcrPolicyRef := ComputeV3PcrPolicyRefFromCounterName(key.NameAlg, []byte(role), indexName)
+		pcrPolicyRef := ComputeV3PcrPolicyRef(key.NameAlg, []byte(role), indexName)
 
 		trial := util.ComputeAuthPolicy(alg)
 		trial.PolicyAuthorize(pcrPolicyRef, key.Name())

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -304,7 +304,7 @@ func ensureSufficientORDigests(digests tpm2.DigestList) tpm2.DigestList {
 //
 // This returns some policy metadata and a policy digest which is used as the auth policy field of the
 // protected object.
-var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role string, pcrPolicyCounterPub *tpm2.NVPublic) (keyDataPolicy, tpm2.Digest, error) {
+var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role string, pcrPolicyCounterPub *tpm2.NVPublic, requireAuthValue bool) (keyDataPolicy, tpm2.Digest, error) {
 	if len(role) > 1024 {
 		// We serialize this in the TPM wire format in computeV3PcrPolicyRefFromCounterName
 		// and define the type as TPM2B_MAX_BUFFER in the SE041, and this has a maximum size
@@ -324,13 +324,16 @@ var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role str
 
 	trial := util.ComputeAuthPolicy(alg)
 	trial.PolicyAuthorize(pcrPolicyRef, key.Name())
-	trial.PolicyAuthValue()
+	if requireAuthValue {
+		trial.PolicyAuthValue()
+	}
 
 	return &keyDataPolicy_v3{
 		StaticData: &staticPolicyData_v3{
 			AuthPublicKey:          key,
 			PCRPolicyRef:           pcrPolicyRef,
-			PCRPolicyCounterHandle: pcrPolicyCounterHandle},
+			PCRPolicyCounterHandle: pcrPolicyCounterHandle,
+			RequireAuthValue:       requireAuthValue},
 		PCRData: &pcrPolicyData_v3{
 			// Set AuthorizedPolicySignature here because this object needs to be
 			// serializable before the initial signature is created.

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -54,6 +54,8 @@ type pcrPolicyParams struct {
 	// policies. The name must be associated with the handle in the keyDataPolicy,
 	// else the policy will not work.
 	policyCounterName tpm2.Name
+
+	policySequence uint64 // the PCR policy sequence
 }
 
 // policyOrNode represents a collection of up to 8 digests used in a single
@@ -248,7 +250,7 @@ func ensureSufficientORDigests(digests tpm2.DigestList) tpm2.DigestList {
 //
 // This returns some policy metadata and a policy digest which is used as the auth policy field of the
 // protected object.
-var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role string, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (keyDataPolicy, tpm2.Digest, error) {
+var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role string, pcrPolicyCounterPub *tpm2.NVPublic) (keyDataPolicy, tpm2.Digest, error) {
 	if len(role) > 1024 {
 		// We serialize this in the TPM wire format in computeV3PcrPolicyRefFromCounterName
 		// and define the type as TPM2B_MAX_BUFFER in the SE041, and this has a maximum size
@@ -276,7 +278,6 @@ var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role str
 			PCRPolicyRef:           pcrPolicyRef,
 			PCRPolicyCounterHandle: pcrPolicyCounterHandle},
 		PCRData: &pcrPolicyData_v3{
-			PolicySequence: pcrPolicySequence,
 			// Set AuthorizedPolicySignature here because this object needs to be
 			// serializable before the initial signature is created.
 			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgNull}}}, trial.GetDigest(), nil

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -44,7 +44,8 @@ const (
 
 // pcrPolicyParams provides the parameters to keyDataPolicy.updatePcrPolicy.
 type pcrPolicyParams struct {
-	key secboot.PrimaryKey // Key used to authorize the generated dynamic authorization policy
+	key  secboot.PrimaryKey // Key used to authorize the generated dynamic authorization policy
+	role []byte
 
 	pcrs       tpm2.PCRSelectionList // PCR selection
 	pcrDigests tpm2.DigestList       // Approved PCR digests

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -213,7 +213,7 @@ var ensurePcrPolicyCounter = func(tpm *tpm2.TPMContext, handle tpm2.Handle, upda
 		AuthPolicy: trial.GetDigest(),
 		Size:       8}
 
-	index, err := tpm.CreateResourceContextFromTPM(handle, hmacSession)
+	index, err := tpm.CreateResourceContextFromTPM(handle, hmacSession.IncludeAttrs(tpm2.AttrAudit))
 	switch {
 	case tpm2.IsResourceUnavailableError(err, handle):
 		// ok, need to create

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -306,10 +306,10 @@ func ensureSufficientORDigests(digests tpm2.DigestList) tpm2.DigestList {
 // protected object.
 var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role string, pcrPolicyCounterPub *tpm2.NVPublic, requireAuthValue bool) (keyDataPolicy, tpm2.Digest, error) {
 	if len(role) > 1024 {
-		// We serialize this in the TPM wire format in computeV3PcrPolicyRefFromCounterName
-		// and define the type as TPM2B_MAX_BUFFER in the SE041, and this has a maximum size
-		// of 1024 bytes, although the real ceiling for us is MaxUint16. Let's be consistent
-		// though, and 1024 bytes is more than enough.
+		// We serialize this in the TPM wire format in computeV3PcrPolicyRef and define the
+		// type as TPM2B_MAX_BUFFER in the SE041, and this has a maximum size of 1024 bytes,
+		// although the real ceiling for us is MaxUint16. Let's be consistent though, and
+		// 1024 bytes is more than enough.
 		return nil, nil, errors.New("invalid role: too large")
 	}
 
@@ -320,7 +320,7 @@ var newKeyDataPolicy = func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role str
 		pcrPolicyCounterName = pcrPolicyCounterPub.Name()
 	}
 
-	pcrPolicyRef := computeV3PcrPolicyRefFromCounterName(key.NameAlg, []byte(role), pcrPolicyCounterName)
+	pcrPolicyRef := computeV3PcrPolicyRef(key.NameAlg, []byte(role), pcrPolicyCounterName)
 
 	trial := util.ComputeAuthPolicy(alg)
 	trial.PolicyAuthorize(pcrPolicyRef, key.Name())

--- a/tpm2/policy_test.go
+++ b/tpm2/policy_test.go
@@ -228,7 +228,7 @@ func (s *policySuiteNoTPM) testNewKeyDataPolicy(c *C, data *testNewKeyDataPolicy
 		pcrPolicyCounterHandle = data.pcrPolicyCounterPub.Index
 	}
 
-	policy, digest, err := NewKeyDataPolicy(data.alg, authKey, data.pcrPolicyCounterPub, data.pcrPolicySequence)
+	policy, digest, err := NewKeyDataPolicy(data.alg, authKey, "", data.pcrPolicyCounterPub, false)
 	c.Assert(err, IsNil)
 	c.Assert(policy, testutil.ConvertibleTo, &KeyDataPolicy_v3{})
 	c.Check(policy.(*KeyDataPolicy_v3).StaticData.AuthPublicKey, DeepEquals, authKey)
@@ -251,8 +251,8 @@ xtjPyepMPNg3K7iPmPopFLA5Ap8RjR1Eu9B8LllUHTqYHJY6YQ3o+CP5TQ==
 			NameAlg: tpm2.HashAlgorithmSHA256,
 			Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVWritten),
 			Size:    8},
-		pcrPolicySequence: 10,
-		expected:          testutil.DecodeHexString(c, "61f5396bcbd2bd3ed1392edaf88314da1230f6f252962c704119659295eca112")})
+		pcrPolicySequence: 0,
+		expected:          testutil.DecodeHexString(c, "aaf8226b1df9aefc9d03533b58abaf514b0f4ab6c10af0e26ef5d9db0d8aff24")})
 }
 
 func (s *policySuiteNoTPM) TestNewKeyDataPolicySHA1(c *C) {
@@ -268,8 +268,8 @@ xtjPyepMPNg3K7iPmPopFLA5Ap8RjR1Eu9B8LllUHTqYHJY6YQ3o+CP5TQ==
 			NameAlg: tpm2.HashAlgorithmSHA256,
 			Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVWritten),
 			Size:    8},
-		pcrPolicySequence: 10,
-		expected:          testutil.DecodeHexString(c, "1a1afefb96937bd752a24cc23dbc16ecde3c8268")})
+		pcrPolicySequence: 0,
+		expected:          testutil.DecodeHexString(c, "9a9aeb1e55e96cbae4cba7bc798046cc82ff669f")})
 }
 
 func (s *policySuiteNoTPM) TestNewKeyDataPolicyNoPCRPolicyCounterHandle(c *C) {
@@ -280,7 +280,7 @@ func (s *policySuiteNoTPM) TestNewKeyDataPolicyNoPCRPolicyCounterHandle(c *C) {
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE49+rltJgmI3V7QqrkLBpB4V3xunW
 xtjPyepMPNg3K7iPmPopFLA5Ap8RjR1Eu9B8LllUHTqYHJY6YQ3o+CP5TQ==
 -----END PUBLIC KEY-----`,
-		expected: testutil.DecodeHexString(c, "2171bcd975facbf5bf0ac504e2e9812d3cf5583c0162f96c849dd9b8154f4dc0")})
+		expected: testutil.DecodeHexString(c, "9cac9314ff38f2cdf8c876b57d344657e76996ea872925acd95abec805165c31")})
 }
 
 func (s *policySuiteNoTPM) TestNewKeyDataPolicyDifferentInitialSequence(c *C) {
@@ -296,8 +296,8 @@ xtjPyepMPNg3K7iPmPopFLA5Ap8RjR1Eu9B8LllUHTqYHJY6YQ3o+CP5TQ==
 			NameAlg: tpm2.HashAlgorithmSHA256,
 			Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVWritten),
 			Size:    8},
-		pcrPolicySequence: 3000,
-		expected:          testutil.DecodeHexString(c, "61f5396bcbd2bd3ed1392edaf88314da1230f6f252962c704119659295eca112")})
+		pcrPolicySequence: 0,
+		expected:          testutil.DecodeHexString(c, "aaf8226b1df9aefc9d03533b58abaf514b0f4ab6c10af0e26ef5d9db0d8aff24")})
 }
 
 type testNewKeyDataPolicyLegacyData struct {

--- a/tpm2/policy_v0.go
+++ b/tpm2/policy_v0.go
@@ -374,7 +374,7 @@ func (p *keyDataPolicy_v0) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcr
 		return xerrors.Errorf("cannot compute base PCR policy: %w", err)
 	}
 
-	pcrData.addRevocationCheck(trial, params.policyCounterName, params.policySequence+1)
+	pcrData.addRevocationCheck(trial, params.policyCounterName, params.policySequence)
 
 	key, err := x509.ParsePKCS1PrivateKey(params.key)
 	if err != nil {

--- a/tpm2/policy_v0_test.go
+++ b/tpm2/policy_v0_test.go
@@ -347,7 +347,7 @@ func (s *policyV0SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV0UpdatePCRPoli
 	}
 	s.checkPolicyOrTree(c, data.alg, digests, orTree)
 
-	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.PolicySequence, Equals, data.initialSeq+1)
+	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.PolicySequence, Equals, data.initialSeq)
 
 	c.Check(policyData.(*KeyDataPolicy_v0).PCRData.AuthorizedPolicy, DeepEquals, data.expectedPolicy)
 
@@ -365,7 +365,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicy(c *C) {
 	s.testUpdatePCRPolicy(c, &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -376,7 +376,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicyDepth1(c *C) {
 	s.testUpdatePCRPolicy(c, &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests: tpm2.DigestList{
@@ -392,7 +392,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicyDepth2(c *C) {
 	data := &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		expectedPolicy:      testutil.DecodeHexString(c, "3dbd5e8007fe9a181b38f489da1577a71c2a049fd9d540f04bee5ed760621d36")}
@@ -406,7 +406,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicyDifferentCounter(c *C) {
 	s.testUpdatePCRPolicy(c, &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x0180ffff,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -417,7 +417,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicySHA1AuthKey(c *C) {
 	s.testUpdatePCRPolicy(c, &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA1,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -428,7 +428,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicyDifferentSequence(c *C) {
 	s.testUpdatePCRPolicy(c, &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          9999,
+		initialSeq:          10000,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -439,7 +439,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicySHA1Policy(c *C) {
 	s.testUpdatePCRPolicy(c, &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA1,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA1, "1")},
@@ -450,7 +450,7 @@ func (s *policyV0SuiteNoTPM) TestUpdatePCRPolicyDifferentPCRs(c *C) {
 	s.testUpdatePCRPolicy(c, &testV0UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA1, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -52,6 +52,7 @@ func computeV1PcrPolicyCounterAuthPolicies(alg tpm2.HashAlgorithmId, updateKeyNa
 		// avoid a panic if updateKeyName is invalid. Note that this will
 		// produce invalid policies - callers should take steps to ensure that
 		// updateKeyName is valid.
+		// TODO: Use tpm2.MakeHandleName here
 		updateKeyName = tpm2.Name(mu.MustMarshalToBytes(tpm2.HandleUnassigned))
 	}
 
@@ -138,10 +139,10 @@ func (p *keyDataPolicy_v1) PCRPolicySequence() uint64 {
 // validated during execution before executing the corresponding PolicyAuthorize assertion as part of the
 // static policy.
 func (p *keyDataPolicy_v1) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcrPolicyParams) error {
-	pcrData := p.PCRData.new(params)
+	pcrData := new(pcrPolicyData_v1)
 
 	trial := util.ComputeAuthPolicy(alg)
-	if err := pcrData.addPcrAssertions(alg, trial, params.pcrDigests); err != nil {
+	if err := pcrData.addPcrAssertions(alg, trial, params.pcrs, params.pcrDigests); err != nil {
 		return xerrors.Errorf("cannot compute base PCR policy: %w", err)
 	}
 

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -147,7 +147,7 @@ func (p *keyDataPolicy_v1) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcr
 	}
 
 	if params.policyCounterName != nil {
-		pcrData.addRevocationCheck(trial, params.policyCounterName, params.policySequence+1)
+		pcrData.addRevocationCheck(trial, params.policyCounterName, params.policySequence)
 	}
 
 	key, err := createECDSAPrivateKeyFromTPM(p.StaticData.AuthPublicKey, tpm2.ECCParameter(params.key))

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -147,7 +147,7 @@ func (p *keyDataPolicy_v1) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcr
 	}
 
 	if params.policyCounterName != nil {
-		pcrData.addRevocationCheck(trial, params.policyCounterName)
+		pcrData.addRevocationCheck(trial, params.policyCounterName, params.policySequence+1)
 	}
 
 	key, err := createECDSAPrivateKeyFromTPM(p.StaticData.AuthPublicKey, tpm2.ECCParameter(params.key))

--- a/tpm2/policy_v1_test.go
+++ b/tpm2/policy_v1_test.go
@@ -125,7 +125,7 @@ func (s *policyV1SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV1UpdatePCRPoli
 
 	// Skip check for NoCounter case
 	if data.policyCounterHandle != tpm2.HandleNull {
-		c.Check(policyData.(*KeyDataPolicy_v1).PCRData.PolicySequence, Equals, data.initialSeq+1)
+		c.Check(policyData.(*KeyDataPolicy_v1).PCRData.PolicySequence, Equals, data.initialSeq)
 	}
 
 	c.Logf("%x", policyData.(*KeyDataPolicy_v1).PCRData.AuthorizedPolicy)
@@ -147,7 +147,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicy(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -158,7 +158,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicyDepth1(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests: tpm2.DigestList{
@@ -174,7 +174,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicyDepth2(c *C) {
 	data := &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		expectedPolicy:      testutil.DecodeHexString(c, "3dbd5e8007fe9a181b38f489da1577a71c2a049fd9d540f04bee5ed760621d36")}
@@ -188,7 +188,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicyDifferentCounter(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x0180ffff,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -199,7 +199,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicyNoCounter(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: tpm2.HandleNull,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -210,7 +210,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicySHA1AuthKey(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA1,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -221,7 +221,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicyDifferentSequence(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          9999,
+		initialSeq:          10000,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -232,7 +232,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicySHA1Policy(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA1,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA1, "1")},
@@ -243,7 +243,7 @@ func (s *policyV1SuiteNoTPM) TestUpdatePCRPolicyDifferentPCRs(c *C) {
 	s.testUpdatePCRPolicy(c, &testV1UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		initialSeq:          1001,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA1, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},

--- a/tpm2/policy_v3.go
+++ b/tpm2/policy_v3.go
@@ -179,7 +179,7 @@ func (p *keyDataPolicy_v3) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcr
 	}
 
 	if params.policyCounterName != nil {
-		pcrData.addRevocationCheck(trial, params.policyCounterName)
+		pcrData.addRevocationCheck(trial, params.policyCounterName, params.policySequence)
 	}
 
 	key, err := deriveV3PolicyAuthKey(p.StaticData.AuthPublicKey.NameAlg.GetHash(), params.key)

--- a/tpm2/policy_v3.go
+++ b/tpm2/policy_v3.go
@@ -171,10 +171,10 @@ func (p *keyDataPolicy_v3) PCRPolicySequence() uint64 {
 // validated during execution before executing the corresponding PolicyAuthorize assertion as part of the
 // static policy.
 func (p *keyDataPolicy_v3) UpdatePCRPolicy(alg tpm2.HashAlgorithmId, params *pcrPolicyParams) error {
-	pcrData := p.PCRData.new(params)
+	pcrData := new(pcrPolicyData_v3)
 
 	trial := util.ComputeAuthPolicy(alg)
-	if err := pcrData.addPcrAssertions(alg, trial, params.pcrDigests); err != nil {
+	if err := pcrData.addPcrAssertions(alg, trial, params.pcrs, params.pcrDigests); err != nil {
 		return xerrors.Errorf("cannot compute base PCR policy: %w", err)
 	}
 

--- a/tpm2/policy_v3_test.go
+++ b/tpm2/policy_v3_test.go
@@ -1422,7 +1422,7 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 				Details: &tpm2.SigSchemeU{
 					ECDSA: &tpm2.SigSchemeECDSA{
 						HashAlg: data.StaticData.AuthPublicKey.NameAlg}}}
-			_, signature, err := util.PolicyAuthorize(key, scheme, data.PCRData.AuthorizedPolicy, ComputeV3PcrPolicyRefFromCounterName(tpm2.HashAlgorithmSHA256, []byte(""), nil))
+			_, signature, err := util.PolicyAuthorize(key, scheme, data.PCRData.AuthorizedPolicy, ComputeV3PcrPolicyRef(tpm2.HashAlgorithmSHA256, []byte(""), nil))
 			c.Assert(err, IsNil)
 			data.PCRData.AuthorizedPolicySignature = signature
 		},

--- a/tpm2/policy_v3_test.go
+++ b/tpm2/policy_v3_test.go
@@ -112,7 +112,7 @@ func (s *policyV3SuiteNoTPM) TestPCRPolicySequence(c *C) {
 type testV3UpdatePCRPolicyData struct {
 	policyCounterHandle tpm2.Handle
 	authKeyNameAlg      tpm2.HashAlgorithmId
-	initialSeq          uint64
+	expectedCount       uint64
 
 	alg        tpm2.HashAlgorithmId
 	pcrs       tpm2.PCRSelectionList
@@ -141,10 +141,9 @@ func (s *policyV3SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV3UpdatePCRPoli
 	var policyData KeyDataPolicy = &KeyDataPolicy_v3{
 		StaticData: &StaticPolicyData_v3{
 			AuthPublicKey: authPublicKey},
-		PCRData: &PcrPolicyData_v3{
-			PolicySequence: data.initialSeq}}
+	}
 
-	params := NewPcrPolicyParams(key, data.pcrs, data.pcrDigests, policyCounterName)
+	params := NewPcrPolicyParams(key, data.pcrs, data.pcrDigests, policyCounterName, 1)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	c.Check(policyData.(*KeyDataPolicy_v3).PCRData.Selection, tpm2_testutil.TPMValueDeepEquals, data.pcrs)
@@ -159,7 +158,7 @@ func (s *policyV3SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV3UpdatePCRPoli
 	}
 	s.checkPolicyOrTree(c, data.alg, digests, orTree)
 
-	c.Check(policyData.(*KeyDataPolicy_v3).PCRData.PolicySequence, Equals, data.initialSeq+1)
+	c.Check(policyData.(*KeyDataPolicy_v3).PCRData.PolicySequence, Equals, data.expectedCount)
 
 	c.Check(policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicy, DeepEquals, data.expectedPolicy)
 
@@ -168,7 +167,7 @@ func (s *policyV3SuiteNoTPM) testUpdatePCRPolicy(c *C, data *testV3UpdatePCRPoli
 
 	digest, err := util.ComputePolicyAuthorizeDigest(data.authKeyNameAlg,
 		policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicy,
-		ComputeV3PcrPolicyRefFromCounterName(policyCounterName))
+		policyData.(*KeyDataPolicy_v3).StaticData.PCRPolicyRef)
 	c.Check(err, IsNil)
 	ok, err := util.VerifySignature(authPublicKey.Public(), digest, policyData.(*KeyDataPolicy_v3).PCRData.AuthorizedPolicySignature)
 	c.Check(err, IsNil)
@@ -179,18 +178,18 @@ func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicy(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
-		expectedPolicy:      testutil.DecodeHexString(c, "70affe6f1ca3f4bee098b50fc474d8e247adcf5bc54b1bd6fe356104c2641a8b")})
+		expectedPolicy:      testutil.DecodeHexString(c, "214063f761968beacf47ed3cfa692480aaba7981e3a4f95f606da88cc45182f3")})
 }
 
 func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicyDepth1(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests: tpm2.DigestList{
@@ -199,17 +198,17 @@ func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicyDepth1(c *C) {
 			hash(crypto.SHA256, "3"),
 			hash(crypto.SHA256, "4"),
 			hash(crypto.SHA256, "5")},
-		expectedPolicy: testutil.DecodeHexString(c, "96eb06bc20faa6dbfa138b644a33470e92176db65b373577fe0e92f5518a5693")})
+		expectedPolicy: testutil.DecodeHexString(c, "0ced4fca4da1c7a3c7342e37a7e5c0f40a9c4d19d53eb3c4c63371fba54e4bac")})
 }
 
 func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicyDepth2(c *C) {
 	data := &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
-		expectedPolicy:      testutil.DecodeHexString(c, "3dbd5e8007fe9a181b38f489da1577a71c2a049fd9d540f04bee5ed760621d36")}
+		expectedPolicy:      testutil.DecodeHexString(c, "e51cd2aa2f8f6b872c2f3e3e98f6093591928af6deeaceae191e5b3ade3290f1")}
 	for i := 1; i < 26; i++ {
 		data.pcrDigests = append(data.pcrDigests, hash(crypto.SHA256, strconv.Itoa(i)))
 	}
@@ -220,18 +219,18 @@ func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicyDifferentCounter(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x0180ffff,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
-		expectedPolicy:      testutil.DecodeHexString(c, "dd3b263babcfaa7316376889c917587b4586fea8096de29dc3360611a887e835")})
+		expectedPolicy:      testutil.DecodeHexString(c, "e08a219a6a7fdbaf52e64f9f3fb7208948ed3994997be53cc79be4464bd6405f")})
 }
 
 func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicyNoCounter(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: tpm2.HandleNull,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		expectedCount:       0,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
@@ -242,44 +241,44 @@ func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicySHA1AuthKey(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA1,
-		initialSeq:          1000,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
-		expectedPolicy:      testutil.DecodeHexString(c, "70affe6f1ca3f4bee098b50fc474d8e247adcf5bc54b1bd6fe356104c2641a8b")})
+		expectedPolicy:      testutil.DecodeHexString(c, "214063f761968beacf47ed3cfa692480aaba7981e3a4f95f606da88cc45182f3")})
 }
 
 func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicyDifferentSequence(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          9999,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
-		expectedPolicy:      testutil.DecodeHexString(c, "abc59e04a533674dc796b6bc51276a5fac18fed2177ab99a87e8a636c83bc8cc")})
+		expectedPolicy:      testutil.DecodeHexString(c, "214063f761968beacf47ed3cfa692480aaba7981e3a4f95f606da88cc45182f3")})
 }
 
 func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicySHA1Policy(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA1,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA1, "1")},
-		expectedPolicy:      testutil.DecodeHexString(c, "10d3874da9f0605876695f76efa0bfbf1ea57f16")})
+		expectedPolicy:      testutil.DecodeHexString(c, "e537ec1e4b1d4ec5bae9a3644194e8d1a9181bf1")})
 }
 
 func (s *policyV3SuiteNoTPM) TestUpdatePCRPolicyDifferentPCRs(c *C) {
 	s.testUpdatePCRPolicy(c, &testV3UpdatePCRPolicyData{
 		policyCounterHandle: 0x01800000,
 		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		initialSeq:          1000,
+		expectedCount:       1,
 		alg:                 tpm2.HashAlgorithmSHA256,
 		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA1, Select: []int{4, 7, 12}}},
 		pcrDigests:          tpm2.DigestList{hash(crypto.SHA256, "1")},
-		expectedPolicy:      testutil.DecodeHexString(c, "a4569fcb0e2c2f1a6651c53e00c526c383c108edb3142339e6fad9d6ae5a488c")})
+		expectedPolicy:      testutil.DecodeHexString(c, "ce6e3eb8ecd88ef2e21327ad58c77b21a8b563b5b373f1eab08dcc8296c6ee56")})
 }
 
 func (s *policyV3SuiteNoTPM) TestSetPCRPolicyFrom(c *C) {
@@ -295,13 +294,12 @@ func (s *policyV3SuiteNoTPM) TestSetPCRPolicyFrom(c *C) {
 	policyData1 := &KeyDataPolicy_v3{
 		StaticData: &StaticPolicyData_v3{
 			AuthPublicKey: s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, key)},
-		PCRData: &PcrPolicyData_v3{
-			PolicySequence: 5000}}
+	}
 
 	params := NewPcrPolicyParams(key,
 		tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{4, 7, 12}}},
 		tpm2.DigestList{hash(crypto.SHA256, "1"), hash(crypto.SHA256, "2")},
-		policyCounterPub.Name())
+		policyCounterPub.Name(), 5000)
 	c.Check(policyData1.UpdatePCRPolicy(tpm2.HashAlgorithmSHA256, params), IsNil)
 
 	var policyData2 KeyDataPolicy = &KeyDataPolicy_v3{
@@ -324,24 +322,32 @@ type testV3ExecutePCRPolicyData struct {
 }
 
 func (s *policyV3Suite) testExecutePCRPolicy(c *C, data *testV3ExecutePCRPolicyData) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
 
-	authKeyPublic := s.newPolicyAuthPublicKey(c, data.authKeyNameAlg, authKey)
+	authKeyPublic := s.newPolicyAuthPublicKey(c, data.authKeyNameAlg, primaryKey)
 
 	var policyCounterPub *tpm2.NVPublic
-	var policyCount uint64
 	var policyCounterName tpm2.Name
 	if data.policyCounterHandle != tpm2.HandleNull {
 		var err error
-		policyCounterPub, policyCount, err = CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
+		policyCounterPub, err = EnsurePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
 		c.Assert(err, IsNil)
 		policyCounterName = policyCounterPub.Name()
 	}
 
-	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, policyCounterPub, policyCount)
+	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, "", policyCounterPub, false)
 	c.Assert(err, IsNil)
 	c.Assert(policyData, testutil.ConvertibleTo, &KeyDataPolicy_v3{})
+
+	var policyCount uint64
+	if data.policyCounterHandle != tpm2.HandleNull {
+		context, err := policyData.PCRPolicyCounterContext(s.TPM().TPMContext, policyCounterPub, s.TPM().HmacSession())
+		c.Assert(err, IsNil)
+
+		policyCount, err = context.Get()
+		c.Assert(err, IsNil)
+	}
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
@@ -349,7 +355,7 @@ func (s *policyV3Suite) testExecutePCRPolicy(c *C, data *testV3ExecutePCRPolicyD
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(authKey, data.pcrs, digests, policyCounterName)
+	params := NewPcrPolicyParams(primaryKey, data.pcrs, digests, policyCounterName, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -675,28 +681,36 @@ type testV3ExecutePCRPolicyErrorHandlingData struct {
 
 	pcrEvents []pcrEvent
 
-	fn func(data *KeyDataPolicy_v3, authKey secboot.PrimaryKey)
+	fn func(data *KeyDataPolicy_v3, primaryKey secboot.PrimaryKey)
 }
 
 func (s *policyV3Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV3ExecutePCRPolicyErrorHandlingData) error {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
 
-	authKeyPublic := s.newPolicyAuthPublicKey(c, data.authKeyNameAlg, authKey)
+	authKeyPublic := s.newPolicyAuthPublicKey(c, data.authKeyNameAlg, primaryKey)
 
 	var policyCounterPub *tpm2.NVPublic
-	var policyCount uint64
 	var policyCounterName tpm2.Name
 	if data.policyCounterHandle != tpm2.HandleNull {
 		var err error
-		policyCounterPub, policyCount, err = CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
+		policyCounterPub, err = EnsurePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, data.policyCounterHandle), authKeyPublic, s.TPM().HmacSession())
 		c.Assert(err, IsNil)
 		policyCounterName = policyCounterPub.Name()
 	}
 
-	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, policyCounterPub, policyCount)
+	policyData, expectedDigest, err := NewKeyDataPolicy(data.alg, authKeyPublic, "", policyCounterPub, false)
 	c.Assert(err, IsNil)
 	c.Assert(policyData, testutil.ConvertibleTo, &KeyDataPolicy_v3{})
+
+	var policyCount uint64
+	if data.policyCounterHandle != tpm2.HandleNull {
+		context, err := policyData.PCRPolicyCounterContext(s.TPM().TPMContext, policyCounterPub, s.TPM().HmacSession())
+		c.Assert(err, IsNil)
+
+		policyCount, err = context.Get()
+		c.Assert(err, IsNil)
+	}
 
 	var digests tpm2.DigestList
 	for _, v := range data.pcrValues {
@@ -704,7 +718,7 @@ func (s *policyV3Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV3Exec
 		digests = append(digests, d)
 	}
 
-	params := NewPcrPolicyParams(authKey, data.pcrs, digests, policyCounterName)
+	params := NewPcrPolicyParams(primaryKey, data.pcrs, digests, policyCounterName, policyCount)
 	c.Check(policyData.UpdatePCRPolicy(data.alg, params), IsNil)
 
 	for _, selection := range data.pcrs {
@@ -718,7 +732,7 @@ func (s *policyV3Suite) testExecutePCRPolicyErrorHandling(c *C, data *testV3Exec
 		c.Check(err, IsNil)
 	}
 
-	data.fn(policyData.(*KeyDataPolicy_v3), authKey)
+	data.fn(policyData.(*KeyDataPolicy_v3), primaryKey)
 
 	session := s.StartAuthSession(c, nil, nil, tpm2.SessionTypePolicy, nil, data.alg)
 	executeErr := policyData.ExecutePCRPolicy(s.TPM().TPMContext, session, s.TPM().HmacSession())
@@ -1202,24 +1216,34 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounter
 		},
 	})
 	c.Check(IsPolicyDataError(err), testutil.IsTrue)
-	c.Check(err, ErrorMatches, "cannot verify PCR policy signature: TPM returned an error for parameter 2 whilst executing command TPM_CC_VerifySignature: TPM_RC_SIGNATURE \\(the signature is not valid\\)")
+	c.Check(err, ErrorMatches, "the PCR policy is invalid")
 }
 
 func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 	// Test with a revoked PCR policy.
-	err := s.testExecutePCRPolicyErrorHandling(c, &testV3ExecutePCRPolicyErrorHandlingData{
-		authKeyNameAlg:      tpm2.HashAlgorithmSHA256,
-		policyCounterHandle: 0x01800000,
-		alg:                 tpm2.HashAlgorithmSHA256,
-		pcrs:                tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{16, 23}}},
-		pcrValues: []tpm2.PCRValues{
-			{
-				tpm2.HashAlgorithmSHA256: {
-					16: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo", "bar"),
-					23: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar", "foo"),
-				},
+	alg := tpm2.HashAlgorithmSHA256
+	pcrs := tpm2.PCRSelectionList{{Hash: tpm2.HashAlgorithmSHA256, Select: []int{16, 23}}}
+	pcrValues := []tpm2.PCRValues{
+		{
+			tpm2.HashAlgorithmSHA256: {
+				16: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "foo", "bar"),
+				23: tpm2test.MakePCRValueFromEvents(tpm2.HashAlgorithmSHA256, "bar", "foo"),
 			},
 		},
+	}
+
+	var digests tpm2.DigestList
+	for _, v := range pcrValues {
+		d, _ := util.ComputePCRDigest(alg, pcrs, v)
+		digests = append(digests, d)
+	}
+
+	err := s.testExecutePCRPolicyErrorHandling(c, &testV3ExecutePCRPolicyErrorHandlingData{
+		authKeyNameAlg:      alg,
+		policyCounterHandle: 0x01800000,
+		alg:                 tpm2.HashAlgorithmSHA256,
+		pcrs:                pcrs,
+		pcrValues:           pcrValues,
 		pcrEvents: []pcrEvent{
 			{
 				index: 16,
@@ -1238,11 +1262,19 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 				data:  "foo",
 			},
 		},
-		fn: func(data *KeyDataPolicy_v3, authKey secboot.PrimaryKey) {
+		fn: func(data *KeyDataPolicy_v3, primaryKey secboot.PrimaryKey) {
 			pub, _, err := s.TPM().NVReadPublic(tpm2.CreatePartialHandleContext(data.StaticData.PCRPolicyCounterHandle))
 			c.Assert(err, IsNil)
 
 			target := data.PCRData.PolicySequence
+
+			authKeyPublic := s.newPolicyAuthPublicKey(c, alg, primaryKey)
+			policyCounterPub, err := EnsurePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, 0x01800000), authKeyPublic, s.TPM().HmacSession())
+			c.Assert(err, IsNil)
+			policyCounterName := policyCounterPub.Name()
+
+			params := NewPcrPolicyParams(primaryKey, pcrs, digests, policyCounterName, target+1)
+			data.UpdatePCRPolicy(alg, params)
 
 			context, err := data.PCRPolicyCounterContext(s.TPM().TPMContext, pub, s.TPM().HmacSession())
 			c.Assert(err, IsNil)
@@ -1254,12 +1286,12 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingRevoked(c *C) {
 					break
 				}
 
-				c.Assert(context.Increment(authKey), IsNil)
+				c.Assert(context.Increment(primaryKey), IsNil)
 			}
 		},
 	})
 	c.Check(IsPolicyDataError(err), testutil.IsTrue)
-	c.Check(err, ErrorMatches, "the PCR policy has been revoked")
+	c.Check(err, ErrorMatches, "the PCR policy is invalid")
 }
 
 func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthPublicKey(c *C) {
@@ -1390,7 +1422,7 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 				Details: &tpm2.SigSchemeU{
 					ECDSA: &tpm2.SigSchemeECDSA{
 						HashAlg: data.StaticData.AuthPublicKey.NameAlg}}}
-			_, signature, err := util.PolicyAuthorize(key, scheme, data.PCRData.AuthorizedPolicy, ComputeV3PcrPolicyRefFromCounterName(nil))
+			_, signature, err := util.PolicyAuthorize(key, scheme, data.PCRData.AuthorizedPolicy, ComputeV3PcrPolicyRefFromCounterName(tpm2.HashAlgorithmSHA256, []byte(""), nil))
 			c.Assert(err, IsNil)
 			data.PCRData.AuthorizedPolicySignature = signature
 		},
@@ -1398,33 +1430,12 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidAuthorizedPolicy
 	c.Check(err, IsNil)
 }
 
-func (s *policyV3Suite) TestPolicyCounterContextGet(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
-	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, authKey)
-
-	policyCounterPub, policyCount, err := CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, 0x01800000), authKeyPublic, s.TPM().HmacSession())
-	c.Assert(err, IsNil)
-
-	data := &KeyDataPolicy_v3{
-		StaticData: &StaticPolicyData_v3{
-			AuthPublicKey:          authKeyPublic,
-			PCRPolicyCounterHandle: policyCounterPub.Index}}
-
-	context, err := data.PCRPolicyCounterContext(s.TPM().TPMContext, policyCounterPub, s.TPM().HmacSession())
-	c.Assert(err, IsNil)
-
-	count, err := context.Get()
-	c.Check(err, IsNil)
-	c.Check(count, Equals, policyCount)
-}
-
 func (s *policyV3Suite) TestPolicyCounterContextIncrement(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
-	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, authKey)
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
+	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, primaryKey)
 
-	policyCounterPub, policyCount, err := CreatePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, 0x01800000), authKeyPublic, s.TPM().HmacSession())
+	policyCounterPub, err := EnsurePcrPolicyCounter(s.TPM().TPMContext, s.NextAvailableHandle(c, 0x01800000), authKeyPublic, s.TPM().HmacSession())
 	c.Assert(err, IsNil)
 
 	data := &KeyDataPolicy_v3{
@@ -1435,36 +1446,40 @@ func (s *policyV3Suite) TestPolicyCounterContextIncrement(c *C) {
 	context, err := data.PCRPolicyCounterContext(s.TPM().TPMContext, policyCounterPub, s.TPM().HmacSession())
 	c.Assert(err, IsNil)
 
-	c.Check(context.Increment(authKey), IsNil)
-
-	count, err := context.Get()
+	initialCount, err := context.Get()
 	c.Check(err, IsNil)
-	c.Check(count, Equals, policyCount+1)
+
+	c.Check(context.Increment(primaryKey), IsNil)
+
+	incCount, err := context.Get()
+	c.Check(err, IsNil)
+
+	c.Check(incCount, Equals, initialCount+1)
 }
 
 func (s *policyV3SuiteNoTPM) TestValidateAuthKey(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
-	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, authKey)
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
+	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, primaryKey)
 
 	data := &KeyDataPolicy_v3{
 		StaticData: &StaticPolicyData_v3{
 			AuthPublicKey: authKeyPublic}}
-	c.Check(data.ValidateAuthKey(authKey), IsNil)
+	c.Check(data.ValidateAuthKey(primaryKey), IsNil)
 }
 
 func (s *policyV3SuiteNoTPM) TestValidateAuthKeyWrongKey(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
-	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, authKey)
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
+	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, primaryKey)
 
 	data := &KeyDataPolicy_v3{
 		StaticData: &StaticPolicyData_v3{
 			AuthPublicKey: authKeyPublic}}
 
-	rand.Read(authKey)
+	rand.Read(primaryKey)
 
-	err := data.ValidateAuthKey(authKey)
+	err := data.ValidateAuthKey(primaryKey)
 	c.Check(IsPolicyDataError(err), testutil.IsTrue)
 	c.Check(err, ErrorMatches, "dynamic authorization policy signing private key doesn't match public key")
 }

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -187,9 +187,9 @@ func makeSealedKeyData(tpm *tpm2.TPMContext, params *makeSealedKeyDataParams, se
 	}
 
 	aad, err := mu.MarshalToBytes(&additionalData_v3{
-		BaseVersion: uint32(secboot.KeyDataVersion),
-		KDFAlg:      tpm2.HashAlgorithmSHA256,
-		AuthMode:    params.AuthMode,
+		Generation: uint32(secboot.KeyDataGeneration),
+		KDFAlg:     tpm2.HashAlgorithmSHA256,
+		AuthMode:   params.AuthMode,
 	})
 	if err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot create AAD: %w", err)

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -182,6 +182,8 @@ func makeSealedKeyData(tpm *tpm2.TPMContext, params *makeSealedKeyDataParams, se
 		return nil, nil, nil, xerrors.Errorf("cannot create new unlock key: %w", err)
 	}
 
+	// Serialize the AAD. Note that we don't protect the role parameter directly because it's
+	// already bound to the sealed object via its authorization policy.
 	aad, err := mu.MarshalToBytes(&additionalData_v3{
 		Generation: uint32(secboot.KeyDataGeneration),
 		KDFAlg:     tpm2.HashAlgorithmSHA256,

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -175,7 +175,7 @@ func makeSealedKeyData(tpm *tpm2.TPMContext, params *makeSealedKeyDataParams, se
 	if pcrProfile == nil {
 		pcrProfile = NewPCRProtectionProfile()
 	}
-	if err := skdbUpdatePCRProtectionPolicyNoValidate(&skd.sealedKeyDataBase, tpm, primaryKey, pcrPolicyCounterPub, pcrProfile, false, session); err != nil {
+	if err := skdbUpdatePCRProtectionPolicyNoValidate(&skd.sealedKeyDataBase, tpm, primaryKey, pcrPolicyCounterPub, pcrProfile, resetPcrPolicyVersion, session); err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot set initial PCR policy: %w", err)
 	}
 

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -69,11 +69,7 @@ type PassphraseProtectKeyParams struct {
 
 type keyDataConstructor func(skd *SealedKeyData, role string, encryptedPayload []byte, kdfAlg crypto.Hash) (*secboot.KeyData, error)
 
-func (fn keyDataConstructor) NewKeyData(skd *SealedKeyData, role string, encryptedPayload []byte, kdfAlg crypto.Hash) (*secboot.KeyData, error) {
-	return fn(skd, role, encryptedPayload, kdfAlg)
-}
-
-var makeKeyDataNoAuth keyDataConstructor = func(skd *SealedKeyData, role string, encryptedPayload []byte, kdfAlg crypto.Hash) (*secboot.KeyData, error) {
+func makeKeyDataNoAuth(skd *SealedKeyData, role string, encryptedPayload []byte, kdfAlg crypto.Hash) (*secboot.KeyData, error) {
 	return secbootNewKeyData(&secboot.KeyParams{
 		Handle:           skd,
 		Role:             role,
@@ -206,7 +202,7 @@ func makeSealedKeyData(tpm *tpm2.TPMContext, params *makeSealedKeyDataParams, se
 	ciphertext := aead.Seal(nil, symKey[32:], payload, aad)
 
 	// Construct the secboot.KeyData object
-	kd, err := constructor.NewKeyData(skd, params.Role, ciphertext, kdfAlg)
+	kd, err := constructor(skd, params.Role, ciphertext, kdfAlg)
 	if err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot create key data object: %w", err)
 	}

--- a/tpm2/seal.go
+++ b/tpm2/seal.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 
 	"golang.org/x/xerrors"
 
@@ -45,6 +46,8 @@ type ProtectKeyParams struct {
 	// by calling SealedKeyData.UpdatePCRProtectionPolicy.
 	PCRProfile *PCRProtectionProfile
 
+	Role string
+
 	// PCRPolicyCounterHandle is the handle at which to create a NV index for PCR
 	// authorization policy revocation support. The handle must either be tpm2.HandleNull
 	// (in which case, no NV index will be created and the sealed key will not benefit
@@ -55,92 +58,13 @@ type ProtectKeyParams struct {
 	// owner objects (0x01800000 - 0x01bfffff).
 	PCRPolicyCounterHandle tpm2.Handle
 
-	// AuthKey is the key used to authorize changes to the newly create key,
-	// via the SealedKeyObject.UpdatePCRProtectionPolicy and
-	// secboot.KeyData.SetAuthorizedSnapModels APIs. If set, this should be a
-	// random 32-byte number.
-	// If not set, one is generated automatically.
-	AuthKey secboot.PrimaryKey
-
-	// AuthorizedSnapModels is a list of models initially authorized to access
-	// the data protected by the newly created key. These can be updated later
-	// on by calling secboot.KeyData.SetAuthorizedSnapModels.
-	AuthorizedSnapModels []secboot.SnapModel
+	PrimaryKey secboot.PrimaryKey
 }
 
-// makeKeyDataWithPolicy protects the supplied keys using the supplied keySealer and
-// policy data. This can be called multiple times to protect an arbitary number of
-// keys with an identical policy.
-func makeKeyDataWithPolicy(key secboot.DiskUnlockKey, authKey secboot.PrimaryKey, policy *keyDataPolicyParams, sealer keySealer) (*secboot.KeyData, error) {
-	var symKey [32 + aes.BlockSize]byte
-	if _, err := rand.Read(symKey[:]); err != nil {
-		return nil, xerrors.Errorf("cannot create symmetric key: %w", err)
-	}
+type PassphraseProtectKeyParams struct {
+	ProtectKeyParams
 
-	priv, pub, importSymSeed, err := sealer.CreateSealedObject(symKey[:], policy.Alg, policy.AuthPolicy)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a new SealedKeyObject.
-	data, err := newKeyData(priv, pub, importSymSeed, policy.PolicyData)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create key data: %w", err)
-	}
-	skd := &SealedKeyData{sealedKeyDataBase: sealedKeyDataBase{data: data}}
-
-	// Create encrypted payload
-	payload := secboot.MarshalKeys(key, authKey)
-
-	b, err := aes.NewCipher(symKey[:32])
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create new cipher: %w", err)
-	}
-	stream := cipher.NewCFBEncrypter(b, symKey[32:])
-	stream.XORKeyStream(payload, payload)
-
-	kd, err := secbootNewKeyData(&secboot.KeyParams{
-		Handle:           skd,
-		EncryptedPayload: payload,
-		PlatformName:     platformName,
-		PrimaryKey:       authKey,
-		// Hardcode SHA-256 here. We already hardcode this as the name algorithm
-		// for the sealed object and elliptic key.
-		SnapModelAuthHash: crypto.SHA256})
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create key data object: %w", err)
-	}
-
-	return kd, nil
-}
-
-type createdPcrPolicyCounter struct {
-	tpm     *tpm2.TPMContext
-	session tpm2.SessionContext
-	pub     *tpm2.NVPublic
-}
-
-func (c *createdPcrPolicyCounter) Pub() *tpm2.NVPublic {
-	if c == nil {
-		return nil
-	}
-	return c.pub
-}
-
-func (c *createdPcrPolicyCounter) undefineOnError(err error) {
-	if c == nil {
-		return
-	}
-
-	if err == nil {
-		return
-	}
-
-	index, err := tpm2.CreateNVIndexResourceContextFromPublic(c.pub)
-	if err != nil {
-		return
-	}
-	c.tpm.NVUndefineSpace(c.tpm.OwnerHandleContext(), index, c.session)
+	KDFOptions *secboot.KDFOptions
 }
 
 type keyDataConstructor func(skd *SealedKeyData, role string, encryptedPayload []byte, kdfAlg crypto.Hash) (*secboot.KeyData, error)
@@ -175,116 +99,122 @@ func makeKeyDataWithPassphraseConstructor(kdfOptions *secboot.KDFOptions, passph
 	}
 }
 
-// keyDataPolicyParams corresponds to the parameters of a key's computed authorization
-// policy, consisting of the digest algorithm, the policy digest and the associated policy
-// data.
-type keyDataPolicyParams struct {
-	Alg        tpm2.HashAlgorithmId
-	PolicyData keyDataPolicy
-	AuthPolicy tpm2.Digest
+type makeSealedKeyDataParams struct {
+	pcrProfile             *PCRProtectionProfile
+	role                   string
+	pcrPolicyCounterHandle tpm2.Handle
+	primaryKey             secboot.PrimaryKey
+	authMode               secboot.AuthMode
 }
 
-// makeKeyDataPolicy creates the policy data required to seal a key with makeKeyDataWithPolicy
-// and creates a PCR policy counter if required.
-func makeKeyDataPolicy(tpm *tpm2.TPMContext, pcrPolicyCounterHandle tpm2.Handle, authKey secboot.PrimaryKey,
-	session tpm2.SessionContext) (data *keyDataPolicyParams, pcrPolicyCounterOut *createdPcrPolicyCounter,
-	authKeyOut secboot.PrimaryKey, err error) {
-	// Create an auth key.
-	if authKey == nil {
-		authKey = make(secboot.PrimaryKey, 32)
-		if _, err := rand.Read(authKey); err != nil {
-			return nil, nil, nil, xerrors.Errorf("cannot create key for signing dynamic authorization policies: %w", err)
+func makeSealedKeyData(tpm *tpm2.TPMContext, params *makeSealedKeyDataParams, sealer keySealer, constructor keyDataConstructor, session tpm2.SessionContext) (*secboot.KeyData, secboot.PrimaryKey, secboot.DiskUnlockKey, error) {
+	// Create a primary key, if required.
+	primaryKey := params.primaryKey
+	if primaryKey == nil {
+		primaryKey = make(secboot.PrimaryKey, 32)
+		if _, err := rand.Read(primaryKey); err != nil {
+			return nil, nil, nil, xerrors.Errorf("cannot create primary key: %w", err)
 		}
 	}
-	authPublicKey, err := newPolicyAuthPublicKey(authKey)
+
+	// Create the key for authorizing PCR policy updates.
+	authPublicKey, err := newPolicyAuthPublicKey(primaryKey)
 	if err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot derive public area of key for signing dynamic authorization policies: %w", err)
 	}
 
-	// Create PCR policy counter, if requested.
-	var pcrPolicyCount uint64
-	var pcrPolicyCounter *createdPcrPolicyCounter
-	if pcrPolicyCounterHandle != tpm2.HandleNull {
+	// Create PCR policy counter, if requested and if one doesn't already exist.
+	var pcrPolicyCounterPub *tpm2.NVPublic
+	if params.pcrPolicyCounterHandle != tpm2.HandleNull {
 		if tpm == nil {
 			return nil, nil, nil, errors.New("cannot create a PCR policy counter without a TPM connection")
 		}
 
-		var pub *tpm2.NVPublic
-		pub, pcrPolicyCount, err = createPcrPolicyCounter(tpm, pcrPolicyCounterHandle, authPublicKey, session)
+		var err error
+		pcrPolicyCounterPub, err = ensurePcrPolicyCounter(tpm, params.pcrPolicyCounterHandle, authPublicKey, session)
 		switch {
 		case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
-			return nil, nil, nil, TPMResourceExistsError{pcrPolicyCounterHandle}
+			return nil, nil, nil, TPMResourceExistsError{params.pcrPolicyCounterHandle}
 		case isAuthFailError(err, tpm2.CommandNVDefineSpace, 1):
 			return nil, nil, nil, AuthFailError{tpm2.HandleOwner}
 		case err != nil:
 			return nil, nil, nil, xerrors.Errorf("cannot create new PCR policy counter: %w", err)
 		}
-
-		pcrPolicyCounter = &createdPcrPolicyCounter{
-			tpm:     tpm,
-			session: session,
-			pub:     pub}
-
-		defer func() { pcrPolicyCounter.undefineOnError(err) }()
 	}
 
-	alg := tpm2.HashAlgorithmSHA256
+	// Create the initial policy data.
+	nameAlg := tpm2.HashAlgorithmSHA256
+	requireAuthValue := params.authMode != secboot.AuthModeNone
 
-	// Create the initial policy data
-	policyData, authPolicy, err := newKeyDataPolicy(alg, authPublicKey, pcrPolicyCounter.Pub(), pcrPolicyCount)
+	policyData, authPolicyDigest, err := newKeyDataPolicy(nameAlg, authPublicKey, params.role, pcrPolicyCounterPub, requireAuthValue)
 	if err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot create initial policy data: %w", err)
 	}
 
-	return &keyDataPolicyParams{
-		Alg:        alg,
-		PolicyData: policyData,
-		AuthPolicy: authPolicy}, pcrPolicyCounter, authKey, nil
-}
-
-// keyDataParams contains the parameters required to seal a new key with makeKeyData.
-type keyDataParams struct {
-	PCRPolicyCounterHandle tpm2.Handle
-	PCRProfile             *PCRProtectionProfile
-}
-
-// makeKeyData protects the supplied keys using the supplied keySealer and
-// parameters. If required, a PCR policy counter is created. The returned key
-// will have an initial PCR policy as specified via the supplied parameters.
-func makeKeyData(tpm *tpm2.TPMContext, key secboot.DiskUnlockKey, authKey secboot.PrimaryKey, params *keyDataParams,
-	sealer keySealer, session tpm2.SessionContext) (protectedKey *secboot.KeyData, authKeyOut secboot.PrimaryKey,
-	pcrPolicyCounterOut *createdPcrPolicyCounter, err error) {
-	policy, pcrPolicyCounter, authKey, err := makeKeyDataPolicy(tpm, params.PCRPolicyCounterHandle, authKey, session)
-	if err != nil {
-		return nil, nil, nil, err
+	// Create a 32 byte symmetric key and 12 byte nonce.
+	var symKey [32 + 12]byte
+	if _, err := rand.Read(symKey[:]); err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create symmetric key: %w", err)
 	}
-	defer func() { pcrPolicyCounter.undefineOnError(err) }()
 
-	protectedKey, err = makeKeyDataWithPolicy(key, authKey, policy, sealer)
+	// Seal the symmetric key and nonce.
+	priv, pub, importSymSeed, err := sealer.CreateSealedObject(symKey[:], nameAlg, authPolicyDigest)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	skd, err := NewSealedKeyData(protectedKey)
+	// Create a new SealedKeyData.
+	data, err := newKeyData(priv, pub, importSymSeed, policyData)
 	if err != nil {
-		return nil, nil, nil, xerrors.Errorf("cannot obtain SealedKeyObject from KeyData: %w", err)
+		return nil, nil, nil, xerrors.Errorf("cannot create key data: %w", err)
 	}
+	skd := &SealedKeyData{sealedKeyDataBase: sealedKeyDataBase{data: data}}
 
-	pcrProfile := params.PCRProfile
+	// Set the initial PCR policy.
+	pcrProfile := params.pcrProfile
 	if pcrProfile == nil {
 		pcrProfile = NewPCRProtectionProfile()
 	}
-	if err := skdbUpdatePCRProtectionPolicyImpl(&skd.sealedKeyDataBase, tpm, authKey, pcrPolicyCounter.Pub(), pcrProfile, session); err != nil {
+	if err := skdbUpdatePCRProtectionPolicyNoValidate(&skd.sealedKeyDataBase, tpm, primaryKey, pcrPolicyCounterPub, pcrProfile, false, session); err != nil {
 		return nil, nil, nil, xerrors.Errorf("cannot set initial PCR policy: %w", err)
 	}
-	if err := protectedKey.MarshalAndUpdatePlatformHandle(skd); err != nil {
-		return nil, nil, nil, xerrors.Errorf("cannot update platform handle: %w", err)
+
+	// Create the GCM encrypted payload. Use the name algorithm as the KDF algorithm here.
+	kdfAlg := crypto.SHA256
+	unlockKey, payload, err := secboot.MakeDiskUnlockKey(rand.Reader, kdfAlg, primaryKey)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create new unlock key: %w", err)
 	}
 
-	return protectedKey, authKey, pcrPolicyCounter, nil
+	aad, err := mu.MarshalToBytes(&additionalData_v3{
+		BaseVersion: uint32(secboot.KeyDataVersion),
+		KDFAlg:      tpm2.HashAlgorithmSHA256,
+		AuthMode:    params.authMode,
+	})
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create AAD: %w", err)
+	}
+
+	b, err := aes.NewCipher(symKey[:32])
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create new cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(b)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create AEAD cipher: %w", err)
+	}
+	ciphertext := aead.Seal(nil, symKey[32:], payload, aad)
+
+	// Construct the secboot.KeyData object
+	kd, err := constructor.NewKeyData(skd, params.role, ciphertext, kdfAlg)
+	if err != nil {
+		return nil, nil, nil, xerrors.Errorf("cannot create key data object: %w", err)
+	}
+
+	return kd, primaryKey, unlockKey, nil
 }
 
-// ProtectKeyWithExternalStorageKey seals the supplied disk encryption key to the TPM storage
+// NewExternalTPMProtectedKey seals the supplied primary key to the TPM storage
 // key asociated with the supplied public tpmKey. This creates an importable sealed key and
 // is suitable in environments that don't have access to the TPM but do have access to the
 // public part of the TPM's storage primary key.
@@ -299,143 +229,27 @@ func makeKeyData(tpm *tpm2.TPMContext, key secboot.DiskUnlockKey, authKey secboo
 // supplied via the PCRProfile field of the params argument. The PCR policy can be updated
 // later on via the SealedKeyObject.UpdatePCRProtectionPolicy API.
 //
-// The sealed key will be created with the snap models provided via the AuthorizedSnapModels
-// field of params authorized to access the data protected by this key. The set of
-// authorized models can be updated later on by calling
-// secboot.KeyData.SetAuthorizedSnapModels.
-//
-// The key used for authorizing changes to the sealed key object via the
-// SealedKeyObject.UpdatePCRProtectionPolicy and secboot.KeyData.SetAuthorizedSnapModels
-// APIs can be supplied via the AuthKey field of params. This should be cryptographically
-// strong 32-byte key. If one is not supplied, it will be created automatically.
-//
-// On success, this function returns the the sealed key object and a key used for
-// authorizing changes via the SealedKeyObject.UpdatePCRProtectionPolicy and
-// secboot.KeyData.SetAuthorizedSnapModels APIs. This key doesn't need to be
-// stored anywhere, and certainly mustn't be stored outside of the encrypted container
-// protected by the supplied key. The key is stored encrypted inside the sealed
-// key data and will be returnred from future calls to secboot.KeyData.RecoverKeys.
-func ProtectKeyWithExternalStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockKey, params *ProtectKeyParams) (protectedKey *secboot.KeyData, authKey secboot.PrimaryKey, err error) {
+// On success, this function returns the the sealed key object, the primary key and the
+// unique key which is used for disk unlocking.
+func NewExternalTPMProtectedKey(tpmKey *tpm2.Public, params *ProtectKeyParams) (protectedKey *secboot.KeyData, primaryKey secboot.PrimaryKey, unlockKey secboot.DiskUnlockKey, err error) {
 	// params is mandatory.
 	if params == nil {
-		return nil, nil, errors.New("no ProtectKeyParams provided")
-	}
-	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
-		return nil, nil, errors.New("PCR policy counter handle must be tpm2.HandleNull when creating an importable sealed key")
+		return nil, nil, nil, errors.New("no ProtectKeyParams provided")
 	}
 
 	sealer := &importableObjectKeySealer{tpmKey: tpmKey}
 
-	protectedKey, authKey, _, err = makeKeyData(nil, key, params.AuthKey, &keyDataParams{
-		PCRPolicyCounterHandle: params.PCRPolicyCounterHandle,
-		PCRProfile:             params.PCRProfile}, sealer, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := protectedKey.SetAuthorizedSnapModels(authKey, params.AuthorizedSnapModels...); err != nil {
-		return nil, nil, xerrors.Errorf("cannot set authorized snap models: %w", err)
-	}
-
-	return protectedKey, authKey, nil
+	return makeSealedKeyData(nil, &makeSealedKeyDataParams{
+		primaryKey:             params.PrimaryKey,
+		pcrPolicyCounterHandle: params.PCRPolicyCounterHandle,
+		authMode:               secboot.AuthModeNone,
+		role:                   params.Role,
+		pcrProfile:             params.PCRProfile,
+	}, sealer, makeKeyDataNoAuth, nil)
 }
 
-// ProtectKeysWithTPM seals the supplied disk encryption keys to the storage
-// hierarchy of the TPM. The keys are specified by the keys argument.
-//
-// This function requires knowledge of the authorization value for the storage hierarchy,
-// which must be provided by calling Connection.OwnerHandleContext().SetAuthValue() prior
-// to calling this function. If the provided authorization value is incorrect, a
-// AuthFailError error will be returned.
-//
-// This function will create a NV index at the handle specified by the
-// PCRPolicyCounterHandle field of the params argument if it is not tpm2.HandleNull. If
-// the handle is already in use, a TPMResourceExistsError error will be returned. In this
-// case, the caller will need to either choose a different handle or undefine the existing
-// one. If it is not tpm2.HandleNull, then it must be a valid NV index handle (MSO == 0x01),
-// and the choice of handle should take in to consideration the reserved indices from the
-// "Registry of reserved TPM 2.0 handles and localities" specification. It is recommended
-// that the handle is in the block reserved for owner objects (0x01800000 - 0x01bfffff).
-//
-// All keys will be created with the same authorization policy, and will be protected with
-// a PCR policy computed from the PCRProtectionProfile supplied via the PCRProfile field
-// of the params argument. The PCR policy can be updated later on via the
-// UpdateKeyPCRProtectionPolicyMultiple API.
-//
-// The sealed keys will be created with the snap models provided via the AuthorizedSnapModels
-// field of params authorized to access the data protected by these keys. The set
-// of authorized models can be updated later on by calling
-// secboot.KeyData.SetAuthorizedSnapModels for each key.
-//
-// The key used for authorizing changes to the sealed key objects via the
-// UpdateKeyPCRProtectionPolicyMultiple and secboot.KeyData.SetAuthorizedSnapModels
-// APIs can be supplied via the AuthKey field of params. This should be cryptographically
-// strong 32-byte key. If one is not supplied, it will be created automatically.
-//
-// On success, this function returns the the sealed key objects and a key used for
-// authorizing changes via the UpdateKeyPCRProtectionPolicyMultiple and
-// secboot.KeyData.SetAuthorizedSnapModels APIs. This key doesn't need to be
-// stored anywhere, and certainly mustn't be stored outside of the encrypted containers
-// protected by the supplied keys. The key is stored encrypted inside the sealed
-// key data and will be returnred from future calls to secboot.KeyData.RecoverKeys.
-func ProtectKeysWithTPM(tpm *Connection, keys []secboot.DiskUnlockKey, params *ProtectKeyParams) (protectedKeys []*secboot.KeyData, authKey secboot.PrimaryKey, err error) {
-	// params is mandatory.
-	if params == nil {
-		return nil, nil, errors.New("no ProtectKeyParams provided")
-	}
-	if len(keys) == 0 {
-		return nil, nil, errors.New("no keys provided")
-	}
-
-	sealer := &sealedObjectKeySealer{tpm}
-
-	var protectedKey *secboot.KeyData
-	var pcrPolicyCounter *createdPcrPolicyCounter
-
-	protectedKey, authKey, pcrPolicyCounter, err = makeKeyData(tpm.TPMContext, keys[0], params.AuthKey,
-		&keyDataParams{
-			PCRPolicyCounterHandle: params.PCRPolicyCounterHandle,
-			PCRProfile:             params.PCRProfile},
-		sealer, tpm.HmacSession())
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() { pcrPolicyCounter.undefineOnError(err) }()
-	protectedKeys = append(protectedKeys, protectedKey)
-
-	skd, err := NewSealedKeyData(protectedKey)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot obtain SealedKeyObject from KeyData: %w", err)
-	}
-
-	policy := &keyDataPolicyParams{
-		Alg:        skd.data.Public().NameAlg,
-		AuthPolicy: skd.data.Public().AuthPolicy,
-		PolicyData: skd.data.Policy()}
-	for _, key := range keys[1:] {
-		protectedKey, err := makeKeyDataWithPolicy(key, authKey, policy, sealer)
-		if err != nil {
-			return nil, nil, err
-		}
-		protectedKeys = append(protectedKeys, protectedKey)
-	}
-
-	for _, kd := range protectedKeys {
-		if err := kd.SetAuthorizedSnapModels(authKey, params.AuthorizedSnapModels...); err != nil {
-			return nil, nil, xerrors.Errorf("cannot set authorized snap models: %w", err)
-		}
-	}
-
-	return protectedKeys, authKey, nil
-}
-
-// ProtectKeyWithTPM seals the supplied disk encryption key to the storage hierarchy of
+// NewTPMProtectedKey seals the supplied disk encryption key to the storage hierarchy of
 // the TPM.
-//
-// This function requires knowledge of the authorization value for the storage hierarchy,
-// which must be provided by calling Connection.OwnerHandleContext().SetAuthValue() prior
-// to calling this function. If the provided authorization value is incorrect, a
-// AuthFailError error will be returned.
 //
 // This function will create a NV index at the handle specified by the
 // PCRPolicyCounterHandle field of the params argument if it is not tpm2.HandleNull. If
@@ -450,34 +264,41 @@ func ProtectKeysWithTPM(tpm *Connection, keys []secboot.DiskUnlockKey, params *P
 // supplied via the PCRProfile field of the params argument. The PCR policy can be updated
 // later on via the SealedKeyObject.UpdatePCRProtectionPolicy API.
 //
-// The sealed key will be created with the snap models provided via the AuthorizedSnapModels
-// field of params authorized to access the data protected by this key. The set of
-// authorized models can be updated later on by calling
-// secboot.KeyData.SetAuthorizedSnapModels.
-//
 // The key used for authorizing changes to the sealed key object via the
-// SealedKeyObject.UpdatePCRProtectionPolicy and secboot.KeyData.SetAuthorizedSnapModels
-// APIs can be supplied via the AuthKey field of params. This should be cryptographically
-// strong 32-byte key. If one is not supplied, it will be created automatically.
+// SealedKeyObject.UpdatePCRProtectionPolicy is derived from the primary key.
 //
-// On success, this function returns the the sealed key object and a key used for
-// authorizing changes via the SealedKeyObject.UpdatePCRProtectionPolicy and
-// secboot.KeyData.SetAuthorizedSnapModels APIs. This key doesn't need to be
-// stored anywhere, and certainly mustn't be stored outside of the encrypted container
-// protected by the supplied key. The key is stored encrypted inside the sealed
-// key data and will be returnred from future calls to secboot.KeyData.RecoverKeys.
-func ProtectKeyWithTPM(tpm *Connection, key secboot.DiskUnlockKey, params *ProtectKeyParams) (protectedKey *secboot.KeyData, authKey secboot.PrimaryKey, err error) {
+// On success, this function returns the the sealed key object, the primary key and the
+// unique key which is used for disk unlocking.
+func NewTPMProtectedKey(tpm *Connection, params *ProtectKeyParams) (protectedKey *secboot.KeyData, primaryKey secboot.PrimaryKey, unlockKey secboot.DiskUnlockKey, err error) {
 	// params is mandatory.
 	if params == nil {
-		return nil, nil, errors.New("no ProtectKeyParams provided")
+		return nil, nil, nil, errors.New("no ProtectKeyParams provided")
 	}
 
-	var protectedKeys []*secboot.KeyData
+	sealer := &sealedObjectKeySealer{tpm}
 
-	protectedKeys, authKey, err = ProtectKeysWithTPM(tpm, []secboot.DiskUnlockKey{key}, params)
-	if err != nil {
-		return nil, nil, err
+	return makeSealedKeyData(tpm.TPMContext, &makeSealedKeyDataParams{
+		pcrProfile:             params.PCRProfile,
+		role:                   params.Role,
+		pcrPolicyCounterHandle: params.PCRPolicyCounterHandle,
+		primaryKey:             params.PrimaryKey,
+		authMode:               secboot.AuthModeNone,
+	}, sealer, makeKeyDataNoAuth, tpm.HmacSession())
+}
+
+func NewTPMPassphraseProtectedKey(tpm *Connection, params *PassphraseProtectKeyParams, passphrase string, kdf secboot.KDF) (protectedKey *secboot.KeyData, primaryKey secboot.PrimaryKey, unlockKey secboot.DiskUnlockKey, err error) {
+	// params is mandatory.
+	if params == nil {
+		return nil, nil, nil, errors.New("no PassphraseProtectKeyParams provided")
 	}
 
-	return protectedKeys[0], authKey, nil
+	sealer := &sealedObjectKeySealer{tpm}
+
+	return makeSealedKeyData(tpm.TPMContext, &makeSealedKeyDataParams{
+		primaryKey:             params.PrimaryKey,
+		pcrPolicyCounterHandle: params.PCRPolicyCounterHandle,
+		authMode:               secboot.AuthModePassphrase,
+		role:                   params.Role,
+		pcrProfile:             params.PCRProfile,
+	}, sealer, makeKeyDataWithPassphraseConstructor(params.KDFOptions, passphrase, kdf), tpm.HmacSession())
 }

--- a/tpm2/seal_legacy.go
+++ b/tpm2/seal_legacy.go
@@ -291,7 +291,7 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 	var pcrPolicyCounterPub *tpm2.NVPublic
 	var pcrPolicyCount uint64
 	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
-		pcrPolicyCounterPub, pcrPolicyCount, err = createPcrPolicyCounter(tpm.TPMContext, params.PCRPolicyCounterHandle, authPublicKey, session)
+		pcrPolicyCounterPub, pcrPolicyCount, err = createPcrPolicyCounterLegacy(tpm.TPMContext, params.PCRPolicyCounterHandle, authPublicKey, session)
 		switch {
 		case tpm2.IsTPMError(err, tpm2.ErrorNVDefined, tpm2.CommandNVDefineSpace):
 			return nil, TPMResourceExistsError{params.PCRPolicyCounterHandle}

--- a/tpm2/seal_legacy.go
+++ b/tpm2/seal_legacy.go
@@ -184,7 +184,7 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockK
 	if pcrProfile == nil {
 		pcrProfile = NewPCRProtectionProfile()
 	}
-	if err := sko.updatePCRProtectionPolicyImpl(nil, authKey, nil, pcrProfile, nil); err != nil {
+	if err := sko.updatePCRProtectionPolicyNoValidate(nil, authKey, nil, pcrProfile, false, nil); err != nil {
 		return nil, xerrors.Errorf("cannot create initial PCR policy: %w", err)
 	}
 
@@ -367,7 +367,7 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 			if pcrProfile == nil {
 				pcrProfile = NewPCRProtectionProfile()
 			}
-			if err := sko.updatePCRProtectionPolicyImpl(tpm.TPMContext, authKey, pcrPolicyCounterPub, pcrProfile, session); err != nil {
+			if err := sko.updatePCRProtectionPolicyNoValidate(tpm.TPMContext, authKey, pcrPolicyCounterPub, pcrProfile, false, session); err != nil {
 				return nil, xerrors.Errorf("cannot create initial PCR policy: %w", err)
 			}
 		}

--- a/tpm2/seal_legacy.go
+++ b/tpm2/seal_legacy.go
@@ -184,7 +184,7 @@ func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockK
 	if pcrProfile == nil {
 		pcrProfile = NewPCRProtectionProfile()
 	}
-	if err := sko.updatePCRProtectionPolicyNoValidate(nil, authKey, nil, pcrProfile, false, nil); err != nil {
+	if err := sko.updatePCRProtectionPolicyNoValidate(nil, authKey, nil, pcrProfile, resetPcrPolicyVersion, nil); err != nil {
 		return nil, xerrors.Errorf("cannot create initial PCR policy: %w", err)
 	}
 
@@ -367,7 +367,7 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 			if pcrProfile == nil {
 				pcrProfile = NewPCRProtectionProfile()
 			}
-			if err := sko.updatePCRProtectionPolicyNoValidate(tpm.TPMContext, authKey, pcrPolicyCounterPub, pcrProfile, false, session); err != nil {
+			if err := sko.updatePCRProtectionPolicyNoValidate(tpm.TPMContext, authKey, pcrPolicyCounterPub, pcrProfile, resetPcrPolicyVersion, session); err != nil {
 				return nil, xerrors.Errorf("cannot create initial PCR policy: %w", err)
 			}
 		}

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -561,7 +561,7 @@ func (s *sealSuiteNoTPM) testMakeSealedKeyData(c *C, data *testMakeSealedKeyData
 	defer restore()
 
 	pcrPolicyInitialized := false
-	restore = MockSkdbUpdatePCRProtectionPolicyNoValidate(func(skdb *SealedKeyDataBase, tpm *tpm2.TPMContext, primaryKey secboot.PrimaryKey, counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, incrementPolicyVersion bool, session tpm2.SessionContext) error {
+	restore = MockSkdbUpdatePCRProtectionPolicyNoValidate(func(skdb *SealedKeyDataBase, tpm *tpm2.TPMContext, primaryKey secboot.PrimaryKey, counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, policyVersionOption PcrPolicyVersionOption, session tpm2.SessionContext) error {
 		c.Check(tpm, Equals, mockTpm)
 		c.Check(primaryKey, DeepEquals, s.lastAuthKey)
 		c.Check(counterPub, Equals, mockPcrPolicyCounterPub)
@@ -570,7 +570,7 @@ func (s *sealSuiteNoTPM) testMakeSealedKeyData(c *C, data *testMakeSealedKeyData
 			c.Check(profile, Equals, data.PCRProfile)
 		}
 		c.Check(session, Equals, mockSession)
-		c.Check(incrementPolicyVersion, testutil.IsFalse)
+		c.Check(policyVersionOption, Equals, ResetPcrPolicyVersion)
 		pcrPolicyInitialized = true
 		return nil
 	})

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -65,30 +65,20 @@ func (s *sealSuite) SetUpTest(c *C) {
 var _ = Suite(&sealSuite{})
 
 func (s *sealSuite) testProtectKeyWithTPM(c *C, params *ProtectKeyParams) {
-	key := make(secboot.DiskUnlockKey, 32)
-	rand.Read(key)
-
-	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	k, primaryKey, unlockKey, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
-
-	for _, model := range params.AuthorizedSnapModels {
-		ok, err := k.IsSnapModelAuthorized(authKey, model)
-		c.Check(err, IsNil)
-		c.Check(ok, testutil.IsTrue)
-	}
 
 	skd, err := NewSealedKeyData(k)
 	c.Assert(err, IsNil)
-	c.Check(skd.Validate(s.TPM().TPMContext, authKey, s.TPM().HmacSession()), IsNil)
+	c.Check(skd.Validate(s.TPM().TPMContext, primaryKey, s.TPM().HmacSession()), IsNil)
 
 	c.Check(skd.Version(), Equals, uint32(3))
 	c.Check(skd.PCRPolicyCounterHandle(), Equals, params.PCRPolicyCounterHandle)
 
-	policyAuthPublicKey, err := NewPolicyAuthPublicKey(authKey)
+	policyAuthPublicKey, err := NewPolicyAuthPublicKey(primaryKey)
 	c.Assert(err, IsNil)
 
 	var pcrPolicyCounterPub *tpm2.NVPublic
-	var pcrPolicySequence uint64
 	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
 		index, err := s.TPM().CreateResourceContextFromTPM(params.PCRPolicyCounterHandle)
 		c.Assert(err, IsNil)
@@ -96,25 +86,23 @@ func (s *sealSuite) testProtectKeyWithTPM(c *C, params *ProtectKeyParams) {
 		pcrPolicyCounterPub, _, err = s.TPM().NVReadPublic(index)
 		c.Check(err, IsNil)
 
-		pcrPolicySequence, err = s.TPM().NVReadCounter(index, index, nil)
-		c.Check(err, IsNil)
 	}
 
-	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, pcrPolicyCounterPub, pcrPolicySequence)
+	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, "", pcrPolicyCounterPub, false)
 	c.Assert(err, IsNil)
 
 	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
 	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
 	c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
 
-	if params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, params.AuthKey)
+	if params.PrimaryKey != nil {
+		c.Check(primaryKey, DeepEquals, params.PrimaryKey)
 	}
 
-	keyUnsealed, authKeyUnsealed, err := k.RecoverKeys()
+	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeys()
 	c.Check(err, IsNil)
-	c.Check(keyUnsealed, DeepEquals, key)
-	c.Check(authKeyUnsealed, DeepEquals, authKey)
+	c.Check(unlockKeyUnsealed, DeepEquals, unlockKey)
+	c.Check(primaryKeyUnsealed, DeepEquals, primaryKey)
 
 	if params.PCRProfile != nil {
 		// Verify that the key is sealed with the supplied PCR profile by changing
@@ -135,28 +123,14 @@ func (s *sealSuite) TestProtectKeyWithTPM(c *C) {
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 }
 
 func (s *sealSuite) TestProtectKeyWithTPMDifferentPCRPolicyCounterHandle(c *C) {
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 }
 
 func (s *sealSuite) TestProtectKeyWithTPMWithNewConnection(c *C) {
@@ -167,14 +141,7 @@ func (s *sealSuite) TestProtectKeyWithTPMWithNewConnection(c *C) {
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 
 	s.validateSRK(c)
 }
@@ -190,14 +157,7 @@ func (s *sealSuite) TestProtectKeyWithTPMMissingSRK(c *C) {
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 
 	s.validateSRK(c)
 }
@@ -238,14 +198,7 @@ func (s *sealSuite) TestProtectKeyWithTPMMissingCustomSRK(c *C) {
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, template)
 }
@@ -289,14 +242,7 @@ func (s *sealSuite) TestProtectKeyWithTPMMissingSRKWithInvalidCustomTemplate(c *
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 
 	s.validateSRK(c)
 }
@@ -310,248 +256,17 @@ func (s *sealSuite) TestProtectKeyWithTPMNoPCRPolicyCounterHandle(c *C) {
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: tpm2.HandleNull,
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 }
 
-func (s *sealSuite) TestProtectKeyWithTPMWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
+func (s *sealSuite) TestProtectKeyWithTPMWithProvidedPrimaryKey(c *C) {
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
 
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")},
-		AuthKey: authKey})
-}
-
-type testProtectKeysWithTPMData struct {
-	n      int
-	params *ProtectKeyParams
-}
-
-func (s *sealSuite) testProtectKeysWithTPM(c *C, data *testProtectKeysWithTPMData) {
-	var keys []secboot.DiskUnlockKey
-	for i := 0; i < data.n; i++ {
-		key := make(secboot.DiskUnlockKey, 32)
-		rand.Read(key)
-
-		keys = append(keys, key)
-	}
-
-	protectedKeys, authKey, err := ProtectKeysWithTPM(s.TPM(), keys, data.params)
-	c.Check(err, IsNil)
-	c.Check(protectedKeys, HasLen, data.n)
-
-	policyAuthPublicKey, err := NewPolicyAuthPublicKey(authKey)
-	c.Assert(err, IsNil)
-
-	var pcrPolicyCounterPub *tpm2.NVPublic
-	var pcrPolicySequence uint64
-	if data.params.PCRPolicyCounterHandle != tpm2.HandleNull {
-		index, err := s.TPM().CreateResourceContextFromTPM(data.params.PCRPolicyCounterHandle)
-		c.Assert(err, IsNil)
-
-		pcrPolicyCounterPub, _, err = s.TPM().NVReadPublic(index)
-		c.Check(err, IsNil)
-
-		pcrPolicySequence, err = s.TPM().NVReadCounter(index, index, nil)
-		c.Check(err, IsNil)
-	}
-
-	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, pcrPolicyCounterPub, pcrPolicySequence)
-	c.Assert(err, IsNil)
-
-	for i, k := range protectedKeys {
-		for _, model := range data.params.AuthorizedSnapModels {
-			ok, err := k.IsSnapModelAuthorized(authKey, model)
-			c.Check(err, IsNil)
-			c.Check(ok, testutil.IsTrue)
-		}
-
-		skd, err := NewSealedKeyData(k)
-		c.Assert(err, IsNil)
-		c.Check(skd.Validate(s.TPM().TPMContext, authKey, s.TPM().HmacSession()), IsNil)
-
-		c.Check(skd.Version(), Equals, uint32(3))
-		c.Check(skd.PCRPolicyCounterHandle(), Equals, data.params.PCRPolicyCounterHandle)
-
-		c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
-		c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
-		c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
-
-		keyUnsealed, authKeyUnsealed, err := k.RecoverKeys()
-		c.Check(err, IsNil)
-		c.Check(keyUnsealed, DeepEquals, keys[i])
-		c.Check(authKeyUnsealed, DeepEquals, authKey)
-	}
-
-	if data.params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, data.params.AuthKey)
-	}
-
-	if data.params.PCRProfile != nil {
-		// Verify that the keys are sealed with the supplied PCR profile by changing
-		// the PCR values.
-		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
-		c.Check(err, IsNil)
-
-		for _, k := range protectedKeys {
-			_, _, err = k.RecoverKeys()
-			c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
-				"cannot execute PolicyOR assertions: current session digest not found in policy data")
-		}
-	}
-}
-
-func (s *sealSuite) TestProtectKeysWithTPMSingle(c *C) {
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 1,
-		params: &ProtectKeyParams{
-			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-			AuthorizedSnapModels: []secboot.SnapModel{
-				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-					"authority-id": "fake-brand",
-					"series":       "16",
-					"brand-id":     "fake-brand",
-					"model":        "fake-model",
-					"grade":        "secured",
-				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
-}
-
-func (s *sealSuite) TestProtectKeysWithTPM2Keys(c *C) {
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 2,
-		params: &ProtectKeyParams{
-			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-			AuthorizedSnapModels: []secboot.SnapModel{
-				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-					"authority-id": "fake-brand",
-					"series":       "16",
-					"brand-id":     "fake-brand",
-					"model":        "fake-model",
-					"grade":        "secured",
-				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
-}
-
-func (s *sealSuite) TestProtectKeysWithTPMDifferentPCRPolicyCounterHandle(c *C) {
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 2,
-		params: &ProtectKeyParams{
-			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181fff0),
-			AuthorizedSnapModels: []secboot.SnapModel{
-				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-					"authority-id": "fake-brand",
-					"series":       "16",
-					"brand-id":     "fake-brand",
-					"model":        "fake-model",
-					"grade":        "secured",
-				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
-}
-
-func (s *sealSuite) TestProtectKeysWithTPMWithNewConnection(c *C) {
-	// ProtectKeysWithTPM behaves slightly different if called immediately
-	// after EnsureProvisioned with the same Connection
-	s.ReinitTPMConnectionFromExisting(c)
-
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 2,
-		params: &ProtectKeyParams{
-			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-			AuthorizedSnapModels: []secboot.SnapModel{
-				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-					"authority-id": "fake-brand",
-					"series":       "16",
-					"brand-id":     "fake-brand",
-					"model":        "fake-model",
-					"grade":        "secured",
-				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
-}
-
-func (s *sealSuite) TestProtectKeysWithTPMMissingSRK(c *C) {
-	// Ensure that calling ProtectKeysWithTPM recreates the SRK with the standard
-	// template
-	srk, err := s.TPM().CreateResourceContextFromTPM(tcg.SRKHandle)
-	c.Assert(err, IsNil)
-	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
-
-	s.ReinitTPMConnectionFromExisting(c)
-
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 2,
-		params: &ProtectKeyParams{
-			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-			AuthorizedSnapModels: []secboot.SnapModel{
-				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-					"authority-id": "fake-brand",
-					"series":       "16",
-					"brand-id":     "fake-brand",
-					"model":        "fake-model",
-					"grade":        "secured",
-				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
-
-	s.validateSRK(c)
-}
-
-func (s *sealSuite) TestProtectKeyWithTPMMultipeNilPCRProfileAndNoAuthorizedSnapModels(c *C) {
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 2,
-		params: &ProtectKeyParams{
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)}})
-}
-
-func (s *sealSuite) TestProtectKeysWithTPMNoPCRPolicyCounterHandle(c *C) {
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 2,
-		params: &ProtectKeyParams{
-			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
-			PCRPolicyCounterHandle: tpm2.HandleNull,
-			AuthorizedSnapModels: []secboot.SnapModel{
-				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-					"authority-id": "fake-brand",
-					"series":       "16",
-					"brand-id":     "fake-brand",
-					"model":        "fake-model",
-					"grade":        "secured",
-				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}}})
-}
-
-func (s *sealSuite) TestProtectKeysWithTPMWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
-
-	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
-		n: 2,
-		params: &ProtectKeyParams{
-			PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-			AuthorizedSnapModels: []secboot.SnapModel{
-				testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-					"authority-id": "fake-brand",
-					"series":       "16",
-					"brand-id":     "fake-brand",
-					"model":        "fake-model",
-					"grade":        "secured",
-				}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")},
-			AuthKey: authKey}})
+		PrimaryKey:             primaryKey})
 }
 
 func (s *sealSuite) testProtectKeyWithTPMErrorHandling(c *C, params *ProtectKeyParams) error {
@@ -568,7 +283,7 @@ func (s *sealSuite) testProtectKeyWithTPMErrorHandling(c *C, params *ProtectKeyP
 	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
-	_, _, sealErr := ProtectKeyWithTPM(s.TPM(), key, params)
+	_, _, _, sealErr := NewTPMProtectedKey(s.TPM(), params)
 
 	var counter tpm2.ResourceContext
 	if params != nil && params.PCRPolicyCounterHandle != tpm2.HandleNull {
@@ -580,12 +295,13 @@ func (s *sealSuite) testProtectKeyWithTPMErrorHandling(c *C, params *ProtectKeyP
 		c.Check(err, IsNil)
 	}
 
-	switch {
-	case origCounter == nil:
-		c.Check(counter, IsNil)
-	case origCounter != nil:
+	if params != nil && params.PCRPolicyCounterHandle != tpm2.HandleNull {
 		c.Assert(counter, NotNil)
-		c.Check(counter.Name(), DeepEquals, origCounter.Name())
+		if origCounter != nil {
+			c.Check(counter.Name(), DeepEquals, origCounter.Name())
+		}
+	} else {
+		c.Check(counter, IsNil)
 	}
 
 	return sealErr
@@ -605,20 +321,6 @@ func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingOwnerAuthFail(c *C) {
 		PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Assert(err, testutil.ConvertibleTo, AuthFailError{})
 	c.Check(err.(AuthFailError).Handle, Equals, tpm2.HandleOwner)
-}
-
-func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingPCRPolicyCounterExists(c *C) {
-	public := tpm2.NVPublic{
-		Index:   s.NextAvailableHandle(c, 0x0181ffff),
-		NameAlg: tpm2.HashAlgorithmSHA256,
-		Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVAuthRead),
-		Size:    0}
-	s.NVDefineSpace(c, tpm2.HandleOwner, nil, &public)
-
-	err := s.testProtectKeyWithTPMErrorHandling(c, &ProtectKeyParams{
-		PCRPolicyCounterHandle: public.Index})
-	c.Assert(err, testutil.ConvertibleTo, TPMResourceExistsError{})
-	c.Check(err.(TPMResourceExistsError).Handle, Equals, public.Index)
 }
 
 func (s *sealSuite) TestProtectKeyWithTPMErrorHandlingInvalidPCRProfile(c *C) {
@@ -650,40 +352,34 @@ func (s *sealSuite) testProtectKeyWithExternalStorageKey(c *C, params *ProtectKe
 	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
-	k, authKey, err := ProtectKeyWithExternalStorageKey(srkPub, key, params)
+	k, primaryKey, unlockKey, err := NewExternalTPMProtectedKey(srkPub, params)
 	c.Assert(err, IsNil)
-
-	for _, model := range params.AuthorizedSnapModels {
-		ok, err := k.IsSnapModelAuthorized(authKey, model)
-		c.Check(err, IsNil)
-		c.Check(ok, testutil.IsTrue)
-	}
 
 	skd, err := NewSealedKeyData(k)
 	c.Assert(err, IsNil)
-	c.Check(skd.Validate(s.TPM().TPMContext, authKey, s.TPM().HmacSession()), IsNil)
+	c.Check(skd.Validate(s.TPM().TPMContext, primaryKey, s.TPM().HmacSession()), IsNil)
 
 	c.Check(skd.Version(), Equals, uint32(3))
 	c.Check(skd.PCRPolicyCounterHandle(), Equals, tpm2.HandleNull)
 
-	policyAuthPublicKey, err := NewPolicyAuthPublicKey(authKey)
+	policyAuthPublicKey, err := NewPolicyAuthPublicKey(primaryKey)
 	c.Assert(err, IsNil)
 
-	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, nil, 0)
+	expectedPolicyData, expectedPolicyDigest, err := NewKeyDataPolicy(tpm2.HashAlgorithmSHA256, policyAuthPublicKey, "", nil, false)
 	c.Assert(err, IsNil)
 
 	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
 	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, expectedPolicyDigest)
 	c.Check(skd.Data().Policy().(*KeyDataPolicy_v3).StaticData, tpm2_testutil.TPMValueDeepEquals, expectedPolicyData.(*KeyDataPolicy_v3).StaticData)
 
-	if params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, params.AuthKey)
+	if params.PrimaryKey != nil {
+		c.Check(primaryKey, DeepEquals, params.PrimaryKey)
 	}
 
-	keyUnsealed, authKeyUnsealed, err := k.RecoverKeys()
+	unlockKeyUnsealed, primaryKeyUnsealed, err := k.RecoverKeys()
 	c.Check(err, IsNil)
-	c.Check(keyUnsealed, DeepEquals, key)
-	c.Check(authKeyUnsealed, DeepEquals, authKey)
+	c.Check(unlockKeyUnsealed, DeepEquals, unlockKey)
+	c.Check(primaryKeyUnsealed, DeepEquals, primaryKey)
 
 	if params.PCRProfile != nil {
 		// Verify that the key is sealed with the supplied PCR profile by changing
@@ -700,14 +396,7 @@ func (s *sealSuite) TestProtectKeyWithExternalStorageKey(c *C) {
 	s.testProtectKeyWithExternalStorageKey(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewResolvedPCRProfileFromCurrentValues(c, s.TPM().TPMContext, tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: tpm2.HandleNull,
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}})
+	})
 }
 
 func (s *sealSuite) TestProtectKeyWithExternalStorageKeyNilPCRProfileAndNoAuthorizedSnapModels(c *C) {
@@ -715,22 +404,14 @@ func (s *sealSuite) TestProtectKeyWithExternalStorageKeyNilPCRProfileAndNoAuthor
 		PCRPolicyCounterHandle: tpm2.HandleNull})
 }
 
-func (s *sealSuite) TestProtectKeyWithExternalStorageKeyWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
+func (s *sealSuite) TestProtectKeyWithExternalStorageKeyWithProvidedPrimaryKey(c *C) {
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
 
 	s.testProtectKeyWithExternalStorageKey(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewResolvedPCRProfileFromCurrentValues(c, s.TPM().TPMContext, tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: tpm2.HandleNull,
-		AuthorizedSnapModels: []secboot.SnapModel{
-			testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
-				"authority-id": "fake-brand",
-				"series":       "16",
-				"brand-id":     "fake-brand",
-				"model":        "fake-model",
-				"grade":        "secured",
-			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")},
-		AuthKey: authKey})
+		PrimaryKey:             primaryKey})
 }
 
 func (s *sealSuite) testProtectKeyWithExternalStorageKeyErrorHandling(c *C, params *ProtectKeyParams) error {
@@ -743,7 +424,7 @@ func (s *sealSuite) testProtectKeyWithExternalStorageKeyErrorHandling(c *C, para
 	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
-	_, _, sealErr := ProtectKeyWithExternalStorageKey(srkPub, key, params)
+	_, _, _, sealErr := NewExternalTPMProtectedKey(srkPub, params)
 	return sealErr
 }
 
@@ -764,13 +445,6 @@ func (s *sealSuite) TestProtectKeyWithExternalStorageKeyErrorHandlingInvalidPCRP
 		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 50, make([]byte, tpm2.HashAlgorithmSHA256.Size())),
 		PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Check(err, ErrorMatches, "cannot set initial PCR policy: PCR protection profile contains digests for unsupported PCRs")
-}
-
-func (s *sealSuite) TestProtectKeyWithExternalStorageKeyErrorHandlingWithPCRPolicyCounter(c *C) {
-	err := s.testProtectKeyWithExternalStorageKeyErrorHandling(c, &ProtectKeyParams{
-		PCRProfile:             tpm2test.NewResolvedPCRProfileFromCurrentValues(c, s.TPM().TPMContext, tpm2.HashAlgorithmSHA256, []int{7}),
-		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)})
-	c.Check(err, ErrorMatches, "PCR policy counter handle must be tpm2.HandleNull when creating an importable sealed key")
 }
 
 type mockKeySealer struct {
@@ -812,151 +486,39 @@ func (s *sealSuiteNoTPM) SetUpTest(c *C) {
 
 	s.lastAuthKey = nil
 	s.lastAuthKeyPublic = nil
-	s.AddCleanup(MockNewPolicyAuthPublicKey(func(authKey secboot.PrimaryKey) (*tpm2.Public, error) {
-		s.lastAuthKey = authKey
+	s.AddCleanup(MockNewPolicyAuthPublicKey(func(primaryKey secboot.PrimaryKey) (*tpm2.Public, error) {
+		s.lastAuthKey = primaryKey
 
-		pub, err := NewPolicyAuthPublicKey(authKey)
+		pub, err := NewPolicyAuthPublicKey(primaryKey)
 		s.lastAuthKeyPublic = pub
 		return pub, err
 	}))
+
 }
 
 var _ = Suite(&sealSuiteNoTPM{})
 
-type testMakeKeyDataWithPolicyData struct {
-	policy *KeyDataPolicyParams
+type testMakeSealedKeyDataData struct {
+	PCRProfile             *PCRProtectionProfile
+	Role                   string
+	PCRPolicyCounterHandle tpm2.Handle
+	PrimaryKey             secboot.PrimaryKey
 }
 
-func (s *sealSuiteNoTPM) testMakeKeyDataWithPolicy(c *C, data *testMakeKeyDataWithPolicyData) {
-	key := make(secboot.DiskUnlockKey, 32)
-	rand.Read(key)
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
-
-	var sealer mockKeySealer
-
-	kd, err := MakeKeyDataWithPolicy(key, authKey, data.policy, &sealer)
-	c.Check(err, IsNil)
-	c.Assert(kd, NotNil)
-
-	c.Assert(s.lastKeyParams, NotNil)
-	c.Check(s.lastKeyParams.PlatformName, Equals, "tpm2")
-	c.Check(s.lastKeyParams.PrimaryKey, DeepEquals, authKey)
-	c.Check(s.lastKeyParams.SnapModelAuthHash, Equals, crypto.SHA256)
-
-	skd, err := NewSealedKeyData(kd)
-	c.Assert(err, IsNil)
-
-	c.Check(skd.Data().Policy(), tpm2_testutil.TPMValueDeepEquals, data.policy.PolicyData)
-	c.Check(skd.Data().Public().NameAlg, Equals, data.policy.Alg)
-	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, data.policy.AuthPolicy)
-
-	payload := make(secboot.KeyPayload, len(s.lastKeyParams.EncryptedPayload))
-
-	c.Assert(skd.Data().Private(), HasLen, 48)
-	b, err := aes.NewCipher(skd.Data().Private()[:32])
-	c.Assert(err, IsNil)
-	stream := cipher.NewCFBDecrypter(b, skd.Data().Private()[32:])
-	stream.XORKeyStream(payload, s.lastKeyParams.EncryptedPayload)
-
-	recoveredKey, recoveredAuthKey, err := payload.Unmarshal()
-	c.Check(err, IsNil)
-	c.Check(recoveredKey, DeepEquals, key)
-	c.Check(recoveredAuthKey, DeepEquals, authKey)
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicy(c *C) {
-	policyData := &KeyDataPolicy_v3{
-		StaticData: &StaticPolicyData_v3{
-			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
-			PCRPolicyCounterHandle: tpm2.HandleNull,
-		},
-		PCRData: &PcrPolicyData_v3{
-			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
-		},
-	}
-
-	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
-		policy: &KeyDataPolicyParams{
-			Alg:        tpm2.HashAlgorithmSHA256,
-			PolicyData: policyData,
-			AuthPolicy: []byte{1, 2, 3, 4}}})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyDifferentNameAlg(c *C) {
-	policyData := &KeyDataPolicy_v3{
-		StaticData: &StaticPolicyData_v3{
-			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
-			PCRPolicyCounterHandle: tpm2.HandleNull,
-		},
-		PCRData: &PcrPolicyData_v3{
-			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
-		},
-	}
-
-	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
-		policy: &KeyDataPolicyParams{
-			Alg:        tpm2.HashAlgorithmSHA1,
-			PolicyData: policyData,
-			AuthPolicy: []byte{1, 2, 3, 4}}})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyDifferentPolicyDigest(c *C) {
-	policyData := &KeyDataPolicy_v3{
-		StaticData: &StaticPolicyData_v3{
-			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
-			PCRPolicyCounterHandle: tpm2.HandleNull,
-		},
-		PCRData: &PcrPolicyData_v3{
-			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
-		},
-	}
-
-	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
-		policy: &KeyDataPolicyParams{
-			Alg:        tpm2.HashAlgorithmSHA256,
-			PolicyData: policyData,
-			AuthPolicy: []byte{5, 6, 7, 8, 9}}})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyDifferentPolicyVersion(c *C) {
-	policyData := &KeyDataPolicy_v1{
-		StaticData: &StaticPolicyData_v1{
-			AuthPublicKey:          templates.NewECCKey(tpm2.HashAlgorithmSHA256, templates.KeyUsageSign, nil, tpm2.ECCCurveNIST_P256),
-			PCRPolicyCounterHandle: tpm2.HandleNull,
-		},
-		PCRData: &PcrPolicyData_v1{
-			AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgECDSA},
-		},
-	}
-
-	s.testMakeKeyDataWithPolicy(c, &testMakeKeyDataWithPolicyData{
-		policy: &KeyDataPolicyParams{
-			Alg:        tpm2.HashAlgorithmSHA256,
-			PolicyData: policyData,
-			AuthPolicy: []byte{1, 2, 3, 4}}})
-}
-
-type testMakeKeyDataPolicyData struct {
-	pcrPolicyCounterHandle       tpm2.Handle
-	authKey                      secboot.PrimaryKey
-	initialPcrPolicyCounterValue uint64
-}
-
-func (s *sealSuiteNoTPM) testMakeKeyDataPolicy(c *C, data *testMakeKeyDataPolicyData) {
+func (s *sealSuiteNoTPM) testMakeSealedKeyData(c *C, data *testMakeSealedKeyDataData) {
 	var mockTpm *tpm2.TPMContext
 	var mockSession tpm2.SessionContext
-	if data.pcrPolicyCounterHandle != tpm2.HandleNull {
+	if data.PCRPolicyCounterHandle != tpm2.HandleNull {
 		mockTpm = new(tpm2.TPMContext)
 		mockSession = new(mockSessionContext)
 	}
 
 	var mockPcrPolicyCounterPub *tpm2.NVPublic
-	restore := MockCreatePcrPolicyCounter(func(tpm *tpm2.TPMContext, handle tpm2.Handle, pub *tpm2.Public, session tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
+	restore := MockEnsurePcrPolicyCounter(func(tpm *tpm2.TPMContext, handle tpm2.Handle, pub *tpm2.Public, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
 		c.Assert(mockTpm, NotNil)
 
 		c.Check(tpm, Equals, mockTpm)
-		c.Check(handle, Equals, data.pcrPolicyCounterHandle)
+		c.Check(handle, Equals, data.PCRPolicyCounterHandle)
 		c.Check(pub, Equals, s.lastAuthKeyPublic)
 		c.Check(session, Equals, mockSession)
 
@@ -967,17 +529,17 @@ func (s *sealSuiteNoTPM) testMakeKeyDataPolicy(c *C, data *testMakeKeyDataPolicy
 			AuthPolicy: make([]byte, 32),
 			Size:       8}
 
-		return mockPcrPolicyCounterPub, data.initialPcrPolicyCounterValue, nil
+		return mockPcrPolicyCounterPub, nil
 	})
 	defer restore()
 
 	var mockPolicyData *KeyDataPolicy_v3
 	var mockPolicyDigest tpm2.Digest
-	restore = MockNewKeyDataPolicy(func(alg tpm2.HashAlgorithmId, key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (KeyDataPolicy, tpm2.Digest, error) {
+	restore = MockNewKeyDataPolicy(func(alg tpm2.HashAlgorithmId, key *tpm2.Public, role string, pcrPolicyCounterPub *tpm2.NVPublic, requireAuthValue bool) (KeyDataPolicy, tpm2.Digest, error) {
 		c.Check(alg, Equals, tpm2.HashAlgorithmSHA256)
 		c.Check(key, Equals, s.lastAuthKeyPublic)
 		c.Check(pcrPolicyCounterPub, Equals, mockPcrPolicyCounterPub)
-		c.Check(pcrPolicySequence, Equals, data.initialPcrPolicyCounterValue)
+		c.Check(requireAuthValue, Equals, false)
 
 		index := tpm2.HandleNull
 		if pcrPolicyCounterPub != nil {
@@ -989,120 +551,6 @@ func (s *sealSuiteNoTPM) testMakeKeyDataPolicy(c *C, data *testMakeKeyDataPolicy
 				AuthPublicKey:          key,
 				PCRPolicyCounterHandle: index},
 			PCRData: &PcrPolicyData_v3{
-				PolicySequence:            pcrPolicySequence,
-				AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgNull}}}
-
-		mockPolicyDigest = make([]byte, alg.Size())
-		rand.Read(mockPolicyDigest)
-
-		return mockPolicyData, mockPolicyDigest, nil
-	})
-	defer restore()
-
-	policy, pcrPolicyCounter, authKeyOut, err := MakeKeyDataPolicy(mockTpm, data.pcrPolicyCounterHandle, data.authKey, mockSession)
-	c.Assert(err, IsNil)
-
-	c.Assert(s.lastAuthKey, NotNil)
-	c.Assert(mockPolicyData, NotNil)
-
-	c.Assert(policy, NotNil)
-	c.Check(policy.Alg, Equals, tpm2.HashAlgorithmSHA256)
-	c.Assert(policy.PolicyData, testutil.ConvertibleTo, new(KeyDataPolicy_v3))
-	c.Check(policy.PolicyData.(*KeyDataPolicy_v3), Equals, mockPolicyData)
-	c.Check(policy.AuthPolicy, DeepEquals, mockPolicyDigest)
-
-	if data.pcrPolicyCounterHandle == tpm2.HandleNull {
-		c.Check(pcrPolicyCounter, IsNil)
-	} else {
-		c.Check(pcrPolicyCounter, NotNil)
-		c.Check(pcrPolicyCounter.Pub(), Equals, mockPcrPolicyCounterPub)
-		c.Check(pcrPolicyCounter.TPM(), Equals, mockTpm)
-		c.Check(pcrPolicyCounter.Session(), Equals, mockSession)
-	}
-
-	c.Check(authKeyOut, DeepEquals, s.lastAuthKey)
-	c.Check(policy.PolicyData.ValidateAuthKey(authKeyOut), IsNil)
-	if data.authKey != nil {
-		c.Check(authKeyOut, DeepEquals, data.authKey)
-	}
-
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataPolicy(c *C) {
-	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
-		pcrPolicyCounterHandle: tpm2.HandleNull})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithPolicyCounter(c *C) {
-	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
-		pcrPolicyCounterHandle:       0x01800001,
-		initialPcrPolicyCounterValue: 20})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithPolicyCounterDifferentInitialValue(c *C) {
-	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
-		pcrPolicyCounterHandle:       0x01800001,
-		initialPcrPolicyCounterValue: 1000})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithProvidedAuthKey(c *C) {
-	s.testMakeKeyDataPolicy(c, &testMakeKeyDataPolicyData{
-		authKey: testutil.DecodeHexString(c, "fb8978601d0c2dd4129e3b9c1bb3f3116f4c5dd217c29b1017ab7cd31a882d3c")})
-}
-
-type testMakeKeyDataData struct {
-	authKey                      secboot.PrimaryKey
-	params                       *KeyDataParams
-	initialPcrPolicyCounterValue uint64
-}
-
-func (s *sealSuiteNoTPM) testMakeKeyData(c *C, data *testMakeKeyDataData) {
-	var mockTpm *tpm2.TPMContext
-	var mockSession tpm2.SessionContext
-	if data.params.PCRPolicyCounterHandle != tpm2.HandleNull {
-		mockTpm = new(tpm2.TPMContext)
-		mockSession = new(mockSessionContext)
-	}
-
-	var mockPcrPolicyCounterPub *tpm2.NVPublic
-	restore := MockCreatePcrPolicyCounter(func(tpm *tpm2.TPMContext, handle tpm2.Handle, pub *tpm2.Public, session tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
-		c.Assert(mockTpm, NotNil)
-
-		c.Check(tpm, Equals, mockTpm)
-		c.Check(handle, Equals, data.params.PCRPolicyCounterHandle)
-		c.Check(pub, Equals, s.lastAuthKeyPublic)
-		c.Check(session, Equals, mockSession)
-
-		mockPcrPolicyCounterPub = &tpm2.NVPublic{
-			Index:      handle,
-			NameAlg:    tpm2.HashAlgorithmSHA256,
-			Attrs:      tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
-			AuthPolicy: make([]byte, 32),
-			Size:       8}
-
-		return mockPcrPolicyCounterPub, data.initialPcrPolicyCounterValue, nil
-	})
-	defer restore()
-
-	var mockPolicyData *KeyDataPolicy_v3
-	var mockPolicyDigest tpm2.Digest
-	restore = MockNewKeyDataPolicy(func(alg tpm2.HashAlgorithmId, key *tpm2.Public, pcrPolicyCounterPub *tpm2.NVPublic, pcrPolicySequence uint64) (KeyDataPolicy, tpm2.Digest, error) {
-		c.Check(alg, Equals, tpm2.HashAlgorithmSHA256)
-		c.Check(key, Equals, s.lastAuthKeyPublic)
-		c.Check(pcrPolicyCounterPub, Equals, mockPcrPolicyCounterPub)
-		c.Check(pcrPolicySequence, Equals, data.initialPcrPolicyCounterValue)
-
-		index := tpm2.HandleNull
-		if pcrPolicyCounterPub != nil {
-			index = pcrPolicyCounterPub.Index
-		}
-
-		mockPolicyData = &KeyDataPolicy_v3{
-			StaticData: &StaticPolicyData_v3{
-				AuthPublicKey:          key,
-				PCRPolicyCounterHandle: index},
-			PCRData: &PcrPolicyData_v3{
-				PolicySequence:            pcrPolicySequence,
 				AuthorizedPolicySignature: &tpm2.Signature{SigAlg: tpm2.SigSchemeAlgNull}}}
 
 		mockPolicyDigest = make([]byte, alg.Size())
@@ -1113,15 +561,16 @@ func (s *sealSuiteNoTPM) testMakeKeyData(c *C, data *testMakeKeyDataData) {
 	defer restore()
 
 	pcrPolicyInitialized := false
-	restore = MockSkdbUpdatePCRProtectionPolicyImpl(func(skdb *SealedKeyDataBase, tpm *tpm2.TPMContext, authKey secboot.PrimaryKey, counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, session tpm2.SessionContext) error {
+	restore = MockSkdbUpdatePCRProtectionPolicyNoValidate(func(skdb *SealedKeyDataBase, tpm *tpm2.TPMContext, primaryKey secboot.PrimaryKey, counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, incrementPolicyVersion bool, session tpm2.SessionContext) error {
 		c.Check(tpm, Equals, mockTpm)
-		c.Check(authKey, DeepEquals, s.lastAuthKey)
+		c.Check(primaryKey, DeepEquals, s.lastAuthKey)
 		c.Check(counterPub, Equals, mockPcrPolicyCounterPub)
 		c.Check(profile, NotNil)
-		if data.params.PCRProfile != nil {
-			c.Check(profile, Equals, data.params.PCRProfile)
+		if data.PCRProfile != nil {
+			c.Check(profile, Equals, data.PCRProfile)
 		}
 		c.Check(session, Equals, mockSession)
+		c.Check(incrementPolicyVersion, testutil.IsFalse)
 		pcrPolicyInitialized = true
 		return nil
 	})
@@ -1129,10 +578,19 @@ func (s *sealSuiteNoTPM) testMakeKeyData(c *C, data *testMakeKeyDataData) {
 
 	var sealer mockKeySealer
 
-	key := make(secboot.DiskUnlockKey, 32)
-	rand.Read(key)
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
 
-	kd, authKeyOut, pcrPolicyCounter, err := MakeKeyData(mockTpm, key, data.authKey, data.params, &sealer, mockSession)
+	params := &SealedKeyDataParams{
+		PcrProfile:             data.PCRProfile,
+		Role:                   data.Role,
+		PcrPolicyCounterHandle: data.PCRPolicyCounterHandle,
+		PrimaryKey:             primaryKey,
+	}
+
+	constructor := MakeKeyDataNoAuth
+
+	kd, pk, _, err := MakeSealedKeyData(mockTpm, params, &sealer, constructor, mockSession)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.lastAuthKey, NotNil)
@@ -1141,70 +599,57 @@ func (s *sealSuiteNoTPM) testMakeKeyData(c *C, data *testMakeKeyDataData) {
 
 	c.Assert(s.lastKeyParams, NotNil)
 	c.Check(s.lastKeyParams.PlatformName, Equals, "tpm2")
-	c.Check(s.lastKeyParams.PrimaryKey, DeepEquals, s.lastAuthKey)
-	c.Check(s.lastKeyParams.SnapModelAuthHash, Equals, crypto.SHA256)
+	c.Check(s.lastKeyParams.Role, Equals, data.Role)
+	c.Check(s.lastKeyParams.KDFAlg, Equals, crypto.SHA256)
 
-	skd, err := NewSealedKeyData(kd)
-	c.Assert(err, IsNil)
+	c.Check(pk, DeepEquals, primaryKey)
+	c.Check(kd.Role(), DeepEquals, data.Role)
+
+	var skd *SealedKeyData
+	c.Check(kd.UnmarshalPlatformHandle(&skd), IsNil)
 
 	c.Check(skd.Data().Policy(), tpm2_testutil.TPMValueDeepEquals, mockPolicyData)
 	c.Check(skd.Data().Public().NameAlg, Equals, tpm2.HashAlgorithmSHA256)
 	c.Check(skd.Data().Public().AuthPolicy, DeepEquals, mockPolicyDigest)
 
-	payload := make(secboot.KeyPayload, len(s.lastKeyParams.EncryptedPayload))
+	payload := make([]byte, len(s.lastKeyParams.EncryptedPayload))
 
-	c.Assert(skd.Data().Private(), HasLen, 48)
+	c.Assert(skd.Data().Private(), HasLen, 44)
 	b, err := aes.NewCipher(skd.Data().Private()[:32])
 	c.Assert(err, IsNil)
-	stream := cipher.NewCFBDecrypter(b, skd.Data().Private()[32:])
-	stream.XORKeyStream(payload, s.lastKeyParams.EncryptedPayload)
 
-	recoveredKey, recoveredAuthKey, err := payload.Unmarshal()
+	aad, err := mu.MarshalToBytes(&AdditionalData_v3{
+		BaseVersion: uint32(kd.Version()),
+		KDFAlg:      tpm2.HashAlgorithmSHA256,
+		AuthMode:    kd.AuthMode(),
+	})
+
+	aead, err := cipher.NewGCM(b)
+	c.Assert(err, IsNil)
+
+	payload, err = aead.Open(nil, skd.Data().Private()[32:], s.lastKeyParams.EncryptedPayload, aad)
+	c.Assert(err, IsNil)
+
+	keys, err := UnmarshalProtectedKeys(payload)
 	c.Check(err, IsNil)
-	c.Check(recoveredKey, DeepEquals, key)
-	c.Check(recoveredAuthKey, DeepEquals, s.lastAuthKey)
 
-	c.Check(skd.Data().Policy().ValidateAuthKey(authKeyOut), IsNil)
-	c.Check(authKeyOut, DeepEquals, s.lastAuthKey)
-	if data.authKey != nil {
-		c.Check(authKeyOut, DeepEquals, data.authKey)
-	}
+	c.Check(keys.Primary, DeepEquals, primaryKey)
 
-	if data.params.PCRPolicyCounterHandle == tpm2.HandleNull {
-		c.Check(pcrPolicyCounter, IsNil)
-	} else {
-		c.Check(pcrPolicyCounter, NotNil)
-		c.Check(pcrPolicyCounter.Pub(), Equals, mockPcrPolicyCounterPub)
-		c.Check(pcrPolicyCounter.TPM(), Equals, mockTpm)
-		c.Check(pcrPolicyCounter.Session(), Equals, mockSession)
-	}
+	c.Check(skd.Data().Policy().ValidateAuthKey(keys.Primary), IsNil)
 }
 
-func (s *sealSuiteNoTPM) TestMakeKeyData(c *C) {
-	s.testMakeKeyData(c, &testMakeKeyDataData{
-		params: &KeyDataParams{
-			PCRPolicyCounterHandle: tpm2.HandleNull,
-			PCRProfile:             NewPCRProtectionProfile()}})
+func (s *sealSuiteNoTPM) TestMakeSealedKeyData(c *C) {
+	s.testMakeSealedKeyData(c, &testMakeSealedKeyDataData{
+		PCRProfile:             NewPCRProtectionProfile(),
+		PCRPolicyCounterHandle: 0x01800000,
+		Role:                   "",
+	})
 }
 
-func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyCounter(c *C) {
-	s.testMakeKeyData(c, &testMakeKeyDataData{
-		params: &KeyDataParams{
-			PCRPolicyCounterHandle: 0x01810000,
-			PCRProfile:             NewPCRProtectionProfile()},
-		initialPcrPolicyCounterValue: 30})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyCounterDifferentInitialValue(c *C) {
-	s.testMakeKeyData(c, &testMakeKeyDataData{
-		params: &KeyDataParams{
-			PCRPolicyCounterHandle: 0x01810000,
-			PCRProfile:             NewPCRProtectionProfile()},
-		initialPcrPolicyCounterValue: 500})
-}
-
-func (s *sealSuiteNoTPM) TestMakeKeyDataNilPCRProfile(c *C) {
-	s.testMakeKeyData(c, &testMakeKeyDataData{
-		params: &KeyDataParams{
-			PCRPolicyCounterHandle: tpm2.HandleNull}})
+func (s *sealSuiteNoTPM) TestMakeSealedKeyData2(c *C) {
+	s.testMakeSealedKeyData(c, &testMakeSealedKeyDataData{
+		PCRProfile:             NewPCRProtectionProfile(),
+		PCRPolicyCounterHandle: 0x01800000,
+		Role:                   "test",
+	})
 }

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -619,9 +619,9 @@ func (s *sealSuiteNoTPM) testMakeSealedKeyData(c *C, data *testMakeSealedKeyData
 	c.Assert(err, IsNil)
 
 	aad, err := mu.MarshalToBytes(&AdditionalData_v3{
-		BaseVersion: uint32(kd.Version()),
-		KDFAlg:      tpm2.HashAlgorithmSHA256,
-		AuthMode:    kd.AuthMode(),
+		Generation: uint32(kd.Generation()),
+		KDFAlg:     tpm2.HashAlgorithmSHA256,
+		AuthMode:   kd.AuthMode(),
 	})
 
 	aead, err := cipher.NewGCM(b)

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/canonical/go-tpm2/mu"
 	"github.com/canonical/go-tpm2/templates"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
+	"golang.org/x/crypto/cryptobyte"
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 
 	. "gopkg.in/check.v1"
 
@@ -40,6 +42,29 @@ import (
 	"github.com/snapcore/secboot/internal/tpm2test"
 	. "github.com/snapcore/secboot/tpm2"
 )
+
+type protectedKeys struct {
+	Primary secboot.PrimaryKey
+	Unique  []byte
+}
+
+func unmarshalProtectedKeys(data []byte) (*protectedKeys, error) {
+	s := cryptobyte.String(data)
+	if !s.ReadASN1(&s, cryptobyte_asn1.SEQUENCE) {
+		return nil, errors.New("malformed input")
+	}
+
+	pk := new(protectedKeys)
+
+	if !s.ReadASN1Bytes((*[]byte)(&pk.Primary), cryptobyte_asn1.OCTET_STRING) {
+		return nil, errors.New("malformed primary key")
+	}
+	if !s.ReadASN1Bytes(&pk.Unique, cryptobyte_asn1.OCTET_STRING) {
+		return nil, errors.New("malformed unique key")
+	}
+
+	return pk, nil
+}
 
 type sealSuite struct {
 	tpm2test.TPMTest
@@ -630,7 +655,7 @@ func (s *sealSuiteNoTPM) testMakeSealedKeyData(c *C, data *testMakeSealedKeyData
 	payload, err = aead.Open(nil, skd.Data().Private()[32:], s.lastKeyParams.EncryptedPayload, aad)
 	c.Assert(err, IsNil)
 
-	keys, err := UnmarshalProtectedKeys(payload)
+	keys, err := unmarshalProtectedKeys(payload)
 	c.Check(err, IsNil)
 
 	c.Check(keys.Primary, DeepEquals, primaryKey)

--- a/tpm2/update.go
+++ b/tpm2/update.go
@@ -109,8 +109,8 @@ func (k *sealedKeyDataBase) updatePCRProtectionPolicyImpl(tpm *tpm2.TPMContext, 
 	return k.data.Policy().UpdatePCRPolicy(alg, params)
 }
 
-func (k *sealedKeyDataBase) revokeOldPCRProtectionPoliciesImpl(tpm *tpm2.TPMContext, key secboot.PrimaryKey, session tpm2.SessionContext) error {
-	pcrPolicyCounterPub, err := k.validateData(tpm, session)
+func (k *sealedKeyDataBase) revokeOldPCRProtectionPolicies(tpm *tpm2.TPMContext, key secboot.PrimaryKey, role string, session tpm2.SessionContext) error {
+	pcrPolicyCounterPub, err := k.validateData(tpm, role, session)
 	if err != nil {
 		if isKeyDataError(err) {
 			return InvalidKeyDataError{err.Error()}
@@ -257,7 +257,7 @@ func (k *SealedKeyData) UpdatePCRProtectionPolicy(tpm *Connection, authKey secbo
 //
 // If validation of the key data fails, a InvalidKeyDataError error will be returned.
 func (k *SealedKeyData) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey secboot.PrimaryKey) error {
-	return k.revokeOldPCRProtectionPoliciesImpl(tpm.TPMContext, authKey, tpm.HmacSession())
+	return k.revokeOldPCRProtectionPolicies(tpm.TPMContext, authKey, k.k.Role(), tpm.HmacSession())
 }
 
 // UpdateKeyPCRProtectionPolicy updates the PCR protection policy for one or more TPM protected KeyData

--- a/tpm2/update.go
+++ b/tpm2/update.go
@@ -32,20 +32,31 @@ import (
 
 var skdbUpdatePCRProtectionPolicyNoValidate = (*sealedKeyDataBase).updatePCRProtectionPolicyNoValidate
 
-// pcrPolicyVersionOption describes how to determine the version of a new PCR policy.
+// pcrPolicyVersionOption is used to tell sealedKeyDataBase.updatePCRProtectionPolicyNoValidate
+// how to determine the version of a new PCR policy.
 type pcrPolicyVersionOption int
 
 const (
 	// resetPcrPolicyVersion indicates that the new policy version should be set
-	// to the current counter value.
+	// to the current counter value. This is used for the initial policy when creating
+	// any key, and is also used when updating a policy for existing keys with the
+	// new SealedKeyData API when called with NoNewPCRPolicyVersion.
 	resetPcrPolicyVersion pcrPolicyVersionOption = iota
 
 	// newPcrPolicyVersion indicates that the new policy version should be the current
-	// counter value plus 1.
+	// counter value plus 1. This is used when updating a policy for existing keys
+	// with the new SealedKeyData API when called with NewPCRPolicyVersion. A subsequent
+	// counter increment to the new policy version will revoke all policies created with
+	// resetPcrPolicyVersion since the previous revocation.
 	newPcrPolicyVersion
 
 	// incrementPolicyVersion indicates that the new policy version should be the
-	// previous policy version plus 1.
+	// current policy version plus 1, and is used to maintain the behaviour of
+	// policy updates when using the previous SealedKeyObject API, which incremented
+	// the policy version with every update.  A subsequent counter increment to the
+	// new policy version will revoke all policies created since the previous
+	// revocation, but this may require multiple counter increments (one per created
+	// policy).
 	incrementPcrPolicyVersion
 )
 

--- a/tpm2/update_legacy.go
+++ b/tpm2/update_legacy.go
@@ -93,7 +93,7 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPoliciesV0(tpm *Connection, poli
 		return InvalidKeyDataError{"invalid metadata version"}
 	}
 
-	return k.revokeOldPCRProtectionPoliciesImpl(tpm.TPMContext, policyUpdateData.AuthKey, tpm.HmacSession())
+	return k.revokeOldPCRProtectionPolicies(tpm.TPMContext, policyUpdateData.AuthKey, "", tpm.HmacSession())
 }
 
 // UpdatePCRProtectionPolicy updates the PCR protection policy for this sealed key object to the profile defined by the
@@ -125,7 +125,7 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey sec
 //
 // If validation of the key data fails, a InvalidKeyDataError error will be returned.
 func (k *SealedKeyObject) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey secboot.PrimaryKey) error {
-	return k.revokeOldPCRProtectionPoliciesImpl(tpm.TPMContext, authKey, tpm.HmacSession())
+	return k.revokeOldPCRProtectionPolicies(tpm.TPMContext, authKey, "", tpm.HmacSession())
 }
 
 // UpdateKeyPCRProtectionPolicyMultiple updates the PCR protection policy for the supplied sealed key objects to the

--- a/tpm2/update_legacy.go
+++ b/tpm2/update_legacy.go
@@ -61,7 +61,7 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicyV0(tpm *Connection, policyUpd
 		return InvalidKeyDataError{"invalid metadata versions"}
 	}
 
-	return k.updatePCRProtectionPolicy(tpm.TPMContext, policyUpdateData.AuthKey, "", pcrProfile, true, tpm.HmacSession())
+	return k.updatePCRProtectionPolicy(tpm.TPMContext, policyUpdateData.AuthKey, "", pcrProfile, incrementPcrPolicyVersion, tpm.HmacSession())
 }
 
 // RevokeOldPCRProtectionPoliciesV0 revokes old PCR protection policies associated with this sealed key. It does
@@ -108,7 +108,7 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPoliciesV0(tpm *Connection, poli
 // On success, this SealedKeyObject will have an updated authorization policy that includes a PCR policy computed
 // from the supplied PCRProtectionProfile. It must be persisted using SealedKeyObject.WriteAtomic.
 func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey secboot.PrimaryKey, pcrProfile *PCRProtectionProfile) error {
-	return k.updatePCRProtectionPolicy(tpm.TPMContext, authKey, "", pcrProfile, true, tpm.HmacSession())
+	return k.updatePCRProtectionPolicy(tpm.TPMContext, authKey, "", pcrProfile, incrementPcrPolicyVersion, tpm.HmacSession())
 }
 
 // RevokeOldPCRProtectionPolicies revokes old PCR protection policies associated with this sealed key. It does

--- a/tpm2/update_legacy_test.go
+++ b/tpm2/update_legacy_test.go
@@ -256,5 +256,5 @@ func (s *updateLegacySuite) TestUpdateKeyPCRProtectionPolicyMultipleUnrelated2(c
 	}
 
 	err = UpdateKeyPCRProtectionPolicyMultiple(s.TPM(), keys, authKey, nil)
-	c.Check(err, ErrorMatches, "invalid key data: key data at index 1 is not related to the primary key data")
+	c.Check(err, ErrorMatches, "cannot update key at index 1: cannot validate auth key: dynamic authorization policy signing private key doesn't match public key")
 }

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -57,7 +57,7 @@ var _ = Suite(&updateSuite{})
 
 type testUpdatePCRProtectionPolicyData struct {
 	pcrPolicyCounterHandle tpm2.Handle
-	authKey                secboot.PrimaryKey
+	primaryKey             secboot.PrimaryKey
 }
 
 func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRProtectionPolicyData) {
@@ -68,8 +68,8 @@ func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRPro
 	params := &ProtectKeyParams{
 		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
 		PCRPolicyCounterHandle: data.pcrPolicyCounterHandle,
-		AuthKey:                data.authKey}
-	k, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+		PrimaryKey:             data.primaryKey}
+	k, primaryKey, _, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
 
 	_, _, err = k.RecoverKeys()
@@ -79,7 +79,7 @@ func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRPro
 	skd, err := NewSealedKeyData(k)
 	c.Assert(err, IsNil)
 
-	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), authKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23})), IsNil)
+	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), false), IsNil)
 
 	_, _, err = k.RecoverKeys()
 	c.Check(err, IsNil)
@@ -102,19 +102,16 @@ func (s *updateSuite) TestUpdatePCRProtectionPolicyNoPCRPolicyCounter(c *C) {
 }
 
 func (s *updateSuite) TestUpdatePCRProtectionPolicyWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
+	primaryKey := make(secboot.PrimaryKey, 32)
+	rand.Read(primaryKey)
 
 	s.testUpdatePCRProtectionPolicy(c, &testUpdatePCRProtectionPolicyData{
 		pcrPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000),
-		authKey:                authKey})
+		primaryKey:             primaryKey})
 }
 
 func (s *updateSuite) testRevokeOldPCRProtectionPolicies(c *C, params *ProtectKeyParams) error {
-	key := make(secboot.DiskUnlockKey, 32)
-	rand.Read(key)
-
-	k1, authKey, err := ProtectKeyWithTPM(s.TPM(), key, params)
+	k1, primaryKey, _, err := NewTPMProtectedKey(s.TPM(), params)
 	c.Assert(err, IsNil)
 
 	w := newMockKeyDataWriter()
@@ -125,7 +122,7 @@ func (s *updateSuite) testRevokeOldPCRProtectionPolicies(c *C, params *ProtectKe
 
 	skd, err := NewSealedKeyData(k2)
 	c.Assert(err, IsNil)
-	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), authKey, params.PCRProfile), IsNil)
+	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, params.PCRProfile, true), IsNil)
 
 	_, _, err = k1.RecoverKeys()
 	c.Check(err, IsNil)
@@ -134,7 +131,7 @@ func (s *updateSuite) testRevokeOldPCRProtectionPolicies(c *C, params *ProtectKe
 
 	skd, err = NewSealedKeyData(k1)
 	c.Assert(err, IsNil)
-	c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), authKey), IsNil)
+	c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), primaryKey), IsNil)
 
 	_, _, err = k1.RecoverKeys()
 	c.Check(err, IsNil)
@@ -143,7 +140,7 @@ func (s *updateSuite) testRevokeOldPCRProtectionPolicies(c *C, params *ProtectKe
 
 	skd, err = NewSealedKeyData(k2)
 	c.Assert(err, IsNil)
-	c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), authKey), IsNil)
+	c.Check(skd.RevokeOldPCRProtectionPolicies(s.TPM(), primaryKey), IsNil)
 
 	_, _, err = k2.RecoverKeys()
 	c.Check(err, IsNil)
@@ -163,108 +160,4 @@ func (s *updateSuite) TestRevokeOldPCRProtectionPoliciesWithoutPCRPolicyCounter(
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: tpm2.HandleNull})
 	c.Check(err, IsNil)
-}
-
-func (s *updateSuite) testUpdateKeyDataPCRProtectionPolicy(c *C, n int) {
-	var keys []secboot.DiskUnlockKey
-	for i := 0; i < n; i++ {
-		key := make(secboot.DiskUnlockKey, 32)
-		rand.Read(key)
-		keys = append(keys, key)
-	}
-
-	// Protect the key with an initial PCR policy that can't be satisfied
-	params := &ProtectKeyParams{
-		PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
-		PCRPolicyCounterHandle: tpm2.HandleNull}
-	ks, authKey, err := ProtectKeysWithTPM(s.TPM(), keys, params)
-	c.Assert(err, IsNil)
-
-	for _, k := range ks {
-		_, _, err = k.RecoverKeys()
-		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
-			"cannot execute PolicyOR assertions: current session digest not found in policy data")
-	}
-
-	c.Check(UpdateKeyDataPCRProtectionPolicy(s.TPM(), authKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), ks...), IsNil)
-
-	for _, k := range ks {
-		_, _, err = k.RecoverKeys()
-		c.Check(err, IsNil)
-	}
-
-	_, err = s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
-	c.Check(err, IsNil)
-
-	for _, k := range ks {
-		_, _, err = k.RecoverKeys()
-		c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: cannot execute PCR assertions: "+
-			"cannot execute PolicyOR assertions: current session digest not found in policy data")
-	}
-}
-
-func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy1(c *C) {
-	s.testUpdateKeyDataPCRProtectionPolicy(c, 1)
-}
-
-func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy2(c *C) {
-	s.testUpdateKeyDataPCRProtectionPolicy(c, 2)
-}
-
-func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy3(c *C) {
-	s.testUpdateKeyDataPCRProtectionPolicy(c, 3)
-}
-
-func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicyUnrelated1(c *C) {
-	var keys []secboot.DiskUnlockKey
-	for i := 0; i < 2; i++ {
-		key := make(secboot.DiskUnlockKey, 32)
-		rand.Read(key)
-		keys = append(keys, key)
-	}
-
-	authKey := make(secboot.PrimaryKey, 32)
-	rand.Read(authKey)
-
-	var ks []*secboot.KeyData
-	for i := 0; i < 2; i++ {
-		params := &ProtectKeyParams{
-			PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
-			PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x0181ff00+tpm2.Handle(i)),
-			AuthKey:                authKey}
-		k, _, err := ProtectKeyWithTPM(s.TPM(), keys[i], params)
-		c.Assert(err, IsNil)
-		ks = append(ks, k)
-	}
-
-	err := UpdateKeyDataPCRProtectionPolicy(s.TPM(), authKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), ks...)
-	c.Check(err, ErrorMatches, "invalid key data: key data at index 1 is not related to the primary key data")
-}
-
-func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicyUnrelated2(c *C) {
-	var keys []secboot.DiskUnlockKey
-	var authKeys []secboot.PrimaryKey
-	for i := 0; i < 2; i++ {
-		key := make(secboot.DiskUnlockKey, 32)
-		rand.Read(key)
-		keys = append(keys, key)
-
-		authKey := make(secboot.PrimaryKey, 32)
-		rand.Read(authKey)
-		authKeys = append(authKeys, authKey)
-	}
-
-	var ks []*secboot.KeyData
-	for i := 0; i < 2; i++ {
-		params := &ProtectKeyParams{
-			PCRProfile:             NewPCRProtectionProfile().AddPCRValue(tpm2.HashAlgorithmSHA256, 7, testutil.DecodeHexString(c, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
-			PCRPolicyCounterHandle: tpm2.HandleNull,
-			AuthKey:                authKeys[i]}
-		k, _, err := ProtectKeyWithTPM(s.TPM(), keys[i], params)
-		c.Assert(err, IsNil)
-		ks = append(ks, k)
-	}
-
-	err := UpdateKeyDataPCRProtectionPolicy(s.TPM(), authKeys[0], tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), ks...)
-	c.Check(err, ErrorMatches, "invalid key data: key data at index 1 is not related to the primary key data")
 }

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -79,7 +79,7 @@ func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRPro
 	skd, err := NewSealedKeyData(k)
 	c.Assert(err, IsNil)
 
-	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), false), IsNil)
+	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), NoNewPCRPolicyVersion), IsNil)
 
 	_, _, err = k.RecoverKeys()
 	c.Check(err, IsNil)
@@ -122,7 +122,7 @@ func (s *updateSuite) testRevokeOldPCRProtectionPolicies(c *C, params *ProtectKe
 
 	skd, err := NewSealedKeyData(k2)
 	c.Assert(err, IsNil)
-	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, params.PCRProfile, true), IsNil)
+	c.Check(skd.UpdatePCRProtectionPolicy(s.TPM(), primaryKey, params.PCRProfile, NewPCRPolicyVersion), IsNil)
 
 	_, _, err = k1.RecoverKeys()
 	c.Check(err, IsNil)
@@ -184,7 +184,7 @@ func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy(c *C) {
 		keys = append(keys, k)
 	}
 
-	c.Check(UpdateKeyDataPCRProtectionPolicy(s.TPM(), primaryKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), false, keys...), IsNil)
+	c.Check(UpdateKeyDataPCRProtectionPolicy(s.TPM(), primaryKey, tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}), NoNewPCRPolicyVersion, keys...), IsNil)
 
 	for _, k := range keys {
 		_, _, err := k.RecoverKeys()

--- a/tpm2/utils.go
+++ b/tpm2/utils.go
@@ -21,6 +21,7 @@ package tpm2
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"errors"
@@ -228,4 +229,25 @@ func digestListContains(list tpm2.DigestList, digest tpm2.Digest) bool {
 		}
 	}
 	return false
+}
+
+func hashAlgorithmIdFromCryptoHash(alg crypto.Hash) (tpm2.HashAlgorithmId, error) {
+	switch alg {
+	case crypto.SHA1:
+		return tpm2.HashAlgorithmSHA1, nil
+	case crypto.SHA256:
+		return tpm2.HashAlgorithmSHA256, nil
+	case crypto.SHA384:
+		return tpm2.HashAlgorithmSHA384, nil
+	case crypto.SHA512:
+		return tpm2.HashAlgorithmSHA512, nil
+	case crypto.SHA3_256:
+		return tpm2.HashAlgorithmSHA3_256, nil
+	case crypto.SHA3_384:
+		return tpm2.HashAlgorithmSHA3_384, nil
+	case crypto.SHA3_512:
+		return tpm2.HashAlgorithmSHA3_512, nil
+	default:
+		return tpm2.HashAlgorithmNull, errors.New("unrecognized digest algorithm")
+	}
 }


### PR DESCRIPTION
Original commit: https://github.com/chrisccoulson/secboot/commit/87d9aa34d1d80d64ffe82f0a008693799d633cd9

I will split the commit above in 3 separate cascading PRs and add tests for it:

1. https://github.com/snapcore/secboot/pull/265
2. https://github.com/snapcore/secboot/pull/270
2. This one

This PR is rebased on top of 2. It adds the changes to the TPM platform that use the new v3 cross-platform API + fixes existing tests and adds a few more.