### PR TITLE
Keydata v3 auxiliary primary rename and legacy keydata test

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -148,7 +148,7 @@ func (s *activateWithKeyDataState) errors() (out []*activateWithKeyDataError) {
 	return out
 }
 
-func (s *activateWithKeyDataState) tryActivateWithRecoveredKey(key DiskUnlockKey, slot int, keyData *KeyData, auxKey AuxiliaryKey) error {
+func (s *activateWithKeyDataState) tryActivateWithRecoveredKey(key DiskUnlockKey, slot int, keyData *KeyData, auxKey PrimaryKey) error {
 	if s.model != SkipSnapModelCheck {
 		authorized, err := keyData.IsSnapModelAuthorized(auxKey, s.model)
 		switch {

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -453,7 +453,7 @@ func (s *cryptSuite) checkRecoveryKeyInKeyring(c *C, prefix, path string, expect
 	c.Check(key, DeepEquals, DiskUnlockKey(expected[:]))
 }
 
-func (s *cryptSuite) checkKeyDataKeysInKeyring(c *C, prefix, path string, expectedKey DiskUnlockKey, expectedAuxKey AuxiliaryKey) {
+func (s *cryptSuite) checkKeyDataKeysInKeyring(c *C, prefix, path string, expectedKey DiskUnlockKey, expectedAuxKey PrimaryKey) {
 	// The following test will fail if the user keyring isn't reachable from the session keyring. If the test have succeeded
 	// so far, mark the current test as expected to fail.
 	if !s.ProcessPossessesUserKeyringKeys && !c.Failed() {
@@ -464,12 +464,12 @@ func (s *cryptSuite) checkKeyDataKeysInKeyring(c *C, prefix, path string, expect
 	c.Check(err, IsNil)
 	c.Check(key, DeepEquals, expectedKey)
 
-	auxKey, err := GetAuxiliaryKeyFromKernel(prefix, path, false)
+	auxKey, err := GetPrimaryKeyFromKernel(prefix, path, false)
 	c.Check(err, IsNil)
 	c.Check(auxKey, DeepEquals, expectedAuxKey)
 }
 
-func (s *cryptSuite) newMultipleNamedKeyData(c *C, names ...string) (keyData []*KeyData, keys []DiskUnlockKey, auxKeys []AuxiliaryKey) {
+func (s *cryptSuite) newMultipleNamedKeyData(c *C, names ...string) (keyData []*KeyData, keys []DiskUnlockKey, auxKeys []PrimaryKey) {
 	for _, name := range names {
 		key, auxKey := s.newKeyDataKeys(c, 32, 32)
 		protected := s.mockProtectKeys(c, key, auxKey, crypto.SHA256)
@@ -492,7 +492,7 @@ func (s *cryptSuite) newMultipleNamedKeyData(c *C, names ...string) (keyData []*
 	return keyData, keys, auxKeys
 }
 
-func (s *cryptSuite) newNamedKeyData(c *C, name string) (*KeyData, DiskUnlockKey, AuxiliaryKey) {
+func (s *cryptSuite) newNamedKeyData(c *C, name string) (*KeyData, DiskUnlockKey, PrimaryKey) {
 	keyData, keys, auxKeys := s.newMultipleNamedKeyData(c, name)
 	return keyData[0], keys[0], auxKeys[0]
 }
@@ -1400,7 +1400,7 @@ type testActivateVolumeWithMultipleKeyDataData struct {
 	keyData       []*KeyData
 	activateSlots []int
 	validKey      DiskUnlockKey
-	validAuxKey   AuxiliaryKey
+	validAuxKey   PrimaryKey
 }
 
 func (s *cryptSuite) testActivateVolumeWithMultipleKeyData(c *C, data *testActivateVolumeWithMultipleKeyDataData) {

--- a/internal/compattest/compattest_test.go
+++ b/internal/compattest/compattest_test.go
@@ -159,7 +159,7 @@ func (s *compatTestSuiteBase) testUnsealCommon(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(key, DeepEquals, secboot.DiskUnlockKey(expectedKey))
 
-	var expectedAuthPrivateKey secboot.AuxiliaryKey
+	var expectedAuthPrivateKey secboot.PrimaryKey
 	authKeyPath := s.absPath("authKey")
 	if _, err := os.Stat(authKeyPath); err == nil {
 		expectedAuthPrivateKey, err = ioutil.ReadFile(authKeyPath)

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -244,7 +244,7 @@ func (s *keyDataTestBase) TearDownSuite(c *C) {
 	RegisterPlatformKeyDataHandler(mockPlatformName, nil)
 }
 
-func (s *keyDataTestBase) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKey, AuxiliaryKey) {
+func (s *keyDataTestBase) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKey, PrimaryKey) {
 	key := make([]byte, sz1)
 	auxKey := make([]byte, sz2)
 	_, err := rand.Read(key)
@@ -254,7 +254,7 @@ func (s *keyDataTestBase) newKeyDataKeys(c *C, sz1, sz2 int) (DiskUnlockKey, Aux
 	return key, auxKey
 }
 
-func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey AuxiliaryKey, modelAuthHash crypto.Hash) (out *KeyParams) {
+func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey PrimaryKey, modelAuthHash crypto.Hash) (out *KeyParams) {
 	payload := MarshalKeys(key, auxKey)
 
 	k := make([]byte, 48)
@@ -276,7 +276,7 @@ func (s *keyDataTestBase) mockProtectKeys(c *C, key DiskUnlockKey, auxKey Auxili
 		PlatformName:      mockPlatformName,
 		Handle:            &handle,
 		EncryptedPayload:  make([]byte, len(payload)),
-		AuxiliaryKey:      auxKey,
+		PrimaryKey:        auxKey,
 		SnapModelAuthHash: modelAuthHash}
 	stream.XORKeyStream(out.EncryptedPayload, payload)
 	return
@@ -457,7 +457,7 @@ func (s *keyDataSuite) checkKeyDataJSONAuthModePassphrase(c *C, keyData *KeyData
 
 type testKeyPayloadData struct {
 	key    DiskUnlockKey
-	auxKey AuxiliaryKey
+	auxKey PrimaryKey
 }
 
 func (s *keyDataSuite) testKeyPayload(c *C, data *testKeyPayloadData) {
@@ -505,7 +505,7 @@ func (s *keyDataSuite) TestKeyPayloadUnmarshalInvalid1(c *C) {
 }
 
 func (s *keyDataSuite) TestKeyPayloadUnmarshalInvalid2(c *C) {
-	payload := MarshalKeys(make(DiskUnlockKey, 32), make(AuxiliaryKey, 32))
+	payload := MarshalKeys(make(DiskUnlockKey, 32), make(PrimaryKey, 32))
 	payload = append(payload, 0xff)
 
 	key, auxKey, err := payload.Unmarshal()
@@ -1044,7 +1044,7 @@ func (s *keyDataSuite) TestSetAuthorizedSnapModelsWithWrongKey(c *C) {
 			"grade":        "secured",
 		}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")}
 
-	c.Check(keyData.SetAuthorizedSnapModels(make(AuxiliaryKey, 32), models...), ErrorMatches, "incorrect key supplied")
+	c.Check(keyData.SetAuthorizedSnapModels(make(PrimaryKey, 32), models...), ErrorMatches, "incorrect key supplied")
 }
 
 type testWriteAtomicData struct {
@@ -1141,7 +1141,7 @@ func (s *keyDataSuite) TestWriteAtomic4(c *C) {
 
 type testReadKeyDataData struct {
 	key        DiskUnlockKey
-	auxKey     AuxiliaryKey
+	auxKey     PrimaryKey
 	id         KeyID
 	r          KeyDataReader
 	model      SnapModel

--- a/keyring.go
+++ b/keyring.go
@@ -72,7 +72,7 @@ func GetDiskUnlockKeyFromKernel(prefix, devicePath string, remove bool) (DiskUnl
 	return key, nil
 }
 
-// GetAuxiliaryKeyFromKernel retrieves the auxiliary key associated with the
+// GetPrimaryKeyFromKernel retrieves the auxiliary key associated with the
 // KeyData that was used to unlock the encrypted container at the specified path.
 // The value of prefix must match the prefix that was supplied via
 // ActivateVolumeOptions during unlocking.
@@ -81,7 +81,7 @@ func GetDiskUnlockKeyFromKernel(prefix, devicePath string, remove bool) (DiskUnl
 // to returning.
 //
 // If no key is found, a ErrKernelKeyNotFound error will be returned.
-func GetAuxiliaryKeyFromKernel(prefix, devicePath string, remove bool) (AuxiliaryKey, error) {
+func GetPrimaryKeyFromKernel(prefix, devicePath string, remove bool) (PrimaryKey, error) {
 	key, err := keyring.GetKeyFromUserKeyring(devicePath, keyringPurposeAuxiliary, keyringPrefixOrDefault(prefix))
 	if err != nil {
 		var e syscall.Errno

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -111,59 +111,59 @@ func (s *keyringSuite) TestGetDiskUnlockKeyFromKernelAndRemove(c *C) {
 	c.Check(err, ErrorMatches, "cannot find key: required key not available")
 }
 
-type testGetAuxiliaryKeyFromKernelData struct {
-	key        AuxiliaryKey
+type testGetPrimaryKeyFromKernelData struct {
+	key        PrimaryKey
 	prefix     string
 	devicePath string
 }
 
-func (s *keyringSuite) testGetAuxiliaryKeyFromKernel(c *C, data *testGetAuxiliaryKeyFromKernelData) {
+func (s *keyringSuite) testGetPrimaryKeyFromKernel(c *C, data *testGetPrimaryKeyFromKernelData) {
 	prefix := data.prefix
 	if prefix == "" {
 		prefix = "ubuntu-fde"
 	}
 	c.Check(keyring.AddKeyToUserKeyring(data.key, data.devicePath, "aux", prefix), IsNil)
 
-	key, err := GetAuxiliaryKeyFromKernel(data.prefix, data.devicePath, false)
+	key, err := GetPrimaryKeyFromKernel(data.prefix, data.devicePath, false)
 	c.Check(err, IsNil)
 	c.Check(key, DeepEquals, data.key)
 }
 
-func (s *keyringSuite) TestGetAuxiliaryKeyFromKernel1(c *C) {
-	key := make(AuxiliaryKey, 32)
+func (s *keyringSuite) TestGetPrimaryKeyFromKernel1(c *C) {
+	key := make(PrimaryKey, 32)
 	rand.Read(key)
 
-	s.testGetAuxiliaryKeyFromKernel(c, &testGetAuxiliaryKeyFromKernelData{
+	s.testGetPrimaryKeyFromKernel(c, &testGetPrimaryKeyFromKernelData{
 		key:        key,
 		devicePath: "/dev/sda1"})
 }
 
-func (s *keyringSuite) TestGetAuxiliaryKeyFromKernel2(c *C) {
-	key := make(AuxiliaryKey, 32)
+func (s *keyringSuite) TestGetPrimaryKeyFromKernel2(c *C) {
+	key := make(PrimaryKey, 32)
 	rand.Read(key)
 
-	s.testGetAuxiliaryKeyFromKernel(c, &testGetAuxiliaryKeyFromKernelData{
+	s.testGetPrimaryKeyFromKernel(c, &testGetPrimaryKeyFromKernelData{
 		key:        key,
 		prefix:     "foo",
 		devicePath: "/dev/nvme0n1p2"})
 }
 
-func (s *keyringSuite) TestGetAuxiliaryKeyFromKernelNoKey(c *C) {
-	_, err := GetAuxiliaryKeyFromKernel("", "/dev/sda1", false)
+func (s *keyringSuite) TestGetPrimaryKeyFromKernelNoKey(c *C) {
+	_, err := GetPrimaryKeyFromKernel("", "/dev/sda1", false)
 	c.Check(err, ErrorMatches, "cannot find key in kernel keyring")
 }
 
-func (s *keyringSuite) TestGetAuxiliaryKeyFromKernelAndRemove(c *C) {
-	key := make(AuxiliaryKey, 32)
+func (s *keyringSuite) TestGetPrimaryKeyFromKernelAndRemove(c *C) {
+	key := make(PrimaryKey, 32)
 	rand.Read(key)
 
 	c.Check(keyring.AddKeyToUserKeyring(key, "/dev/sda1", "aux", "ubuntu-fde"), IsNil)
 
-	key2, err := GetAuxiliaryKeyFromKernel("", "/dev/sda1", true)
+	key2, err := GetPrimaryKeyFromKernel("", "/dev/sda1", true)
 	c.Check(err, IsNil)
 	c.Check(key2, DeepEquals, key)
 
-	_, err = GetAuxiliaryKeyFromKernel("", "/dev/sda1", true)
+	_, err = GetPrimaryKeyFromKernel("", "/dev/sda1", true)
 	c.Check(err, ErrorMatches, "cannot find key in kernel keyring")
 
 	_, err = keyring.GetKeyFromUserKeyring("/dev/sda1", "aux", "ubuntu-fde")

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -123,7 +123,7 @@ type PcrPolicyData_v3 = pcrPolicyData_v3
 
 type PcrPolicyParams = pcrPolicyParams
 
-func NewPcrPolicyParams(key secboot.AuxiliaryKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name) *PcrPolicyParams {
+func NewPcrPolicyParams(key secboot.PrimaryKey, pcrs tpm2.PCRSelectionList, pcrDigests tpm2.DigestList, policyCounterName tpm2.Name) *PcrPolicyParams {
 	return &PcrPolicyParams{
 		key:               key,
 		pcrs:              pcrs,
@@ -196,7 +196,7 @@ func MockNewKeyDataPolicy(fn func(tpm2.HashAlgorithmId, *tpm2.Public, *tpm2.NVPu
 	}
 }
 
-func MockNewPolicyAuthPublicKey(fn func(authKey secboot.AuxiliaryKey) (*tpm2.Public, error)) (restore func()) {
+func MockNewPolicyAuthPublicKey(fn func(authKey secboot.PrimaryKey) (*tpm2.Public, error)) (restore func()) {
 	orig := newPolicyAuthPublicKey
 	newPolicyAuthPublicKey = fn
 	return func() {
@@ -212,7 +212,7 @@ func MockSecbootNewKeyData(fn func(*secboot.KeyParams) (*secboot.KeyData, error)
 	}
 }
 
-func MockSkdbUpdatePCRProtectionPolicyImpl(fn func(*sealedKeyDataBase, *tpm2.TPMContext, secboot.AuxiliaryKey, *tpm2.NVPublic, *PCRProtectionProfile, tpm2.SessionContext) error) (restore func()) {
+func MockSkdbUpdatePCRProtectionPolicyImpl(fn func(*sealedKeyDataBase, *tpm2.TPMContext, secboot.PrimaryKey, *tpm2.NVPublic, *PCRProtectionProfile, tpm2.SessionContext) error) (restore func()) {
 	orig := skdbUpdatePCRProtectionPolicyImpl
 	skdbUpdatePCRProtectionPolicyImpl = fn
 	return func() {
@@ -224,7 +224,7 @@ func (k *SealedKeyData) Data() KeyData {
 	return k.data
 }
 
-func (k *SealedKeyData) Validate(tpm *tpm2.TPMContext, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {
+func (k *SealedKeyData) Validate(tpm *tpm2.TPMContext, authKey secboot.PrimaryKey, session tpm2.SessionContext) error {
 	if _, err := k.validateData(tpm, session); err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (k *SealedKeyObject) Data() KeyData {
 	return k.data
 }
 
-func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {
+func (k *SealedKeyObject) Validate(tpm *tpm2.TPMContext, authKey secboot.PrimaryKey, session tpm2.SessionContext) error {
 	if _, err := k.validateData(tpm, session); err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func (c *createdPcrPolicyCounter) Session() tpm2.SessionContext {
 	return c.session
 }
 
-func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authKey secboot.AuxiliaryKey, session tpm2.SessionContext) error {
+func ValidateKeyDataFile(tpm *tpm2.TPMContext, keyFile string, authKey secboot.PrimaryKey, session tpm2.SessionContext) error {
 	k, err := ReadSealedKeyObjectFromFile(keyFile)
 	if err != nil {
 		return err

--- a/tpm2/keydata_legacy.go
+++ b/tpm2/keydata_legacy.go
@@ -42,7 +42,7 @@ const (
 
 type sealedData struct {
 	Key            secboot.DiskUnlockKey
-	AuthPrivateKey secboot.AuxiliaryKey
+	AuthPrivateKey secboot.PrimaryKey
 }
 
 // SealedKeyObject corresponds to a sealed key data file created by

--- a/tpm2/keydata_v3_test.go
+++ b/tpm2/keydata_v3_test.go
@@ -59,7 +59,7 @@ func (s *keyDataV3Suite) SetUpTest(c *C) {
 
 func (s *keyDataV3Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle) (KeyData, tpm2.Name) {
 	// Create the auth key
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, authKey)
@@ -110,7 +110,7 @@ func (s *keyDataV3Suite) newMockKeyData(c *C, pcrPolicyCounterHandle tpm2.Handle
 
 func (s *keyDataV3Suite) newMockImportableKeyData(c *C) KeyData {
 	// Create the auth key
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	authKeyPublic := s.newPolicyAuthPublicKey(c, tpm2.HashAlgorithmSHA256, authKey)

--- a/tpm2/platform_legacy.go
+++ b/tpm2/platform_legacy.go
@@ -127,7 +127,7 @@ func NewKeyDataFromSealedKeyObjectFile(path string) (*secboot.KeyData, error) {
 	params := secboot.KeyParams{
 		Handle:            json.RawMessage(handle),
 		PlatformName:      legacyPlatformName,
-		AuxiliaryKey:      make([]byte, 32), // Not used, but must be the expected size
+		PrimaryKey:        make([]byte, 32), // Not used, but must be the expected size
 		SnapModelAuthHash: crypto.SHA256,    // Not used, but just set it a valid alg
 	}
 

--- a/tpm2/platform_legacy_test.go
+++ b/tpm2/platform_legacy_test.go
@@ -71,7 +71,7 @@ func (s *platformLegacySuite) TestRecoverKeys(c *C) {
 	recoveredKey, recoveredAuthPrivateKey, err := k.RecoverKeys()
 	c.Check(err, IsNil)
 	c.Check(recoveredKey, DeepEquals, key)
-	c.Check(recoveredAuthPrivateKey, DeepEquals, secboot.AuxiliaryKey(authPrivateKey))
+	c.Check(recoveredAuthPrivateKey, DeepEquals, secboot.PrimaryKey(authPrivateKey))
 }
 
 func (s *platformLegacySuite) TestRecoverKeysNoTPMConnection(c *C) {

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -44,7 +44,7 @@ const (
 
 // pcrPolicyParams provides the parameters to keyDataPolicy.updatePcrPolicy.
 type pcrPolicyParams struct {
-	key secboot.AuxiliaryKey // Key used to authorize the generated dynamic authorization policy
+	key secboot.PrimaryKey // Key used to authorize the generated dynamic authorization policy
 
 	pcrs       tpm2.PCRSelectionList // PCR selection
 	pcrDigests tpm2.DigestList       // Approved PCR digests
@@ -92,8 +92,8 @@ type policyOrTree struct {
 
 // pcrPolicyCounterContext corresponds to a PCR policy counter.
 type pcrPolicyCounterContext interface {
-	Get() (uint64, error)                     // Return the current counter value
-	Increment(key secboot.AuxiliaryKey) error // Increment the counter value using the supplied key for authorization
+	Get() (uint64, error)                   // Return the current counter value
+	Increment(key secboot.PrimaryKey) error // Increment the counter value using the supplied key for authorization
 }
 
 // keyDataPolicy corresponds to the authorization policy for keyData.
@@ -123,7 +123,7 @@ type keyDataPolicy interface {
 
 	// ValidateAuthKey verifies that the supplied key is associated with this
 	// keyDataPolicy.
-	ValidateAuthKey(key secboot.AuxiliaryKey) error
+	ValidateAuthKey(key secboot.PrimaryKey) error
 }
 
 func createPcrPolicyCounterImpl(tpm *tpm2.TPMContext, handle tpm2.Handle, updateKey *tpm2.Public, computeAuthPolicies func(tpm2.HashAlgorithmId, tpm2.Name) tpm2.DigestList, hmacSession tpm2.SessionContext) (*tpm2.NVPublic, uint64, error) {
@@ -211,7 +211,7 @@ func createPcrPolicyCounterLegacy(tpm *tpm2.TPMContext, handle tpm2.Handle, upda
 	return createPcrPolicyCounterImpl(tpm, handle, updateKey, computeV2PcrPolicyCounterAuthPolicies, hmacSession)
 }
 
-var newPolicyAuthPublicKey = func(key secboot.AuxiliaryKey) (*tpm2.Public, error) {
+var newPolicyAuthPublicKey = func(key secboot.PrimaryKey) (*tpm2.Public, error) {
 	ecdsaKey, err := deriveV3PolicyAuthKey(crypto.SHA256, key)
 	if err != nil {
 		return nil, err

--- a/tpm2/policy_v0.go
+++ b/tpm2/policy_v0.go
@@ -539,7 +539,7 @@ func (c *pcrPolicyCounterContext_v0) Get() (uint64, error) {
 	return c.tpm.NVReadCounter(c.index, c.index, authSession, c.session.IncludeAttrs(tpm2.AttrAudit))
 }
 
-func (c *pcrPolicyCounterContext_v0) Increment(key secboot.AuxiliaryKey) error {
+func (c *pcrPolicyCounterContext_v0) Increment(key secboot.PrimaryKey) error {
 	rsaKey, err := x509.ParsePKCS1PrivateKey(key)
 	if err != nil {
 		return xerrors.Errorf("cannot parse auth key: %w", err)
@@ -609,7 +609,7 @@ func (p *keyDataPolicy_v0) PCRPolicyCounterContext(tpm *tpm2.TPMContext, pub *tp
 		authPolicies: p.StaticData.PCRPolicyCounterAuthPolicies}, nil
 }
 
-func (p *keyDataPolicy_v0) ValidateAuthKey(key secboot.AuxiliaryKey) error {
+func (p *keyDataPolicy_v0) ValidateAuthKey(key secboot.PrimaryKey) error {
 	rsaKey, err := x509.ParsePKCS1PrivateKey(key)
 	if err != nil {
 		return xerrors.Errorf("cannot parse auth key: %w", err)

--- a/tpm2/policy_v1.go
+++ b/tpm2/policy_v1.go
@@ -257,7 +257,7 @@ func (c *pcrPolicyCounterContext_v1) Get() (uint64, error) {
 	return c.tpm.NVReadCounter(c.index, c.index, c.session)
 }
 
-func (c *pcrPolicyCounterContext_v1) Increment(key secboot.AuxiliaryKey) error {
+func (c *pcrPolicyCounterContext_v1) Increment(key secboot.PrimaryKey) error {
 	ecdsaKey, err := createECDSAPrivateKeyFromTPM(c.updateKey, tpm2.ECCParameter(key))
 	if err != nil {
 		return xerrors.Errorf("cannot create auth key: %w", err)
@@ -319,7 +319,7 @@ func (p *keyDataPolicy_v1) PCRPolicyCounterContext(tpm *tpm2.TPMContext, pub *tp
 		updateKey: p.StaticData.AuthPublicKey}, nil
 }
 
-func (p *keyDataPolicy_v1) ValidateAuthKey(key secboot.AuxiliaryKey) error {
+func (p *keyDataPolicy_v1) ValidateAuthKey(key secboot.PrimaryKey) error {
 	pub, ok := p.StaticData.AuthPublicKey.Public().(*ecdsa.PublicKey)
 	if !ok {
 		return policyDataError{errors.New("unexpected dynamic authorization policy public key type")}

--- a/tpm2/seal_legacy.go
+++ b/tpm2/seal_legacy.go
@@ -96,7 +96,7 @@ type KeyCreationParams struct {
 // AuthKey in the params argument.
 //
 // Deprecated: Use ProtectKeyWithExternalStorageKey.
-func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockKey, keyPath string, params *KeyCreationParams) (authKey secboot.AuxiliaryKey, err error) {
+func SealKeyToExternalTPMStorageKey(tpmKey *tpm2.Public, key secboot.DiskUnlockKey, keyPath string, params *KeyCreationParams) (authKey secboot.PrimaryKey, err error) {
 	// params is mandatory.
 	if params == nil {
 		return nil, errors.New("no KeyCreationParams provided")
@@ -234,7 +234,7 @@ type SealKeyRequest struct {
 // AuthKey in the params argument.
 //
 // Deprecated: Use ProtectKeysWithTPM.
-func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCreationParams) (authKey secboot.AuxiliaryKey, err error) {
+func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCreationParams) (authKey secboot.PrimaryKey, err error) {
 	// params is mandatory.
 	if params == nil {
 		return nil, errors.New("no KeyCreationParams provided")
@@ -411,6 +411,6 @@ func SealKeyToTPMMultiple(tpm *Connection, keys []*SealKeyRequest, params *KeyCr
 // AuthKey in the params argument.
 //
 // Deprecated: Use ProtectKeyWithTPM.
-func SealKeyToTPM(tpm *Connection, key secboot.DiskUnlockKey, keyPath string, params *KeyCreationParams) (authKey secboot.AuxiliaryKey, err error) {
+func SealKeyToTPM(tpm *Connection, key secboot.DiskUnlockKey, keyPath string, params *KeyCreationParams) (authKey secboot.PrimaryKey, err error) {
 	return SealKeyToTPMMultiple(tpm, []*SealKeyRequest{{Key: key, Path: keyPath}}, params)
 }

--- a/tpm2/seal_legacy_test.go
+++ b/tpm2/seal_legacy_test.go
@@ -80,7 +80,7 @@ func (s *sealLegacySuite) testSealKeyToTPM(c *C, params *KeyCreationParams) {
 	c.Check(k.PCRPolicyCounterHandle(), Equals, params.PCRPolicyCounterHandle)
 
 	if params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, secboot.AuxiliaryKey(params.AuthKey.D.Bytes()))
+		c.Check(authKey, DeepEquals, secboot.PrimaryKey(params.AuthKey.D.Bytes()))
 	}
 
 	keyUnsealed, authKeyUnsealed, err := k.UnsealFromTPM(s.TPM())
@@ -273,7 +273,7 @@ func (s *sealLegacySuite) testSealKeyToTPMMultiple(c *C, data *testSealKeyToTPMM
 	}
 
 	if data.params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, secboot.AuxiliaryKey(data.params.AuthKey.D.Bytes()))
+		c.Check(authKey, DeepEquals, secboot.PrimaryKey(data.params.AuthKey.D.Bytes()))
 	}
 
 	if data.params.PCRProfile != nil {
@@ -499,7 +499,7 @@ func (s *sealLegacySuite) testSealKeyToExternalTPMStorageKey(c *C, params *KeyCr
 	c.Check(k.PCRPolicyCounterHandle(), Equals, params.PCRPolicyCounterHandle)
 
 	if params.AuthKey != nil {
-		c.Check(authKey, DeepEquals, secboot.AuxiliaryKey(params.AuthKey.D.Bytes()))
+		c.Check(authKey, DeepEquals, secboot.PrimaryKey(params.AuthKey.D.Bytes()))
 	}
 
 	keyUnsealed, authKeyUnsealed, err := k.UnsealFromTPM(s.TPM())

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -321,7 +321,7 @@ func (s *sealSuite) TestProtectKeyWithTPMNoPCRPolicyCounterHandle(c *C) {
 }
 
 func (s *sealSuite) TestProtectKeyWithTPMWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	s.testProtectKeyWithTPM(c, &ProtectKeyParams{
@@ -535,7 +535,7 @@ func (s *sealSuite) TestProtectKeysWithTPMNoPCRPolicyCounterHandle(c *C) {
 }
 
 func (s *sealSuite) TestProtectKeysWithTPMWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	s.testProtectKeysWithTPM(c, &testProtectKeysWithTPMData{
@@ -716,7 +716,7 @@ func (s *sealSuite) TestProtectKeyWithExternalStorageKeyNilPCRProfileAndNoAuthor
 }
 
 func (s *sealSuite) TestProtectKeyWithExternalStorageKeyWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	s.testProtectKeyWithExternalStorageKey(c, &ProtectKeyParams{
@@ -797,7 +797,7 @@ type sealSuiteNoTPM struct {
 
 	lastKeyParams *secboot.KeyParams
 
-	lastAuthKey       secboot.AuxiliaryKey
+	lastAuthKey       secboot.PrimaryKey
 	lastAuthKeyPublic *tpm2.Public
 }
 
@@ -812,7 +812,7 @@ func (s *sealSuiteNoTPM) SetUpTest(c *C) {
 
 	s.lastAuthKey = nil
 	s.lastAuthKeyPublic = nil
-	s.AddCleanup(MockNewPolicyAuthPublicKey(func(authKey secboot.AuxiliaryKey) (*tpm2.Public, error) {
+	s.AddCleanup(MockNewPolicyAuthPublicKey(func(authKey secboot.PrimaryKey) (*tpm2.Public, error) {
 		s.lastAuthKey = authKey
 
 		pub, err := NewPolicyAuthPublicKey(authKey)
@@ -830,7 +830,7 @@ type testMakeKeyDataWithPolicyData struct {
 func (s *sealSuiteNoTPM) testMakeKeyDataWithPolicy(c *C, data *testMakeKeyDataWithPolicyData) {
 	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	var sealer mockKeySealer
@@ -841,7 +841,7 @@ func (s *sealSuiteNoTPM) testMakeKeyDataWithPolicy(c *C, data *testMakeKeyDataWi
 
 	c.Assert(s.lastKeyParams, NotNil)
 	c.Check(s.lastKeyParams.PlatformName, Equals, "tpm2")
-	c.Check(s.lastKeyParams.AuxiliaryKey, DeepEquals, authKey)
+	c.Check(s.lastKeyParams.PrimaryKey, DeepEquals, authKey)
 	c.Check(s.lastKeyParams.SnapModelAuthHash, Equals, crypto.SHA256)
 
 	skd, err := NewSealedKeyData(kd)
@@ -939,7 +939,7 @@ func (s *sealSuiteNoTPM) TestMakeKeyDataWithPolicyDifferentPolicyVersion(c *C) {
 
 type testMakeKeyDataPolicyData struct {
 	pcrPolicyCounterHandle       tpm2.Handle
-	authKey                      secboot.AuxiliaryKey
+	authKey                      secboot.PrimaryKey
 	initialPcrPolicyCounterValue uint64
 }
 
@@ -1051,7 +1051,7 @@ func (s *sealSuiteNoTPM) TestMakeKeyDataPolicyWithProvidedAuthKey(c *C) {
 }
 
 type testMakeKeyDataData struct {
-	authKey                      secboot.AuxiliaryKey
+	authKey                      secboot.PrimaryKey
 	params                       *KeyDataParams
 	initialPcrPolicyCounterValue uint64
 }
@@ -1113,7 +1113,7 @@ func (s *sealSuiteNoTPM) testMakeKeyData(c *C, data *testMakeKeyDataData) {
 	defer restore()
 
 	pcrPolicyInitialized := false
-	restore = MockSkdbUpdatePCRProtectionPolicyImpl(func(skdb *SealedKeyDataBase, tpm *tpm2.TPMContext, authKey secboot.AuxiliaryKey, counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, session tpm2.SessionContext) error {
+	restore = MockSkdbUpdatePCRProtectionPolicyImpl(func(skdb *SealedKeyDataBase, tpm *tpm2.TPMContext, authKey secboot.PrimaryKey, counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, session tpm2.SessionContext) error {
 		c.Check(tpm, Equals, mockTpm)
 		c.Check(authKey, DeepEquals, s.lastAuthKey)
 		c.Check(counterPub, Equals, mockPcrPolicyCounterPub)
@@ -1141,7 +1141,7 @@ func (s *sealSuiteNoTPM) testMakeKeyData(c *C, data *testMakeKeyDataData) {
 
 	c.Assert(s.lastKeyParams, NotNil)
 	c.Check(s.lastKeyParams.PlatformName, Equals, "tpm2")
-	c.Check(s.lastKeyParams.AuxiliaryKey, DeepEquals, s.lastAuthKey)
+	c.Check(s.lastKeyParams.PrimaryKey, DeepEquals, s.lastAuthKey)
 	c.Check(s.lastKeyParams.SnapModelAuthHash, Equals, crypto.SHA256)
 
 	skd, err := NewSealedKeyData(kd)

--- a/tpm2/unseal_legacy.go
+++ b/tpm2/unseal_legacy.go
@@ -74,7 +74,7 @@ import (
 // SealedKeyObject.UpdatePCRProtectionPolicy is returned as the second return value.
 //
 // Deprecated: Use NewKeyData and the secboot.KeyData API for key recovery.
-func (k *SealedKeyObject) UnsealFromTPM(tpm *Connection) (key secboot.DiskUnlockKey, authKey secboot.AuxiliaryKey, err error) {
+func (k *SealedKeyObject) UnsealFromTPM(tpm *Connection) (key secboot.DiskUnlockKey, authKey secboot.PrimaryKey, err error) {
 	data, err := k.unsealDataFromTPM(tpm.TPMContext, nil, tpm.HmacSession())
 	if err != nil {
 		return nil, nil, err

--- a/tpm2/unseal_legacy_test.go
+++ b/tpm2/unseal_legacy_test.go
@@ -167,7 +167,7 @@ func (s *unsealSuite) TestUnsealImportableFromTPMNilPCRProfile(c *C) {
 	s.testUnsealImportableFromTPM(c, &KeyCreationParams{PCRPolicyCounterHandle: tpm2.HandleNull})
 }
 
-func (s *unsealSuite) testUnsealFromTPMErrorHandling(c *C, prepare func(string, secboot.AuxiliaryKey)) error {
+func (s *unsealSuite) testUnsealFromTPMErrorHandling(c *C, prepare func(string, secboot.PrimaryKey)) error {
 	key := make(secboot.DiskUnlockKey, 32)
 	rand.Read(key)
 
@@ -189,7 +189,7 @@ func (s *unsealSuite) testUnsealFromTPMErrorHandling(c *C, prepare func(string, 
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingLockout(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.AuxiliaryKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.PrimaryKey) {
 		// Put the TPM in DA lockout mode
 		c.Check(s.TPM().DictionaryAttackParameters(s.TPM().LockoutHandleContext(), 0, 7200, 86400, nil), IsNil)
 	})
@@ -197,7 +197,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingLockout(c *C) {
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingInvalidPCRProfile(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.AuxiliaryKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.PrimaryKey) {
 		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
 		c.Check(err, IsNil)
 	})
@@ -207,7 +207,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingInvalidPCRProfile(c *C) {
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingRevokedPolicy(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(path string, authKey secboot.AuxiliaryKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(path string, authKey secboot.PrimaryKey) {
 		k, err := ReadSealedKeyObjectFromFile(path)
 		c.Assert(err, IsNil)
 		c.Check(k.UpdatePCRProtectionPolicy(s.TPM(), authKey, nil), IsNil)
@@ -219,7 +219,7 @@ func (s *unsealSuite) TestUnsealFromTPMErrorHandlingRevokedPolicy(c *C) {
 }
 
 func (s *unsealSuite) TestUnsealFromTPMErrorHandlingSealedKeyAccessLocked(c *C) {
-	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.AuxiliaryKey) {
+	err := s.testUnsealFromTPMErrorHandling(c, func(_ string, _ secboot.PrimaryKey) {
 		c.Check(BlockPCRProtectionPolicies(s.TPM(), []int{23}), IsNil)
 	})
 	c.Check(err, testutil.ConvertibleTo, InvalidKeyDataError{})

--- a/tpm2/update.go
+++ b/tpm2/update.go
@@ -43,7 +43,7 @@ var skdbUpdatePCRProtectionPolicyImpl = (*sealedKeyDataBase).updatePCRProtection
 //
 // If k.data.policy().pcrPolicyCounterHandle() is not tpm2.HandleNull, then counterPub
 // must be supplied, and it must correspond to the public area associated with that handle.
-func (k *sealedKeyDataBase) updatePCRProtectionPolicyImpl(tpm *tpm2.TPMContext, key secboot.AuxiliaryKey,
+func (k *sealedKeyDataBase) updatePCRProtectionPolicyImpl(tpm *tpm2.TPMContext, key secboot.PrimaryKey,
 	counterPub *tpm2.NVPublic, profile *PCRProtectionProfile, session tpm2.SessionContext) error {
 	var counterName tpm2.Name
 	if counterPub != nil {
@@ -109,7 +109,7 @@ func (k *sealedKeyDataBase) updatePCRProtectionPolicyImpl(tpm *tpm2.TPMContext, 
 	return k.data.Policy().UpdatePCRPolicy(alg, params)
 }
 
-func (k *sealedKeyDataBase) revokeOldPCRProtectionPoliciesImpl(tpm *tpm2.TPMContext, key secboot.AuxiliaryKey, session tpm2.SessionContext) error {
+func (k *sealedKeyDataBase) revokeOldPCRProtectionPoliciesImpl(tpm *tpm2.TPMContext, key secboot.PrimaryKey, session tpm2.SessionContext) error {
 	pcrPolicyCounterPub, err := k.validateData(tpm, session)
 	if err != nil {
 		if isKeyDataError(err) {
@@ -157,7 +157,7 @@ func (k *sealedKeyDataBase) revokeOldPCRProtectionPoliciesImpl(tpm *tpm2.TPMCont
 	return nil
 }
 
-func updateKeyPCRProtectionPoliciesCommon(tpm *tpm2.TPMContext, keys []*sealedKeyDataBase, authKey secboot.AuxiliaryKey, pcrProfile *PCRProtectionProfile, session tpm2.SessionContext) error {
+func updateKeyPCRProtectionPoliciesCommon(tpm *tpm2.TPMContext, keys []*sealedKeyDataBase, authKey secboot.PrimaryKey, pcrProfile *PCRProtectionProfile, session tpm2.SessionContext) error {
 	primaryKey := keys[0]
 
 	// Validate the primary key object
@@ -210,7 +210,7 @@ func updateKeyPCRProtectionPoliciesCommon(tpm *tpm2.TPMContext, keys []*sealedKe
 	return nil
 }
 
-func updateKeyPCRProtectionPolicies(tpm *tpm2.TPMContext, keys []*SealedKeyData, authKey secboot.AuxiliaryKey, pcrProfile *PCRProtectionProfile, session tpm2.SessionContext) error {
+func updateKeyPCRProtectionPolicies(tpm *tpm2.TPMContext, keys []*SealedKeyData, authKey secboot.PrimaryKey, pcrProfile *PCRProtectionProfile, session tpm2.SessionContext) error {
 	var keysCommon []*sealedKeyDataBase
 	for _, key := range keys {
 		keysCommon = append(keysCommon, &key.sealedKeyDataBase)
@@ -238,7 +238,7 @@ func updateKeyPCRProtectionPolicies(tpm *tpm2.TPMContext, keys []*SealedKeyData,
 //
 // On success, this SealedKeyObject will have an updated authorization policy that includes a PCR policy computed
 // from the supplied PCRProtectionProfile. It must be persisted using SealedKeyObject.WriteAtomic.
-func (k *SealedKeyData) UpdatePCRProtectionPolicy(tpm *Connection, authKey secboot.AuxiliaryKey, pcrProfile *PCRProtectionProfile) error {
+func (k *SealedKeyData) UpdatePCRProtectionPolicy(tpm *Connection, authKey secboot.PrimaryKey, pcrProfile *PCRProtectionProfile) error {
 	return updateKeyPCRProtectionPolicies(tpm.TPMContext, []*SealedKeyData{k}, authKey, pcrProfile, tpm.HmacSession())
 }
 
@@ -256,7 +256,7 @@ func (k *SealedKeyData) UpdatePCRProtectionPolicy(tpm *Connection, authKey secbo
 // after each call to UpdatePCRProtectionPolicy that removes some PCR policy branches.
 //
 // If validation of the key data fails, a InvalidKeyDataError error will be returned.
-func (k *SealedKeyData) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey secboot.AuxiliaryKey) error {
+func (k *SealedKeyData) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey secboot.PrimaryKey) error {
 	return k.revokeOldPCRProtectionPoliciesImpl(tpm.TPMContext, authKey, tpm.HmacSession())
 }
 
@@ -269,7 +269,7 @@ func (k *SealedKeyData) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey 
 // On success, each of the supplied KeyData objects will have an updated authorization policy that includes a
 // PCR policy computed from the supplied PCRProtectionProfile. They must be persisted using
 // secboot.KeyData.WriteAtomic.
-func UpdateKeyDataPCRProtectionPolicy(tpm *Connection, authKey secboot.AuxiliaryKey, pcrProfile *PCRProtectionProfile, keys ...*secboot.KeyData) error {
+func UpdateKeyDataPCRProtectionPolicy(tpm *Connection, authKey secboot.PrimaryKey, pcrProfile *PCRProtectionProfile, keys ...*secboot.KeyData) error {
 	if len(keys) == 0 {
 		return errors.New("no sealed keys supplied")
 	}

--- a/tpm2/update_legacy.go
+++ b/tpm2/update_legacy.go
@@ -106,7 +106,7 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPoliciesV0(tpm *Connection, poli
 //
 // On success, this SealedKeyObject will have an updated authorization policy that includes a PCR policy computed
 // from the supplied PCRProtectionProfile. It must be persisted using SealedKeyObject.WriteAtomic.
-func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey secboot.AuxiliaryKey, pcrProfile *PCRProtectionProfile) error {
+func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey secboot.PrimaryKey, pcrProfile *PCRProtectionProfile) error {
 	return updateKeyPCRProtectionPoliciesCommon(tpm.TPMContext, []*sealedKeyDataBase{&k.sealedKeyDataBase}, authKey, pcrProfile, tpm.HmacSession())
 }
 
@@ -124,7 +124,7 @@ func (k *SealedKeyObject) UpdatePCRProtectionPolicy(tpm *Connection, authKey sec
 // after each call to UpdatePCRProtectionPolicy that removes some PCR policy branches.
 //
 // If validation of the key data fails, a InvalidKeyDataError error will be returned.
-func (k *SealedKeyObject) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey secboot.AuxiliaryKey) error {
+func (k *SealedKeyObject) RevokeOldPCRProtectionPolicies(tpm *Connection, authKey secboot.PrimaryKey) error {
 	return k.revokeOldPCRProtectionPoliciesImpl(tpm.TPMContext, authKey, tpm.HmacSession())
 }
 
@@ -139,7 +139,7 @@ func (k *SealedKeyObject) RevokeOldPCRProtectionPolicies(tpm *Connection, authKe
 // SealedKeyObject.WriteAtomic.
 //
 // Deprecated: Use UpdateKeyDataPCRProtectionPolicy.
-func UpdateKeyPCRProtectionPolicyMultiple(tpm *Connection, keys []*SealedKeyObject, authKey secboot.AuxiliaryKey, pcrProfile *PCRProtectionProfile) error {
+func UpdateKeyPCRProtectionPolicyMultiple(tpm *Connection, keys []*SealedKeyObject, authKey secboot.PrimaryKey, pcrProfile *PCRProtectionProfile) error {
 	if len(keys) == 0 {
 		return errors.New("no sealed keys supplied")
 	}

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -57,7 +57,7 @@ var _ = Suite(&updateSuite{})
 
 type testUpdatePCRProtectionPolicyData struct {
 	pcrPolicyCounterHandle tpm2.Handle
-	authKey                secboot.AuxiliaryKey
+	authKey                secboot.PrimaryKey
 }
 
 func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRProtectionPolicyData) {
@@ -102,7 +102,7 @@ func (s *updateSuite) TestUpdatePCRProtectionPolicyNoPCRPolicyCounter(c *C) {
 }
 
 func (s *updateSuite) TestUpdatePCRProtectionPolicyWithProvidedAuthKey(c *C) {
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	s.testUpdatePCRProtectionPolicy(c, &testUpdatePCRProtectionPolicyData{
@@ -223,7 +223,7 @@ func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicyUnrelated1(c *C) {
 		keys = append(keys, key)
 	}
 
-	authKey := make(secboot.AuxiliaryKey, 32)
+	authKey := make(secboot.PrimaryKey, 32)
 	rand.Read(authKey)
 
 	var ks []*secboot.KeyData
@@ -243,13 +243,13 @@ func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicyUnrelated1(c *C) {
 
 func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicyUnrelated2(c *C) {
 	var keys []secboot.DiskUnlockKey
-	var authKeys []secboot.AuxiliaryKey
+	var authKeys []secboot.PrimaryKey
 	for i := 0; i < 2; i++ {
 		key := make(secboot.DiskUnlockKey, 32)
 		rand.Read(key)
 		keys = append(keys, key)
 
-		authKey := make(secboot.AuxiliaryKey, 32)
+		authKey := make(secboot.PrimaryKey, 32)
 		rand.Read(authKey)
 		authKeys = append(authKeys, authKey)
 	}


### PR DESCRIPTION
First 2 commits taken from https://github.com/chrisccoulson/secboot/tree/keydata-format-improvements-v2 and rebased on top of recent master.

This adds the following changes:
1) Renaming AuxiliaryKey to PrimaryKey
2) adds a basic legacy behavior test to ensure correct behavior for the upcoming changes related to the new keydata format.