### PR TITLE
internal/argon2: return errors

### DIFF
--- a/argon2.go
+++ b/argon2.go
@@ -207,6 +207,9 @@ type Argon2CostParams struct {
 }
 
 func (p *Argon2CostParams) internalParams() *argon2.CostParams {
+	if p == nil {
+		return nil
+	}
 	return &argon2.CostParams{
 		Time:      p.Time,
 		MemoryKiB: p.MemoryKiB,
@@ -228,33 +231,19 @@ type Argon2KDF interface {
 type inProcessArgon2KDFImpl struct{}
 
 func (_ inProcessArgon2KDFImpl) Derive(passphrase string, salt []byte, mode Argon2Mode, params *Argon2CostParams, keyLen uint32) ([]byte, error) {
-	switch {
-	case mode != Argon2i && mode != Argon2id:
+	if mode != Argon2i && mode != Argon2id {
 		return nil, errors.New("invalid mode")
-	case params == nil:
-		return nil, errors.New("nil params")
-	case params.Time == 0:
-		return nil, errors.New("invalid time cost")
-	case params.Threads == 0:
-		return nil, errors.New("invalid number of threads")
 	}
 
-	return argon2.Key(passphrase, salt, argon2.Mode(mode), params.internalParams(), keyLen), nil
+	return argon2.Key(passphrase, salt, argon2.Mode(mode), params.internalParams(), keyLen)
 }
 
 func (_ inProcessArgon2KDFImpl) Time(mode Argon2Mode, params *Argon2CostParams) (time.Duration, error) {
-	switch {
-	case mode != Argon2i && mode != Argon2id:
+	if mode != Argon2i && mode != Argon2id {
 		return 0, errors.New("invalid mode")
-	case params == nil:
-		return 0, errors.New("nil params")
-	case params.Time == 0:
-		return 0, errors.New("invalid time cost")
-	case params.Threads == 0:
-		return 0, errors.New("invalid number of threads")
 	}
 
-	return argon2.KeyDuration(argon2.Mode(mode), params.internalParams()), nil
+	return argon2.KeyDuration(argon2.Mode(mode), params.internalParams())
 }
 
 // InProcessArgon2KDF is the in-process implementation of the Argon2 KDF. This

--- a/argon2_test.go
+++ b/argon2_test.go
@@ -277,6 +277,11 @@ func (s *argon2Suite) TestInProcessKDFTimeInvalidThreads(c *C) {
 	c.Check(err, ErrorMatches, `invalid number of threads`)
 }
 
+func (s *argon2Suite) TestModeConstants(c *C) {
+	c.Check(Argon2i, Equals, Argon2Mode(argon2.ModeI))
+	c.Check(Argon2id, Equals, Argon2Mode(argon2.ModeID))
+}
+
 type argon2SuiteExpensive struct{}
 
 func (s *argon2SuiteExpensive) SetUpSuite(c *C) {
@@ -300,10 +305,11 @@ func (s *argon2SuiteExpensive) testInProcessKDFDerive(c *C, data *testInProcessA
 	c.Check(err, IsNil)
 	runtime.GC()
 
-	expected := argon2.Key(data.passphrase, data.salt, argon2.Mode(data.mode), &argon2.CostParams{
+	expected, err := argon2.Key(data.passphrase, data.salt, argon2.Mode(data.mode), &argon2.CostParams{
 		Time:      data.params.Time,
 		MemoryKiB: data.params.MemoryKiB,
 		Threads:   data.params.Threads}, data.keyLen)
+	c.Check(err, IsNil)
 	runtime.GC()
 
 	c.Check(key, DeepEquals, expected)


### PR DESCRIPTION
We're currently wrapping x/crypto/argon2 which panics on some invalid
arguments. Instead, move the checking of these arguments in order to
avoid some panics.