### PR TITLE
luks2: don't time tests to verify KDF settings

### DIFF
--- a/internal/luks2/cryptsetup_test.go
+++ b/internal/luks2/cryptsetup_test.go
@@ -274,19 +274,12 @@ func (s *cryptsetupSuiteBase) testFormat(c *C, data *testFormatData) {
 		c.Check(keyslot.KDF.Time, Equals, options.KDFOptions.ForceIterations)
 		c.Check(keyslot.KDF.Memory, Equals, expectedMemoryKiB)
 	} else {
-		expectedKDFTime := 2000 * time.Millisecond
-		if options.KDFOptions.TargetDuration > 0 {
-			expectedKDFTime = options.KDFOptions.TargetDuration
-		}
-
 		c.Check(keyslot.KDF.Memory, snapd_testutil.IntLessEqual, expectedMemoryKiB)
 
-		start := time.Now()
+		// We used to time this to make sure we are supplying the correct parameters to
+		// cryptsetup, but that was unreliable. For now, we rely on the command line
+		// parameters that were tested earlier, and trust that those are correct.
 		luks2test.CheckLUKS2Passphrase(c, devicePath, data.key)
-		elapsed := time.Now().Sub(start)
-		// Check KDF time here with +/-20% tolerance and additional 500ms for cryptsetup exec and other activities
-		c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntGreaterThan, int(float64(expectedKDFTime/time.Millisecond)*0.8))
-		c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntLessThan, int(float64(expectedKDFTime/time.Millisecond)*1.2)+500)
 	}
 }
 
@@ -497,19 +490,12 @@ func (s *cryptsetupSuiteBase) testAddKey(c *C, data *testAddKeyData) {
 		c.Check(keyslot.KDF.Time, Equals, options.KDFOptions.ForceIterations)
 		c.Check(keyslot.KDF.Memory, Equals, expectedMemoryKiB)
 	} else {
-		expectedKDFTime := 2000 * time.Millisecond
-		if options.KDFOptions.TargetDuration > 0 {
-			expectedKDFTime = options.KDFOptions.TargetDuration
-		}
-
 		c.Check(keyslot.KDF.Memory, snapd_testutil.IntLessEqual, expectedMemoryKiB)
 
-		start := time.Now()
+		// We used to time this to make sure we are supplying the correct parameters to
+		// cryptsetup, but that was unreliable. For now, we rely on the command line
+		// parameters that were tested earlier, and trust that those are correct.
 		luks2test.CheckLUKS2Passphrase(c, devicePath, data.key)
-		elapsed := time.Now().Sub(start)
-		// Check KDF time here with +/-20% tolerance and additional 500ms for cryptsetup exec and other activities
-		c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntGreaterThan, int(float64(expectedKDFTime/time.Millisecond)*0.8))
-		c.Check(int(elapsed/time.Millisecond), snapd_testutil.IntLessThan, int(float64(expectedKDFTime/time.Millisecond)*1.2)+500)
 	}
 }
 


### PR DESCRIPTION
There are a few tests where we time the KDF operation because there
isn't another way to determine if it was configured correctly by
cryptsetup. These tests have always been a little bit flaky, and they
have been significantly more so recently.
    
Stop timing them, and instead:
- in internal/luks2, just rely on the fact that we verify the expected
  commandline arguments were passed to cryptsetup. We have to assume
  that these options are correct, which is what the existing tests
  attempted to confirm.
- in crypt_test.go, ensure that we pass the correct target time to
  internal/luks2.