### PR TITLE
argon2: refactor API to prepare for PBKDF2 support for passphrases

### DIFF
--- a/argon2.go
+++ b/argon2.go
@@ -21,8 +21,8 @@ package secboot
 
 import (
 	"errors"
-	"math"
 	"runtime"
+	"sync"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -31,16 +31,45 @@ import (
 )
 
 var (
+	argon2Mu   sync.Mutex
+	argon2Impl Argon2KDF = nullArgon2KDFImpl{}
+
 	runtimeNumCPU = runtime.NumCPU
 )
 
-// KDFOptions specifies parameters for the Argon2 KDF used by cryptsetup
+// SetArgon2KDF sets the KDF implementation for Argon2. The default here is
+// the null implementation which returns an error, so this will need to be
+// configured explicitly in order to use Argon2.
+//
+// Passing nil will configure the null implementation as well.
+//
+// This returns the currently set implementation.
+func SetArgon2KDF(kdf Argon2KDF) Argon2KDF {
+	argon2Mu.Lock()
+	defer argon2Mu.Unlock()
+
+	orig := argon2Impl
+	if kdf == nil {
+		argon2Impl = nullArgon2KDFImpl{}
+	} else {
+		argon2Impl = kdf
+	}
+	return orig
+}
+
+func argon2KDF() Argon2KDF {
+	argon2Mu.Lock()
+	defer argon2Mu.Unlock()
+	return argon2Impl
+}
+
+// Argon2Options specifies parameters for the Argon2 KDF used by cryptsetup
 // and for passphrase support.
-type KDFOptions struct {
+type Argon2Options struct {
 	// MemoryKiB specifies the maximum memory cost in KiB when ForceIterations
 	// is zero. If ForceIterations is not zero, then this is used as the
 	// memory cost.
-	MemoryKiB int
+	MemoryKiB uint32
 
 	// TargetDuration specifies the target duration for the KDF which
 	// is used to benchmark the time and memory cost parameters. If it
@@ -51,39 +80,31 @@ type KDFOptions struct {
 	// ForceIterations can be used to turn off KDF benchmarking by
 	// setting the time cost directly. If this is zero then the cost
 	// parameters are benchmarked based on the value of TargetDuration.
-	ForceIterations int
+	ForceIterations uint32
 
 	// Parallel sets the maximum number of parallel threads for the
 	// KDF (up to 4). This will be adjusted downwards based on the
 	// actual number of CPUs.
-	Parallel int
+	Parallel uint8
 }
 
-func (o *KDFOptions) deriveCostParams(keyLen int, kdf KDF) (*KDFCostParams, error) {
+func (o *Argon2Options) deriveCostParams(keyLen int) (*Argon2CostParams, error) {
 	switch {
-	case int64(o.ForceIterations) > math.MaxUint32:
-		return nil, errors.New("ForceIterations too large")
-	case int64(o.MemoryKiB) > math.MaxUint32:
-		return nil, errors.New("MemoryKiB too large")
-	case o.Parallel > math.MaxUint8:
-		return nil, errors.New("Parallel too large")
-	case o.ForceIterations < 0:
-		return nil, errors.New("ForceIterations can't be negative")
 	case o.ForceIterations > 0:
 		threads := runtimeNumCPU()
 		if threads > 4 {
 			threads = 4
 		}
-		params := &KDFCostParams{
-			Time:      uint32(o.ForceIterations),
+		params := &Argon2CostParams{
+			Time:      o.ForceIterations,
 			MemoryKiB: 1 * 1024 * 1024,
 			Threads:   uint8(threads)}
 
 		if o.MemoryKiB != 0 {
-			params.MemoryKiB = uint32(o.MemoryKiB)
+			params.MemoryKiB = o.MemoryKiB
 		}
 		if o.Parallel != 0 {
-			params.Threads = uint8(o.Parallel)
+			params.Threads = o.Parallel
 			if o.Parallel > 4 {
 				params.Threads = 4
 			}
@@ -96,20 +117,20 @@ func (o *KDFOptions) deriveCostParams(keyLen int, kdf KDF) (*KDFCostParams, erro
 			TargetDuration:   2 * time.Second}
 
 		if o.MemoryKiB != 0 {
-			benchmarkParams.MaxMemoryCostKiB = uint32(o.MemoryKiB)
+			benchmarkParams.MaxMemoryCostKiB = o.MemoryKiB
 		}
 		if o.TargetDuration != 0 {
 			benchmarkParams.TargetDuration = o.TargetDuration
 		}
 		if o.Parallel != 0 {
-			benchmarkParams.Threads = uint8(o.Parallel)
+			benchmarkParams.Threads = o.Parallel
 			if o.Parallel > 4 {
 				benchmarkParams.Threads = 4
 			}
 		}
 
 		params, err := argon2.Benchmark(benchmarkParams, func(params *argon2.CostParams) (time.Duration, error) {
-			return kdf.Time(&KDFCostParams{
+			return argon2KDF().Time(&Argon2CostParams{
 				Time:      params.Time,
 				MemoryKiB: params.MemoryKiB,
 				Threads:   params.Threads})
@@ -118,15 +139,15 @@ func (o *KDFOptions) deriveCostParams(keyLen int, kdf KDF) (*KDFCostParams, erro
 			return nil, xerrors.Errorf("cannot benchmark KDF: %w", err)
 		}
 
-		return &KDFCostParams{
+		return &Argon2CostParams{
 			Time:      params.Time,
 			MemoryKiB: params.MemoryKiB,
 			Threads:   params.Threads}, nil
 	}
 }
 
-// KDFCostParams defines the cost parameters for key derivation using Argon2.
-type KDFCostParams struct {
+// Argon2CostParams defines the cost parameters for key derivation using Argon2.
+type Argon2CostParams struct {
 	// Time corresponds to the number of iterations of the algorithm
 	// that the key derivation will use.
 	Time uint32
@@ -140,41 +161,65 @@ type KDFCostParams struct {
 	Threads uint8
 }
 
-func (p *KDFCostParams) internalParams() *argon2.CostParams {
+func (p *Argon2CostParams) internalParams() *argon2.CostParams {
 	return &argon2.CostParams{
 		Time:      p.Time,
 		MemoryKiB: p.MemoryKiB,
 		Threads:   p.Threads}
 }
 
-// KDF is an interface to abstract use of the Argon2 KDF to make it possible
+// Argon2KDF is an interface to abstract use of the Argon2 KDF to make it possible
 // to delegate execution to a short-lived utility process where required.
-type KDF interface {
+type Argon2KDF interface {
 	// Derive derives a key of the specified length in bytes, from the supplied
 	// passphrase and salt and using the supplied cost parameters.
-	Derive(passphrase string, salt []byte, params *KDFCostParams, keyLen uint32) ([]byte, error)
+	Derive(passphrase string, salt []byte, params *Argon2CostParams, keyLen uint32) ([]byte, error)
 
 	// Time measures the amount of time the KDF takes to execute with the
 	// specified cost parameters.
-	Time(params *KDFCostParams) (time.Duration, error)
+	Time(params *Argon2CostParams) (time.Duration, error)
 }
 
-type argon2iKDFImpl struct{}
+type inProcessArgon2KDFImpl struct{}
 
-func (_ argon2iKDFImpl) Derive(passphrase string, salt []byte, params *KDFCostParams, keyLen uint32) ([]byte, error) {
+func (_ inProcessArgon2KDFImpl) Derive(passphrase string, salt []byte, params *Argon2CostParams, keyLen uint32) ([]byte, error) {
+	switch {
+	case params == nil:
+		return nil, errors.New("nil params")
+	case params.Time == 0:
+		return nil, errors.New("invalid time cost")
+	case params.Threads == 0:
+		return nil, errors.New("invalid number of threads")
+	}
+
 	return argon2.Key(passphrase, salt, params.internalParams(), keyLen), nil
 }
 
-func (_ argon2iKDFImpl) Time(params *KDFCostParams) (time.Duration, error) {
+func (_ inProcessArgon2KDFImpl) Time(params *Argon2CostParams) (time.Duration, error) {
+	switch {
+	case params == nil:
+		return 0, errors.New("nil params")
+	case params.Time == 0:
+		return 0, errors.New("invalid time cost")
+	case params.Threads == 0:
+		return 0, errors.New("invalid number of threads")
+	}
+
 	return argon2.KeyDuration(params.internalParams()), nil
 }
 
-var argon2iKDF = argon2iKDFImpl{}
-
-// Argon2iKDF returns the in-process Argon2i implementation of KDF. This
+// InProcessArgon2KDF is the in-process implementation of the Argon2 KDF. This
 // shouldn't be used in long-lived system processes - these processes should
 // instead provide their own KDF implementation which delegates to a short-lived
 // utility process which will use the in-process implementation.
-func Argon2iKDF() KDF {
-	return argon2iKDF
+var InProcessArgon2KDF = inProcessArgon2KDFImpl{}
+
+type nullArgon2KDFImpl struct{}
+
+func (_ nullArgon2KDFImpl) Derive(passphrase string, salt []byte, params *Argon2CostParams, keyLen uint32) ([]byte, error) {
+	return nil, errors.New("no argon2 KDF: please call secboot.SetArgon2KDF")
+}
+
+func (_ nullArgon2KDFImpl) Time(params *Argon2CostParams) (time.Duration, error) {
+	return 0, errors.New("no argon2 KDF: please call secboot.SetArgon2KDF")
 }

--- a/argon2_test.go
+++ b/argon2_test.go
@@ -37,41 +37,59 @@ import (
 )
 
 type argon2Suite struct {
-	halfTotalRamKiB uint64
-	cpus            int
+	snapd_testutil.BaseTest
+
+	kdf testutil.MockArgon2KDF
+
+	halfTotalRamKiB uint32
+	cpus            uint8
 }
 
 func (s *argon2Suite) SetUpSuite(c *C) {
 	var sysInfo unix.Sysinfo_t
 	c.Check(unix.Sysinfo(&sysInfo), IsNil)
 
-	s.halfTotalRamKiB = uint64(sysInfo.Totalram) * uint64(sysInfo.Unit) / 2048
-	if s.halfTotalRamKiB > math.MaxUint32 {
-		s.halfTotalRamKiB = math.MaxUint32
+	halfTotalRamKiB := uint64(sysInfo.Totalram) * uint64(sysInfo.Unit) / 2048
+	if halfTotalRamKiB > math.MaxUint32 {
+		halfTotalRamKiB = math.MaxUint32
 	}
+	s.halfTotalRamKiB = uint32(halfTotalRamKiB)
 
-	s.cpus = runtime.NumCPU()
+	cpus := runtime.NumCPU()
+	if cpus > math.MaxUint8 {
+		cpus = math.MaxUint8
+	}
+	s.cpus = uint8(cpus)
 }
 
-func (s *argon2Suite) checkParams(c *C, opts *KDFOptions, ncpus int, params *KDFCostParams) {
+func (s *argon2Suite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.kdf = testutil.MockArgon2KDF{}
+
+	origKdf := SetArgon2KDF(&s.kdf)
+	s.AddCleanup(func() { SetArgon2KDF(origKdf) })
+}
+
+func (s *argon2Suite) checkParams(c *C, opts *Argon2Options, ncpus uint8, params *Argon2CostParams) {
 	if opts.ForceIterations != 0 {
-		c.Check(params.Time, Equals, uint32(opts.ForceIterations))
+		c.Check(params.Time, Equals, opts.ForceIterations)
 
 		expectedMem := opts.MemoryKiB
 		if expectedMem == 0 {
 			expectedMem = 1 * 1024 * 1024
 		}
-		c.Check(params.MemoryKiB, Equals, uint32(expectedMem))
+		c.Check(params.MemoryKiB, Equals, expectedMem)
 	} else {
 		targetDuration := opts.TargetDuration
 		if targetDuration == 0 {
 			targetDuration = 2 * time.Second
 		}
-		var kdf testutil.MockKDF
+		var kdf testutil.MockArgon2KDF
 		duration, _ := kdf.Time(params)
 		c.Check(duration, Equals, targetDuration)
 
-		maxMem := uint64(opts.MemoryKiB)
+		maxMem := opts.MemoryKiB
 		if maxMem == 0 {
 			maxMem = 1 * 1024 * 1024
 		}
@@ -88,38 +106,32 @@ func (s *argon2Suite) checkParams(c *C, opts *KDFOptions, ncpus int, params *KDF
 	if expectedThreads > 4 {
 		expectedThreads = 4
 	}
-	c.Check(params.Threads, Equals, uint8(expectedThreads))
+	c.Check(params.Threads, Equals, expectedThreads)
 }
 
 var _ = Suite(&argon2Suite{})
 
 func (s *argon2Suite) TestDeriveCostParamsDefault(c *C) {
-	var kdf testutil.MockKDF
-
-	var opts KDFOptions
-	params, err := opts.DeriveCostParams(0, &kdf)
+	var opts Argon2Options
+	params, err := opts.DeriveCostParams(0)
 	c.Assert(err, IsNil)
 
 	s.checkParams(c, &opts, s.cpus, params)
 }
 
 func (s *argon2Suite) TestDeriveCostParamsMemoryLimit(c *C) {
-	var kdf testutil.MockKDF
-
-	var opts KDFOptions
+	var opts Argon2Options
 	opts.MemoryKiB = 32 * 1024
-	params, err := opts.DeriveCostParams(0, &kdf)
+	params, err := opts.DeriveCostParams(0)
 	c.Assert(err, IsNil)
 
 	s.checkParams(c, &opts, s.cpus, params)
 }
 
 func (s *argon2Suite) TestDeriveCostParamsForceBenchmarkedThreads(c *C) {
-	var kdf testutil.MockKDF
-
-	var opts KDFOptions
+	var opts Argon2Options
 	opts.Parallel = 1
-	params, err := opts.DeriveCostParams(0, &kdf)
+	params, err := opts.DeriveCostParams(0)
 	c.Assert(err, IsNil)
 
 	s.checkParams(c, &opts, s.cpus, params)
@@ -129,11 +141,9 @@ func (s *argon2Suite) TestDeriveCostParamsForceIterations(c *C) {
 	restore := MockRuntimeNumCPU(2)
 	defer restore()
 
-	var kdf testutil.MockKDF
-
-	var opts KDFOptions
+	var opts Argon2Options
 	opts.ForceIterations = 3
-	params, err := opts.DeriveCostParams(0, &kdf)
+	params, err := opts.DeriveCostParams(0)
 	c.Assert(err, IsNil)
 
 	s.checkParams(c, &opts, 2, params)
@@ -143,12 +153,10 @@ func (s *argon2Suite) TestDeriveCostParamsForceMemory(c *C) {
 	restore := MockRuntimeNumCPU(2)
 	defer restore()
 
-	var kdf testutil.MockKDF
-
-	var opts KDFOptions
+	var opts Argon2Options
 	opts.ForceIterations = 3
 	opts.MemoryKiB = 32 * 1024
-	params, err := opts.DeriveCostParams(0, &kdf)
+	params, err := opts.DeriveCostParams(0)
 	c.Assert(err, IsNil)
 
 	s.checkParams(c, &opts, 2, params)
@@ -158,11 +166,9 @@ func (s *argon2Suite) TestDeriveCostParamsForceIterationsDifferentCPUNum(c *C) {
 	restore := MockRuntimeNumCPU(8)
 	defer restore()
 
-	var kdf testutil.MockKDF
-
-	var opts KDFOptions
+	var opts Argon2Options
 	opts.ForceIterations = 3
-	params, err := opts.DeriveCostParams(0, &kdf)
+	params, err := opts.DeriveCostParams(0)
 	c.Assert(err, IsNil)
 
 	s.checkParams(c, &opts, 4, params)
@@ -172,12 +178,10 @@ func (s *argon2Suite) TestDeriveCostParamsForceThreads(c *C) {
 	restore := MockRuntimeNumCPU(8)
 	defer restore()
 
-	var kdf testutil.MockKDF
-
-	var opts KDFOptions
+	var opts Argon2Options
 	opts.ForceIterations = 3
 	opts.Parallel = 1
-	params, err := opts.DeriveCostParams(0, &kdf)
+	params, err := opts.DeriveCostParams(0)
 	c.Assert(err, IsNil)
 
 	s.checkParams(c, &opts, 1, params)
@@ -196,32 +200,19 @@ var _ = Suite(&argon2SuiteExpensive{})
 type testArgon2iKDFDeriveData struct {
 	passphrase string
 	salt       []byte
-	params     *KDFCostParams
+	params     *Argon2CostParams
 	keyLen     uint32
 }
 
 func (s *argon2SuiteExpensive) testArgon2iKDFDerive(c *C, data *testArgon2iKDFDeriveData) {
-	kdf := Argon2iKDF()
-	c.Assert(kdf, NotNil)
-
-	params := &KDFCostParams{
-		Time:      data.params.Time,
-		MemoryKiB: data.params.MemoryKiB,
-		Threads:   data.params.Threads}
-
-	cpus := runtime.NumCPU()
-	if int(params.Threads) > cpus {
-		params.Threads = uint8(cpus)
-	}
-
-	key, err := kdf.Derive(data.passphrase, data.salt, params, data.keyLen)
+	key, err := InProcessArgon2KDF.Derive(data.passphrase, data.salt, data.params, data.keyLen)
 	c.Check(err, IsNil)
 	runtime.GC()
 
 	expected := argon2.Key(data.passphrase, data.salt, &argon2.CostParams{
-		Time:      params.Time,
-		MemoryKiB: params.MemoryKiB,
-		Threads:   params.Threads}, data.keyLen)
+		Time:      data.params.Time,
+		MemoryKiB: data.params.MemoryKiB,
+		Threads:   data.params.Threads}, data.keyLen)
 	runtime.GC()
 
 	c.Check(key, DeepEquals, expected)
@@ -231,7 +222,7 @@ func (s *argon2SuiteExpensive) TestArgon2iKDFDerive(c *C) {
 	s.testArgon2iKDFDerive(c, &testArgon2iKDFDeriveData{
 		passphrase: "foo",
 		salt:       []byte("0123456789abcdefghijklmnopqrstuv"),
-		params: &KDFCostParams{
+		params: &Argon2CostParams{
 			Time:      4,
 			MemoryKiB: 32,
 			Threads:   4},
@@ -242,7 +233,7 @@ func (s *argon2SuiteExpensive) TestArgon2iKDFDeriveDifferentPassphrase(c *C) {
 	s.testArgon2iKDFDerive(c, &testArgon2iKDFDeriveData{
 		passphrase: "bar",
 		salt:       []byte("0123456789abcdefghijklmnopqrstuv"),
-		params: &KDFCostParams{
+		params: &Argon2CostParams{
 			Time:      4,
 			MemoryKiB: 32,
 			Threads:   4},
@@ -253,7 +244,7 @@ func (s *argon2SuiteExpensive) TestArgon2iKDFiDeriveDifferentSalt(c *C) {
 	s.testArgon2iKDFDerive(c, &testArgon2iKDFDeriveData{
 		passphrase: "foo",
 		salt:       []byte("zyxwvutsrqponmlkjihgfedcba987654"),
-		params: &KDFCostParams{
+		params: &Argon2CostParams{
 			Time:      4,
 			MemoryKiB: 32,
 			Threads:   4},
@@ -264,7 +255,7 @@ func (s *argon2SuiteExpensive) TestArgon2iKDFDeriveDifferentParams(c *C) {
 	s.testArgon2iKDFDerive(c, &testArgon2iKDFDeriveData{
 		passphrase: "foo",
 		salt:       []byte("0123456789abcdefghijklmnopqrstuv"),
-		params: &KDFCostParams{
+		params: &Argon2CostParams{
 			Time:      48,
 			MemoryKiB: 32 * 1024,
 			Threads:   4},
@@ -275,7 +266,7 @@ func (s *argon2SuiteExpensive) TestArgon2iKDFDeriveDifferentKeyLen(c *C) {
 	s.testArgon2iKDFDerive(c, &testArgon2iKDFDeriveData{
 		passphrase: "foo",
 		salt:       []byte("0123456789abcdefghijklmnopqrstuv"),
-		params: &KDFCostParams{
+		params: &Argon2CostParams{
 			Time:      4,
 			MemoryKiB: 32,
 			Threads:   4},
@@ -283,28 +274,25 @@ func (s *argon2SuiteExpensive) TestArgon2iKDFDeriveDifferentKeyLen(c *C) {
 }
 
 func (s *argon2SuiteExpensive) TestArgon2iKDFTime(c *C) {
-	kdf := Argon2iKDF()
-	c.Assert(kdf, NotNil)
-
-	time1, err := kdf.Time(&KDFCostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 4})
+	time1, err := InProcessArgon2KDF.Time(&Argon2CostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 4})
 	runtime.GC()
 	c.Check(err, IsNil)
 
-	time2, err := kdf.Time(&KDFCostParams{Time: 16, MemoryKiB: 32 * 1024, Threads: 4})
+	time2, err := InProcessArgon2KDF.Time(&Argon2CostParams{Time: 16, MemoryKiB: 32 * 1024, Threads: 4})
 	runtime.GC()
 	c.Check(err, IsNil)
 	// XXX: this needs a checker like go-tpm2/testutil's IntGreater, which copes with
 	// types of int64 kind
 	c.Check(time2 > time1, testutil.IsTrue)
 
-	time2, err = kdf.Time(&KDFCostParams{Time: 4, MemoryKiB: 128 * 1024, Threads: 4})
+	time2, err = InProcessArgon2KDF.Time(&Argon2CostParams{Time: 4, MemoryKiB: 128 * 1024, Threads: 4})
 	runtime.GC()
 	c.Check(err, IsNil)
 	// XXX: this needs a checker like go-tpm2/testutil's IntGreater, which copes with
 	// types of int64 kind
 	c.Check(time2 > time1, testutil.IsTrue)
 
-	time2, err = kdf.Time(&KDFCostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 1})
+	time2, err = InProcessArgon2KDF.Time(&Argon2CostParams{Time: 4, MemoryKiB: 32 * 1024, Threads: 1})
 	runtime.GC()
 	c.Check(err, IsNil)
 	// XXX: this needs a checker like go-tpm2/testutil's IntGreater, which copes with

--- a/export_test.go
+++ b/export_test.go
@@ -33,8 +33,8 @@ var (
 
 type ProtectedKeys = protectedKeys
 
-func (o *KDFOptions) DeriveCostParams(keyLen int, kdf KDF) (*KDFCostParams, error) {
-	return o.deriveCostParams(keyLen, kdf)
+func (o *Argon2Options) DeriveCostParams(keyLen int) (*Argon2CostParams, error) {
+	return o.deriveCostParams(keyLen)
 }
 
 func MockLUKS2Activate(fn func(string, string, []byte, int) error) (restore func()) {
@@ -145,6 +145,6 @@ func MockHashAlgAvailable() (restore func()) {
 	}
 }
 
-func (d *KeyData) DerivePassphraseKeys(passphrase string, kdf KDF) (key, iv, auth []byte, err error) {
-	return d.derivePassphraseKeys(passphrase, kdf)
+func (d *KeyData) DerivePassphraseKeys(passphrase string) (key, iv, auth []byte, err error) {
+	return d.derivePassphraseKeys(passphrase)
 }

--- a/internal/argon2/argon2.go
+++ b/internal/argon2/argon2.go
@@ -275,8 +275,8 @@ func (c *benchmarkContext) run(params *BenchmarkParams, keyFn KeyDurationFunc, s
 // KeyDuration runs the key derivation with the built-in benchmarking values for the
 // supplied set of cost parameters, and then returns the amount of time taken to execute.
 //
-// By design, this function consumes a lot of memory depending on the supplied
-// parameters. It may be desirable to execute it in a short-lived utility process.
+// By design, this function consumes a lot of memory depending on the supplied parameters.
+// It may be desirable to execute it in a short-lived utility process.
 func KeyDuration(params *CostParams) time.Duration {
 	start := time.Now()
 	Key(benchmarkPassword, benchmarkSalt, params, benchmarkKeyLen)

--- a/internal/testutil/argon2.go
+++ b/internal/testutil/argon2.go
@@ -30,15 +30,14 @@ import (
 	"github.com/snapcore/secboot"
 )
 
-// MockKDF provides a mock implementation of secboot.KDF that isn't
+// MockArgon2KDF provides a mock implementation of secboot.Argon2KDF that isn't
 // memory intensive.
-type MockKDF struct {
-}
+type MockArgon2KDF struct{}
 
 // Derive implements secboot.KDF.Derive and derives a key from the supplied
 // passphrase and parameters. This is only intended for testing and is not
 // meant to be secure in any way.
-func (_ *MockKDF) Derive(passphrase string, salt []byte, params *secboot.KDFCostParams, keyLen uint32) ([]byte, error) {
+func (_ *MockArgon2KDF) Derive(passphrase string, salt []byte, params *secboot.Argon2CostParams, keyLen uint32) ([]byte, error) {
 	context := make([]byte, len(salt)+9)
 	copy(context, salt)
 	binary.LittleEndian.PutUint32(context[len(salt):], params.Time)
@@ -50,7 +49,7 @@ func (_ *MockKDF) Derive(passphrase string, salt []byte, params *secboot.KDFCost
 
 // Time implements secboot.KDF.Time and returns a time that is linearly
 // related to the specified cost parameters, suitable for mocking benchmarking.
-func (_ *MockKDF) Time(params *secboot.KDFCostParams) (time.Duration, error) {
+func (_ *MockArgon2KDF) Time(params *secboot.Argon2CostParams) (time.Duration, error) {
 	const memBandwidthKiBPerMs = 2048
 	duration := (time.Duration(float64(params.MemoryKiB)/float64(memBandwidthKiBPerMs)) * time.Duration(params.Time)) * time.Millisecond
 	return duration, nil

--- a/keydata_legacy_test.go
+++ b/keydata_legacy_test.go
@@ -204,7 +204,7 @@ func (s *keyDataLegacySuite) TestRecoverKeysWithPassphraseAuthModeNone(c *C) {
 
 	keyData, err := NewKeyData(protected)
 	c.Assert(err, IsNil)
-	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeysWithPassphrase("", nil)
+	recoveredKey, recoveredAuxKey, err := keyData.RecoverKeysWithPassphrase("")
 	c.Check(err, ErrorMatches, "cannot recover key with passphrase")
 	c.Check(recoveredKey, IsNil)
 	c.Check(recoveredAuxKey, IsNil)

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -216,7 +216,7 @@ func MockSecbootNewKeyData(fn func(*secboot.KeyParams) (*secboot.KeyData, error)
 	}
 }
 
-func MockSecbootNewKeyDataWithPassphrase(fn func(*secboot.KeyWithPassphraseParams, string, secboot.KDF) (*secboot.KeyData, error)) (restore func()) {
+func MockSecbootNewKeyDataWithPassphrase(fn func(*secboot.KeyWithPassphraseParams, string) (*secboot.KeyData, error)) (restore func()) {
 	orig := secbootNewKeyDataWithPassphrase
 	secbootNewKeyDataWithPassphrase = fn
 	return func() {


### PR DESCRIPTION
This renames the existing KDFOptions, KDFCostParams and KDF types to
Argon2Options, Argon2CostParams and Argon2KDF in preparation for
the introduction of PBKDF2 support for passphrases in another PR, which
will use a new options implementation. Both options implementations will
implement a new interface (KDFOptions).

As PBKDF2 won't be abstracted like Argon2 is because it doesn't use lots
of memory, also remove the kdf argument from functions that take them.
Instead, have a process wide Argon2KDF implementation, set by calling
SetArgon2KDF.