### PR TITLE
preinstall: Add checks for virtualization mode

### DIFF
--- a/efi/preinstall/check_virt.go
+++ b/efi/preinstall/check_virt.go
@@ -39,7 +39,7 @@ func detectVirtualization(env internal_efi.HostEnvironment) (detectVirtResult, e
 	// First check for any virtualization
 	virt, err := env.DetectVirtMode(internal_efi.DetectVirtModeAll)
 	if err != nil {
-		return 0, fmt.Errorf("cannot detect if environment if virtualized: %w", err)
+		return 0, fmt.Errorf("cannot detect if environment is virtualized: %w", err)
 	}
 	if virt == internal_efi.VirtModeNone {
 		// we're not in a containerized or virtualized environment

--- a/efi/preinstall/check_virt.go
+++ b/efi/preinstall/check_virt.go
@@ -64,7 +64,7 @@ func detectVirtualization(env internal_efi.HostEnvironment) (detectVirtResult, e
 		return 0, fmt.Errorf("cannot detect if environment is a VM: %w", err)
 	}
 	if vmVirt != virt {
-		return 0, fmt.Errorf("unexpected return value from HostEnvironment.DetectVirtMode(DetectVirtModeVM) (got:%q, expected:%q)", vmVirt, virt)
+		return 0, fmt.Errorf("inconsistent return value from HostEnvironment.DetectVirtMode(DetectVirtModeVM) (got:%q, expected:%q)", vmVirt, virt)
 	}
 
 	return detectVirtVM, nil

--- a/efi/preinstall/check_virt.go
+++ b/efi/preinstall/check_virt.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"errors"
+	"fmt"
+
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+type detectVirtResult int
+
+const (
+	detectVirtNone detectVirtResult = iota
+	detectVirtVM
+)
+
+// detectVirtualization detects if the supplied environment is virtualized,
+// returning the type of virtualization - container or VM.
+func detectVirtualization(env internal_efi.HostEnvironment) (detectVirtResult, error) {
+	// First check for any virtualization
+	virt, err := env.DetectVirtMode(internal_efi.DetectVirtModeAll)
+	if err != nil {
+		return 0, fmt.Errorf("cannot detect if environment if virtualized: %w", err)
+	}
+	if virt == internal_efi.VirtModeNone {
+		// we're not in a containerized or virtualized environment
+		return detectVirtNone, nil
+	}
+
+	// We're in a containerized or virtualized environment. Test for container
+	// first.
+	containerVirt, err := env.DetectVirtMode(internal_efi.DetectVirtModeContainer)
+	if err != nil {
+		return 0, fmt.Errorf("cannot detect if environment is a container: %w", err)
+	}
+	if containerVirt != internal_efi.VirtModeNone {
+		// We're in a containerized environment, which is never supported
+		return 0, errors.New("container environments are not supported")
+	}
+
+	// We're in a virtualized (VM) environment. We expect the following call to return
+	// the same value as our original call here.
+	vmVirt, err := env.DetectVirtMode(internal_efi.DetectVirtModeVM)
+	if err != nil {
+		return 0, fmt.Errorf("cannot detect if environment is a VM: %w", err)
+	}
+	if vmVirt != virt {
+		return 0, fmt.Errorf("unexpected return value from HostEnvironment.DetectVirtMode(DetectVirtModeVM) (got:%q, expected:%q)", vmVirt, virt)
+	}
+
+	return detectVirtVM, nil
+}

--- a/efi/preinstall/check_virt_test.go
+++ b/efi/preinstall/check_virt_test.go
@@ -56,7 +56,7 @@ func (s *virtSuite) TestDetectVirtualizationVM(c *C) {
 func (s *virtSuite) TestDetectVirtualizationDetectVirtModeErr1(c *C) {
 	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithVirtModeError(errors.New("some error")))
 	_, err := DetectVirtualization(env)
-	c.Check(err, ErrorMatches, `cannot detect if environment if virtualized: some error`)
+	c.Check(err, ErrorMatches, `cannot detect if environment is virtualized: some error`)
 }
 
 func (s *virtSuite) TestDetectVirtualizationDetectVirtModeErr2(c *C) {

--- a/efi/preinstall/check_virt_test.go
+++ b/efi/preinstall/check_virt_test.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/secboot/efi/preinstall"
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+	"github.com/snapcore/secboot/internal/efitest"
+)
+
+type virtSuite struct{}
+
+var _ = Suite(&virtSuite{})
+
+func (s *virtSuite) TestDetectVirtualizationNone(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll))
+	mode, err := DetectVirtualization(env)
+	c.Check(err, IsNil)
+	c.Check(mode, Equals, DetectVirtNone)
+}
+
+func (s *virtSuite) TestDetectVirtualizationContainer(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithVirtMode("lxc", internal_efi.DetectVirtModeContainer))
+	_, err := DetectVirtualization(env)
+	c.Check(err, ErrorMatches, `container environments are not supported`)
+}
+
+func (s *virtSuite) TestDetectVirtualizationVM(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithVirtMode("qemu", internal_efi.DetectVirtModeVM))
+	mode, err := DetectVirtualization(env)
+	c.Check(err, IsNil)
+	c.Check(mode, Equals, DetectVirtVM)
+}
+
+func (s *virtSuite) TestDetectVirtualizationDetectVirtModeErr1(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithVirtModeError(errors.New("some error")))
+	_, err := DetectVirtualization(env)
+	c.Check(err, ErrorMatches, `cannot detect if environment if virtualized: some error`)
+}
+
+func (s *virtSuite) TestDetectVirtualizationDetectVirtModeErr2(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithDelayedVirtMode("lxc", internal_efi.DetectVirtModeContainer),
+		efitest.WithDelayedVirtModeError(errors.New("some error")),
+	)
+	_, err := DetectVirtualization(env)
+	c.Check(err, ErrorMatches, `cannot detect if environment is a container: some error`)
+}
+
+func (s *virtSuite) TestDetectVirtualizationDetectVirtModeErr3(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithDelayedVirtMode("qemu", internal_efi.DetectVirtModeVM),
+		efitest.WithDelayedVirtMode("qemu", internal_efi.DetectVirtModeVM),
+		efitest.WithDelayedVirtModeError(errors.New("some error")),
+	)
+	_, err := DetectVirtualization(env)
+	c.Check(err, ErrorMatches, `cannot detect if environment is a VM: some error`)
+}
+
+func (s *virtSuite) TestDetectVirtualizationDetectVirtModeErr4(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts(
+		efitest.WithDelayedVirtMode("qemu", internal_efi.DetectVirtModeVM),
+		efitest.WithDelayedVirtMode("qemu", internal_efi.DetectVirtModeVM),
+		efitest.WithDelayedVirtMode("kvm", internal_efi.DetectVirtModeVM),
+	)
+	_, err := DetectVirtualization(env)
+	c.Check(err, ErrorMatches, `unexpected return value from HostEnvironment.DetectVirtMode\(DetectVirtModeVM\) \(got:\"kvm\", expected:\"qemu\"\)`)
+}

