### PR TITLE
Bump github.com/canonical/go-tpm2 dependency to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/canonical/go-efilib v0.9.5
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
-	github.com/canonical/go-tpm2 v1.1.0
+	github.com/canonical/go-tpm2 v1.3.0
 	github.com/canonical/tcglog-parser v0.0.0-20230929123437-16b3d8d08691
 	github.com/snapcore/snapd v0.0.0-20220714152900-4a1f4c93fc85
 	golang.org/x/crypto v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/canonical/go-tpm2 v1.0.2 h1:2HNCI/UKghbVaR8Ix1BEcK6G/GzKlkOoBSXNc7R7m
 github.com/canonical/go-tpm2 v1.0.2/go.mod h1:FD6TavnteNqLZv1m3meU0QighLDmfyEq5+ShiN2Ik64=
 github.com/canonical/go-tpm2 v1.1.0 h1:i3YeiYTWciamtbUpKZC9FIGhCP9rWSu1AZpYnWUO9HE=
 github.com/canonical/go-tpm2 v1.1.0/go.mod h1:kLkR1//7ocrPDl6LZfijTKEoPGxRIZSbb8GuWaO1JM8=
+github.com/canonical/go-tpm2 v1.3.0 h1:+xc2++IM4kaMCJruFzlgtYgQyV5Q0EReaP++z8VTqJk=
+github.com/canonical/go-tpm2 v1.3.0/go.mod h1:kLkR1//7ocrPDl6LZfijTKEoPGxRIZSbb8GuWaO1JM8=
 github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2/go.mod h1:QoW2apR2tBl6T/4czdND/EHjL1Ia9cCmQnIj9Xe0Kt8=
 github.com/canonical/tcglog-parser v0.0.0-20230929123437-16b3d8d08691 h1:EMZbYZXGGmtSaS2+DIza1gZ54+KVjzsw/NEUAY8me1E=
 github.com/canonical/tcglog-parser v0.0.0-20230929123437-16b3d8d08691/go.mod h1:EPlw+kpcTgSHXkLiUP/Jqp4CmkNPyVnJLAk4oSjNFrQ=

--- a/internal/tpm2test/tcti.go
+++ b/internal/tpm2test/tcti.go
@@ -21,7 +21,6 @@ package tpm2test
 
 import (
 	"os"
-	"time"
 
 	"github.com/canonical/go-tpm2"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
@@ -63,14 +62,6 @@ func (t *TCTI) Close() error {
 	}
 	t.closed = true
 	return t.tcti.Close()
-}
-
-func (t *TCTI) SetTimeout(timeout time.Duration) error {
-	return t.tcti.SetTimeout(timeout)
-}
-
-func (t *TCTI) MakeSticky(handle tpm2.Handle, sticky bool) error {
-	return t.tcti.MakeSticky(handle, sticky)
 }
 
 // SetKeepOpen provides a mechanism to keep the underlying connection

--- a/tpm2/tpm_test.go
+++ b/tpm2/tpm_test.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"os"
 	"syscall"
-	"time"
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/mu"
@@ -183,14 +182,6 @@ func (t *mockTPM12Tcti) Write(data []byte) (int, error) {
 }
 
 func (t *mockTPM12Tcti) Close() error {
-	return nil
-}
-
-func (t *mockTPM12Tcti) SetTimeout(timeout time.Duration) error {
-	return nil
-}
-
-func (t *mockTPM12Tcti) MakeSticky(handle tpm2.Handle, sticky bool) error {
 	return nil
 }
 


### PR DESCRIPTION
This pulls in a fix to github.com/canonical/go-tpm2/linux that ensures I/O system calls are retried on EINTR.