### PR TITLE
argon2: use a fixed key length for benchmarking

### DIFF
--- a/internal/argon2/argon2.go
+++ b/internal/argon2/argon2.go
@@ -32,6 +32,7 @@ import (
 const (
 	// Dummy password for benchmarking (same value used by cryptsetup)
 	benchmarkPassword = "foo"
+	benchmarkKeyLen   = 32
 
 	initialTargetDuration = 250 * time.Millisecond
 
@@ -79,7 +80,6 @@ type CostParams struct {
 }
 
 type benchmarkContext struct {
-	keyLen           uint32          // desired key length
 	keyFn            KeyDurationFunc // callback for running an individual measurement
 	maxMemoryCostKiB uint32          // maximum memory cost
 	cost             CostParams      // current computed cost parameters
@@ -272,15 +272,14 @@ func (c *benchmarkContext) run(params *BenchmarkParams, keyFn KeyDurationFunc, s
 	return &c.cost, nil
 }
 
-// KeyDuration runs a key derivation with the built-in benchmarking values and
-// the specified cost parameters and length, and then returns the amount of time
-// taken to execute.
+// KeyDuration runs the key derivation with the built-in benchmarking values for the
+// supplied set of cost parameters, and then returns the amount of time taken to execute.
 //
-// By design, this function consumes a lot of memory depending on the supplied parameters.
-// It may be desirable to execute it in a short-lived utility process.
-func KeyDuration(params *CostParams, keyLen uint32) time.Duration {
+// By design, this function consumes a lot of memory depending on the supplied
+// parameters. It may be desirable to execute it in a short-lived utility process.
+func KeyDuration(params *CostParams) time.Duration {
 	start := time.Now()
-	Key(benchmarkPassword, benchmarkSalt, params, keyLen)
+	Key(benchmarkPassword, benchmarkSalt, params, benchmarkKeyLen)
 	return time.Now().Sub(start)
 }
 

--- a/internal/argon2/argon2_test.go
+++ b/internal/argon2/argon2_test.go
@@ -431,22 +431,22 @@ func (s *argon2SuiteExpensive) TestKey6(c *C) {
 }
 
 func (s *argon2SuiteExpensive) TestKeyDuration(c *C) {
-	time1 := KeyDuration(&CostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 4}, 32)
+	time1 := KeyDuration(&CostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 4})
 	runtime.GC()
 
-	time2 := KeyDuration(&CostParams{Time: 16, MemoryKiB: 32 * 1024, Threads: 4}, 32)
-	runtime.GC()
-	// XXX: this needs a checker like go-tpm2/testutil's IntGreater, which copes with
-	// types of int64 kind
-	c.Check(time2 > time1, testutil.IsTrue)
-
-	time2 = KeyDuration(&CostParams{Time: 4, MemoryKiB: 128 * 1024, Threads: 4}, 32)
+	time2 := KeyDuration(&CostParams{Time: 16, MemoryKiB: 32 * 1024, Threads: 4})
 	runtime.GC()
 	// XXX: this needs a checker like go-tpm2/testutil's IntGreater, which copes with
 	// types of int64 kind
 	c.Check(time2 > time1, testutil.IsTrue)
 
-	time2 = KeyDuration(&CostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 1}, 32)
+	time2 = KeyDuration(&CostParams{Time: 4, MemoryKiB: 128 * 1024, Threads: 4})
+	runtime.GC()
+	// XXX: this needs a checker like go-tpm2/testutil's IntGreater, which copes with
+	// types of int64 kind
+	c.Check(time2 > time1, testutil.IsTrue)
+
+	time2 = KeyDuration(&CostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 1})
 	runtime.GC()
 	// XXX: this needs a checker like go-tpm2/testutil's IntGreater, which copes with
 	// types of int64 kind

--- a/internal/testutil/kdf.go
+++ b/internal/testutil/kdf.go
@@ -23,7 +23,6 @@ import (
 	"crypto"
 	_ "crypto/sha256"
 	"encoding/binary"
-	"errors"
 	"time"
 
 	kdf "github.com/canonical/go-sp800.108-kdf"
@@ -34,9 +33,6 @@ import (
 // MockKDF provides a mock implementation of secboot.KDF that isn't
 // memory intensive.
 type MockKDF struct {
-	// BenchmarkKeyLen is the key length that Time was called with. Set this
-	// to zero before running a mock benchmark.
-	BenchmarkKeyLen uint32
 }
 
 // Derive implements secboot.KDF.Derive and derives a key from the supplied
@@ -54,12 +50,7 @@ func (_ *MockKDF) Derive(passphrase string, salt []byte, params *secboot.KDFCost
 
 // Time implements secboot.KDF.Time and returns a time that is linearly
 // related to the specified cost parameters, suitable for mocking benchmarking.
-func (k *MockKDF) Time(params *secboot.KDFCostParams, keyLen uint32) (time.Duration, error) {
-	if k.BenchmarkKeyLen != 0 && k.BenchmarkKeyLen != keyLen {
-		return 0, errors.New("unexpected key length")
-	}
-	k.BenchmarkKeyLen = keyLen
-
+func (_ *MockKDF) Time(params *secboot.KDFCostParams) (time.Duration, error) {
 	const memBandwidthKiBPerMs = 2048
 	duration := (time.Duration(float64(params.MemoryKiB)/float64(memBandwidthKiBPerMs)) * time.Duration(params.Time)) * time.Millisecond
 	return duration, nil


### PR DESCRIPTION
The key length has a negligible effect on the execution time, so use
a fixed key length of 32 bytes for benchmarking.

Note that this keeps the keyLen argument to KDFOptions.deriveCostParams
as this is going to become an interface in a future PR, where the key
length will be used to select the default PBKDF2 hash.