--- a/efi/preinstall/check_virt_test.go
+++ b/efi/preinstall/check_virt_test.go
@@ -85,5 +85,5 @@ func (s *virtSuite) TestDetectVirtualizationDetectVirtModeErr4(c *C) {
 		efitest.WithDelayedVirtMode("kvm", internal_efi.DetectVirtModeVM),
 	)
 	_, err := DetectVirtualization(env)
-	c.Check(err, ErrorMatches, `unexpected return value from HostEnvironment.DetectVirtMode\(DetectVirtModeVM\) \(got:\"kvm\", expected:\"qemu\"\)`)
+	c.Check(err, ErrorMatches, `inconsistent return value from HostEnvironment.DetectVirtMode\(DetectVirtModeVM\) \(got:\"kvm\", expected:\"qemu\"\)`)
 }

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+type (
+	DetectVirtResult = detectVirtResult
+)
+
+const (
+	DetectVirtNone = detectVirtNone
+	DetectVirtVM   = detectVirtVM
+)
+
+var (
+	DetectVirtualization = detectVirtualization
+)

--- a/efi/preinstall/preinstall_test.go
+++ b/efi/preinstall/preinstall_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
If a container environment is detected, this always return an error.
Detecting a VM returns a value which will be interpreted by the caller
(`RunChecks`) and will also return an error unless a flag is specified
by snapd to suppress this, in which case the subsequent firmware
protection tests will be skipped because these don't make sense in
virtualized environments.