### PR TITLE
Update go-tpm2 to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/canonical/go-efilib v0.9.4
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
-	github.com/canonical/go-tpm2 v1.0.2
+	github.com/canonical/go-tpm2 v1.1.0
 	github.com/canonical/tcglog-parser v0.0.0-20230929123437-16b3d8d08691
 	github.com/snapcore/snapd v0.0.0-20220714152900-4a1f4c93fc85
 	golang.org/x/crypto v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61/go.mod h1:vG41hd
 github.com/canonical/go-tpm2 v0.1.0/go.mod h1:vG41hdbBjV4+/fkubTT1ENBBqSkLwLr7mCeW9Y6kpZY=
 github.com/canonical/go-tpm2 v1.0.2 h1:2HNCI/UKghbVaR8Ix1BEcK6G/GzKlkOoBSXNc7R7mLw=
 github.com/canonical/go-tpm2 v1.0.2/go.mod h1:FD6TavnteNqLZv1m3meU0QighLDmfyEq5+ShiN2Ik64=
+github.com/canonical/go-tpm2 v1.1.0 h1:i3YeiYTWciamtbUpKZC9FIGhCP9rWSu1AZpYnWUO9HE=
+github.com/canonical/go-tpm2 v1.1.0/go.mod h1:kLkR1//7ocrPDl6LZfijTKEoPGxRIZSbb8GuWaO1JM8=
 github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2/go.mod h1:QoW2apR2tBl6T/4czdND/EHjL1Ia9cCmQnIj9Xe0Kt8=
 github.com/canonical/tcglog-parser v0.0.0-20230929123437-16b3d8d08691 h1:EMZbYZXGGmtSaS2+DIza1gZ54+KVjzsw/NEUAY8me1E=
 github.com/canonical/tcglog-parser v0.0.0-20230929123437-16b3d8d08691/go.mod h1:EPlw+kpcTgSHXkLiUP/Jqp4CmkNPyVnJLAk4oSjNFrQ=

--- a/internal/tpm2test/tcti.go
+++ b/internal/tpm2test/tcti.go
@@ -21,6 +21,7 @@ package tpm2test
 
 import (
 	"os"
+	"time"
 
 	"github.com/canonical/go-tpm2"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
@@ -64,8 +65,8 @@ func (t *TCTI) Close() error {
 	return t.tcti.Close()
 }
 
-func (t *TCTI) SetLocality(locality uint8) error {
-	return t.tcti.SetLocality(locality)
+func (t *TCTI) SetTimeout(timeout time.Duration) error {
+	return t.tcti.SetTimeout(timeout)
 }
 
 func (t *TCTI) MakeSticky(handle tpm2.Handle, sticky bool) error {

--- a/tpm2/tpm_test.go
+++ b/tpm2/tpm_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
@@ -185,7 +186,7 @@ func (t *mockTPM12Tcti) Close() error {
 	return nil
 }
 
-func (t *mockTPM12Tcti) SetLocality(locality uint8) error {
+func (t *mockTPM12Tcti) SetTimeout(timeout time.Duration) error {
 	return nil
 }
 


### PR DESCRIPTION
This includes a few changes that may be used in secboot in future PRs:
- some new helpers for working with objects and constructing templates (package objectutil).
- new APIs for constructing, serializing and executing authorization policies (package policyutil).
- a new API for interacting with the physical presence interface (package ppi).
- a TPMDevice interface and an API for enumerating and opening devices and using the resource manager device.
- deprecated the existing util, templates and crypto packages, as this functionality moved elsewhere.