### PR TITLE
plainkey: rename platform key to protector key

### DIFF
--- a/plainkey/export_test.go
+++ b/plainkey/export_test.go
@@ -30,7 +30,7 @@ type (
 	HashAlg                = hashAlg
 	KeyData                = keyData
 	PlatformKeyDataHandler = platformKeyDataHandler
-	PlatformKeyId          = platformKeyId
+	ProtectorKeyId         = protectorKeyId
 )
 
 var (

--- a/plainkey/keydata_test.go
+++ b/plainkey/keydata_test.go
@@ -39,18 +39,18 @@ type keydataSuite struct{}
 var _ = Suite(&keydataSuite{})
 
 type testNewProtectedKeyParams struct {
-	rand        []byte
-	platformKey []byte
-	primaryKey  secboot.PrimaryKey
+	rand         []byte
+	protectorKey []byte
+	primaryKey   secboot.PrimaryKey
 
-	expectedPrimaryKey        secboot.PrimaryKey
-	expectedUnlockKey         secboot.DiskUnlockKey
-	expectedSalt              []byte
-	expectedNonce             []byte
-	expectedPlatformKeyIdSalt []byte
-	expectedPlatformKeyId     []byte
-	expectedCiphertext        []byte
-	expectedPlaintext         []byte
+	expectedPrimaryKey         secboot.PrimaryKey
+	expectedUnlockKey          secboot.DiskUnlockKey
+	expectedSalt               []byte
+	expectedNonce              []byte
+	expectedProtectorKeyIdSalt []byte
+	expectedProtectorKeyId     []byte
+	expectedCiphertext         []byte
+	expectedPlaintext          []byte
 }
 
 func (s *keydataSuite) testNewProtectedKey(c *C, params *testNewProtectedKeyParams) {
@@ -66,9 +66,9 @@ func (s *keydataSuite) testNewProtectedKey(c *C, params *testNewProtectedKeyPara
 		c.Check(kd.Version, Equals, 1)
 		c.Check(kd.Salt, DeepEquals, params.expectedSalt)
 		c.Assert(kd.Nonce, DeepEquals, params.expectedNonce)
-		c.Check(crypto.Hash(kd.PlatformKeyID.Alg), Equals, crypto.SHA256)
-		c.Check(kd.PlatformKeyID.Salt, DeepEquals, params.expectedPlatformKeyIdSalt)
-		c.Check(kd.PlatformKeyID.Digest, DeepEquals, params.expectedPlatformKeyId)
+		c.Check(crypto.Hash(kd.ProtectorKeyID.Alg), Equals, crypto.SHA256)
+		c.Check(kd.ProtectorKeyID.Salt, DeepEquals, params.expectedProtectorKeyIdSalt)
+		c.Check(kd.ProtectorKeyID.Digest, DeepEquals, params.expectedProtectorKeyId)
 
 		c.Check(keyParams.EncryptedPayload, DeepEquals, params.expectedCiphertext)
 		c.Check(keyParams.PlatformName, Equals, PlatformName)
@@ -78,7 +78,7 @@ func (s *keydataSuite) testNewProtectedKey(c *C, params *testNewProtectedKeyPara
 		expectedHandle, err = json.Marshal(kd)
 		c.Assert(err, IsNil)
 
-		b, err := aes.NewCipher(DeriveAESKey(params.platformKey, kd.Salt))
+		b, err := aes.NewCipher(DeriveAESKey(params.protectorKey, kd.Salt))
 		c.Assert(err, IsNil)
 
 		aead, err := cipher.NewGCM(b)
@@ -103,7 +103,7 @@ func (s *keydataSuite) testNewProtectedKey(c *C, params *testNewProtectedKeyPara
 	})
 	defer restore()
 
-	kd, primaryKey, unlockKey, err := NewProtectedKey(bytes.NewReader(params.rand), params.platformKey, params.primaryKey)
+	kd, primaryKey, unlockKey, err := NewProtectedKey(bytes.NewReader(params.rand), params.protectorKey, params.primaryKey)
 	c.Assert(err, IsNil)
 	c.Check(primaryKey, DeepEquals, params.expectedPrimaryKey)
 	c.Check(unlockKey, DeepEquals, params.expectedUnlockKey)
@@ -115,80 +115,80 @@ func (s *keydataSuite) testNewProtectedKey(c *C, params *testNewProtectedKeyPara
 
 func (s *keydataSuite) TestNewProtectedKey(c *C) {
 	s.testNewProtectedKey(c, &testNewProtectedKeyParams{
-		rand:                      testutil.DecodeHexString(c, "179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		platformKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
-		primaryKey:                testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
-		expectedPrimaryKey:        testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
-		expectedUnlockKey:         testutil.DecodeHexString(c, "f1cffa65c76b15ac7e21dfd0894f21c5ce8986103bfb4916c4ff435513865980"),
-		expectedSalt:              testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
-		expectedNonce:             testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		expectedPlatformKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		expectedPlatformKeyId:     testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
-		expectedCiphertext:        testutil.DecodeHexString(c, "d3ee9e1c228a7436f33377239701059b801dd5167dde322e557edda7a42405f345d534e9728c9158c854a0eb8b11399bcd36a299a40e5258c230f61d5e0b948138fe54718b238f4f6063b782ac2b613a58fc1fdc6d49"),
-		expectedPlaintext:         testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
+		rand:                       testutil.DecodeHexString(c, "179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		protectorKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
+		primaryKey:                 testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
+		expectedPrimaryKey:         testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
+		expectedUnlockKey:          testutil.DecodeHexString(c, "f1cffa65c76b15ac7e21dfd0894f21c5ce8986103bfb4916c4ff435513865980"),
+		expectedSalt:               testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
+		expectedNonce:              testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
+		expectedProtectorKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		expectedProtectorKeyId:     testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
+		expectedCiphertext:         testutil.DecodeHexString(c, "d3ee9e1c228a7436f33377239701059b801dd5167dde322e557edda7a42405f345d534e9728c9158c854a0eb8b11399bcd36a299a40e5258c230f61d5e0b948138fe54718b238f4f6063b782ac2b613a58fc1fdc6d49"),
+		expectedPlaintext:          testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
 	})
 }
 
 func (s *keydataSuite) TestNewProtectedKeyDifferentRand(c *C) {
 	s.testNewProtectedKey(c, &testNewProtectedKeyParams{
-		rand:                      testutil.DecodeHexString(c, "c4f8f04115eb2320f2bba3777240234b535d666b64c0ab10fe32e9b44e07c436dab12d7fa9c4dfb05bcc70bbd3d56ff87d5658c2f42e9e94e6273173a9d0931689b9b05919c41170f32cb00132b030249e7b9c614d160be5985a031654c9bba87842c40e8d1b7f8adf0b277e"),
-		platformKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
-		primaryKey:                testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
-		expectedPrimaryKey:        testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
-		expectedUnlockKey:         testutil.DecodeHexString(c, "0187af22705f098123812aa31032ce003f24bd69649d260153604fb7c0293925"),
-		expectedSalt:              testutil.DecodeHexString(c, "dab12d7fa9c4dfb05bcc70bbd3d56ff87d5658c2f42e9e94e6273173a9d09316"),
-		expectedNonce:             testutil.DecodeHexString(c, "89b9b05919c41170f32cb001"),
-		expectedPlatformKeyIdSalt: testutil.DecodeHexString(c, "32b030249e7b9c614d160be5985a031654c9bba87842c40e8d1b7f8adf0b277e"),
-		expectedPlatformKeyId:     testutil.DecodeHexString(c, "777cae054f1c5103149f5e30152fad0b197b3f0bb4b801327307aca50a02acff"),
-		expectedCiphertext:        testutil.DecodeHexString(c, "b268bb69cafa29a490511819e12f0da25454bf724a76fc9a17b6f72019353371d6c8c13c26251e9e3169936146aa725da7000f39cebdc873adbb6bc6d02c64a6069e71b0c3116657ff8498164a7ab5e6488f552ccc88"),
-		expectedPlaintext:         testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420c4f8f04115eb2320f2bba3777240234b535d666b64c0ab10fe32e9b44e07c436"),
+		rand:                       testutil.DecodeHexString(c, "c4f8f04115eb2320f2bba3777240234b535d666b64c0ab10fe32e9b44e07c436dab12d7fa9c4dfb05bcc70bbd3d56ff87d5658c2f42e9e94e6273173a9d0931689b9b05919c41170f32cb00132b030249e7b9c614d160be5985a031654c9bba87842c40e8d1b7f8adf0b277e"),
+		protectorKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
+		primaryKey:                 testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
+		expectedPrimaryKey:         testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
+		expectedUnlockKey:          testutil.DecodeHexString(c, "0187af22705f098123812aa31032ce003f24bd69649d260153604fb7c0293925"),
+		expectedSalt:               testutil.DecodeHexString(c, "dab12d7fa9c4dfb05bcc70bbd3d56ff87d5658c2f42e9e94e6273173a9d09316"),
+		expectedNonce:              testutil.DecodeHexString(c, "89b9b05919c41170f32cb001"),
+		expectedProtectorKeyIdSalt: testutil.DecodeHexString(c, "32b030249e7b9c614d160be5985a031654c9bba87842c40e8d1b7f8adf0b277e"),
+		expectedProtectorKeyId:     testutil.DecodeHexString(c, "777cae054f1c5103149f5e30152fad0b197b3f0bb4b801327307aca50a02acff"),
+		expectedCiphertext:         testutil.DecodeHexString(c, "b268bb69cafa29a490511819e12f0da25454bf724a76fc9a17b6f72019353371d6c8c13c26251e9e3169936146aa725da7000f39cebdc873adbb6bc6d02c64a6069e71b0c3116657ff8498164a7ab5e6488f552ccc88"),
+		expectedPlaintext:          testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420c4f8f04115eb2320f2bba3777240234b535d666b64c0ab10fe32e9b44e07c436"),
 	})
 }
 
-func (s *keydataSuite) TestNewProtectedKeyDifferentPlatformKey(c *C) {
+func (s *keydataSuite) TestNewProtectedKeyDifferentProtectorKey(c *C) {
 	s.testNewProtectedKey(c, &testNewProtectedKeyParams{
-		rand:                      testutil.DecodeHexString(c, "179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		platformKey:               testutil.DecodeHexString(c, "1d3ae75ec26e284ab2f032256202d653025f2a1969d956a7c3b582aa368db198"),
-		primaryKey:                testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
-		expectedPrimaryKey:        testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
-		expectedUnlockKey:         testutil.DecodeHexString(c, "f1cffa65c76b15ac7e21dfd0894f21c5ce8986103bfb4916c4ff435513865980"),
-		expectedSalt:              testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
-		expectedNonce:             testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		expectedPlatformKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		expectedPlatformKeyId:     testutil.DecodeHexString(c, "a7d200c3951659d5132db221a376cfd937d65e6e991e651b62fbed48855efeaf"),
-		expectedCiphertext:        testutil.DecodeHexString(c, "ad5f76499f91a47a04b1a1e26625cb4e18f6ac38e888b0a2882853d23bfdd6a3d8f1feecf0956cf3667817009c2c3023331e2601dc94f5aad80a1996dcc691b3f9b430ddc7a5cad10566ee530311a3bf267bff9a81b8"),
-		expectedPlaintext:         testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
+		rand:                       testutil.DecodeHexString(c, "179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		protectorKey:               testutil.DecodeHexString(c, "1d3ae75ec26e284ab2f032256202d653025f2a1969d956a7c3b582aa368db198"),
+		primaryKey:                 testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
+		expectedPrimaryKey:         testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
+		expectedUnlockKey:          testutil.DecodeHexString(c, "f1cffa65c76b15ac7e21dfd0894f21c5ce8986103bfb4916c4ff435513865980"),
+		expectedSalt:               testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
+		expectedNonce:              testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
+		expectedProtectorKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		expectedProtectorKeyId:     testutil.DecodeHexString(c, "a7d200c3951659d5132db221a376cfd937d65e6e991e651b62fbed48855efeaf"),
+		expectedCiphertext:         testutil.DecodeHexString(c, "ad5f76499f91a47a04b1a1e26625cb4e18f6ac38e888b0a2882853d23bfdd6a3d8f1feecf0956cf3667817009c2c3023331e2601dc94f5aad80a1996dcc691b3f9b430ddc7a5cad10566ee530311a3bf267bff9a81b8"),
+		expectedPlaintext:          testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
 	})
 }
 
 func (s *keydataSuite) TestNewProtectedKeyDifferentPrimaryKey(c *C) {
 	s.testNewProtectedKey(c, &testNewProtectedKeyParams{
-		rand:                      testutil.DecodeHexString(c, "179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		platformKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
-		primaryKey:                testutil.DecodeHexString(c, "6e5eb7de5a75ec77bbec2f0927f6503bc7d0e2a6ebcb971d7dbe7a77e0d924a7"),
-		expectedPrimaryKey:        testutil.DecodeHexString(c, "6e5eb7de5a75ec77bbec2f0927f6503bc7d0e2a6ebcb971d7dbe7a77e0d924a7"),
-		expectedUnlockKey:         testutil.DecodeHexString(c, "0685e55582e4465ba2336e95304166eaa839d1a645dec1c0629a63f9748fb182"),
-		expectedSalt:              testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
-		expectedNonce:             testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		expectedPlatformKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		expectedPlatformKeyId:     testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
-		expectedCiphertext:        testutil.DecodeHexString(c, "d3ee9e1c3cab20fc4def991994b1f7ea6582b7eae091c2ed1e40508b38e7cdeca313b33d728c9158c854a0eb8b11399bcd36a299a40e5258c230f61d5e0b948138fe54718b23778d5679118961498d551cacecf81ee9"),
-		expectedPlaintext:         testutil.DecodeHexString(c, "304404206e5eb7de5a75ec77bbec2f0927f6503bc7d0e2a6ebcb971d7dbe7a77e0d924a70420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
+		rand:                       testutil.DecodeHexString(c, "179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		protectorKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
+		primaryKey:                 testutil.DecodeHexString(c, "6e5eb7de5a75ec77bbec2f0927f6503bc7d0e2a6ebcb971d7dbe7a77e0d924a7"),
+		expectedPrimaryKey:         testutil.DecodeHexString(c, "6e5eb7de5a75ec77bbec2f0927f6503bc7d0e2a6ebcb971d7dbe7a77e0d924a7"),
+		expectedUnlockKey:          testutil.DecodeHexString(c, "0685e55582e4465ba2336e95304166eaa839d1a645dec1c0629a63f9748fb182"),
+		expectedSalt:               testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
+		expectedNonce:              testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
+		expectedProtectorKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		expectedProtectorKeyId:     testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
+		expectedCiphertext:         testutil.DecodeHexString(c, "d3ee9e1c3cab20fc4def991994b1f7ea6582b7eae091c2ed1e40508b38e7cdeca313b33d728c9158c854a0eb8b11399bcd36a299a40e5258c230f61d5e0b948138fe54718b23778d5679118961498d551cacecf81ee9"),
+		expectedPlaintext:          testutil.DecodeHexString(c, "304404206e5eb7de5a75ec77bbec2f0927f6503bc7d0e2a6ebcb971d7dbe7a77e0d924a70420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
 	})
 }
 
 func (s *keydataSuite) TestNewProtectedKeyGeneratePrimaryKey(c *C) {
 	s.testNewProtectedKey(c, &testNewProtectedKeyParams{
-		rand:                      testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		platformKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
-		expectedPrimaryKey:        testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
-		expectedUnlockKey:         testutil.DecodeHexString(c, "f1cffa65c76b15ac7e21dfd0894f21c5ce8986103bfb4916c4ff435513865980"),
-		expectedSalt:              testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
-		expectedNonce:             testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		expectedPlatformKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
-		expectedPlatformKeyId:     testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
-		expectedCiphertext:        testutil.DecodeHexString(c, "d3ee9e1c228a7436f33377239701059b801dd5167dde322e557edda7a42405f345d534e9728c9158c854a0eb8b11399bcd36a299a40e5258c230f61d5e0b948138fe54718b238f4f6063b782ac2b613a58fc1fdc6d49"),
-		expectedPlaintext:         testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
+		rand:                       testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb078535cc101b9d12d9b8f40edada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		protectorKey:               testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
+		expectedPrimaryKey:         testutil.DecodeHexString(c, "707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa373"),
+		expectedUnlockKey:          testutil.DecodeHexString(c, "f1cffa65c76b15ac7e21dfd0894f21c5ce8986103bfb4916c4ff435513865980"),
+		expectedSalt:               testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
+		expectedNonce:              testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
+		expectedProtectorKeyIdSalt: testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
+		expectedProtectorKeyId:     testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
+		expectedCiphertext:         testutil.DecodeHexString(c, "d3ee9e1c228a7436f33377239701059b801dd5167dde322e557edda7a42405f345d534e9728c9158c854a0eb8b11399bcd36a299a40e5258c230f61d5e0b948138fe54718b238f4f6063b782ac2b613a58fc1fdc6d49"),
+		expectedPlaintext:          testutil.DecodeHexString(c, "30440420707fe314e4a9024db85cdd78c26932c75a9f1265a0f51a31e17db268061fa3730420179059840680febea1a486309c881f3486bcedc2f47b579e7699e1621db74696"),
 	})
 }
 
@@ -197,7 +197,7 @@ func (s *keydataSuite) TestKeyDataMarshalAndUnmarshal(c *C) {
 		Version: 1,
 		Salt:    testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
 		Nonce:   testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		PlatformKeyID: PlatformKeyId{
+		ProtectorKeyID: ProtectorKeyId{
 			Alg:    HashAlg(crypto.SHA256),
 			Salt:   testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
 			Digest: testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
@@ -206,7 +206,7 @@ func (s *keydataSuite) TestKeyDataMarshalAndUnmarshal(c *C) {
 
 	b, err := json.Marshal(orig)
 	c.Check(err, IsNil)
-	c.Check(b, DeepEquals, []byte(`{"version":1,"salt":"1LC2+izu+rryH4jqQs+441ODWtnBkEScwBpdJ13chMs=","nonce":"B4U1zBAbnRLZuPQO","platform-key-id":{"alg":"sha256","salt":"2tqBZOoNYvf8ItCcw0vUNARVS7X/xRk31UbJqX1o4v4=","digest":"EZgSUzlG0EzT/nJib2HPNkh3qPGmZjzo8GBNpSzwuPM="}}`))
+	c.Check(b, DeepEquals, []byte(`{"version":1,"salt":"1LC2+izu+rryH4jqQs+441ODWtnBkEScwBpdJ13chMs=","nonce":"B4U1zBAbnRLZuPQO","protector-key-id":{"alg":"sha256","salt":"2tqBZOoNYvf8ItCcw0vUNARVS7X/xRk31UbJqX1o4v4=","digest":"EZgSUzlG0EzT/nJib2HPNkh3qPGmZjzo8GBNpSzwuPM="}}`))
 	c.Logf("%s", string(b))
 
 	var unmarshalled *KeyData

--- a/plainkey/platform.go
+++ b/plainkey/platform.go
@@ -45,27 +45,27 @@ const (
 )
 
 var (
-	platformKeysMu sync.RWMutex
-	platformKeys   [][]byte
+	protectorKeysMu sync.RWMutex
+	protectorKeys   [][]byte
 )
 
-// SetPlatformKeys sets the keys that will be used by this platform to recover other
+// SetProtectorKeys sets the keys that will be used by this platform to recover other
 // keys. These are typically stored in and loaded from an encrypted container that is
 // unlocked via some other mechanism.
-func SetPlatformKeys(keys ...[]byte) {
-	platformKeysMu.Lock()
-	platformKeys = keys
-	platformKeysMu.Unlock()
+func SetProtectorKeys(keys ...[]byte) {
+	protectorKeysMu.Lock()
+	protectorKeys = keys
+	protectorKeysMu.Unlock()
 }
 
-func getPlatformKey(id *platformKeyId) ([]byte, error) {
+func getProtectorKey(id *protectorKeyId) ([]byte, error) {
 	if !id.Alg.Available() {
 		return nil, errors.New("digest algorithm unavailable")
 	}
 
-	platformKeysMu.RLock()
-	keys := platformKeys
-	platformKeysMu.RUnlock()
+	protectorKeysMu.RLock()
+	keys := protectorKeys
+	protectorKeysMu.RUnlock()
 
 	for _, key := range keys {
 		h := hmac.New(id.Alg.New, key)
@@ -104,11 +104,11 @@ func (*platformKeyDataHandler) RecoverKeys(data *secboot.PlatformKeyData, encryp
 		}
 	}
 
-	key, err := getPlatformKey(&kd.PlatformKeyID)
+	key, err := getProtectorKey(&kd.ProtectorKeyID)
 	if err != nil {
 		return nil, &secboot.PlatformHandlerError{
 			Type: secboot.PlatformHandlerErrorInvalidData,
-			Err:  fmt.Errorf("cannot select platform key: %w", err),
+			Err:  fmt.Errorf("cannot select protector key: %w", err),
 		}
 	}
 

--- a/plainkey/platform_test.go
+++ b/plainkey/platform_test.go
@@ -37,17 +37,17 @@ type platformSuite struct{}
 var _ = Suite(&platformSuite{})
 
 type testRecoverKeysParams struct {
-	platformKeys [][]byte
-	generation   int
-	keyData      *KeyData
-	ciphertext   []byte
+	protectorKeys [][]byte
+	generation    int
+	keyData       *KeyData
+	ciphertext    []byte
 
 	expectedPlaintext []byte
 }
 
 func (s *platformSuite) testRecoverKeys(c *C, params *testRecoverKeysParams) {
-	SetPlatformKeys(params.platformKeys...)
-	defer SetPlatformKeys(nil)
+	SetProtectorKeys(params.protectorKeys...)
+	defer SetProtectorKeys(nil)
 
 	handle, err := json.Marshal(params.keyData)
 	c.Assert(err, IsNil)
@@ -65,13 +65,13 @@ func (s *platformSuite) testRecoverKeys(c *C, params *testRecoverKeysParams) {
 
 func (s *platformSuite) TestRecoverKeys(c *C) {
 	s.testRecoverKeys(c, &testRecoverKeysParams{
-		platformKeys: [][]byte{testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")},
-		generation:   2,
+		protectorKeys: [][]byte{testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")},
+		generation:    2,
 		keyData: &KeyData{
 			Version: 1,
 			Salt:    testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
 			Nonce:   testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-			PlatformKeyID: PlatformKeyId{
+			ProtectorKeyID: ProtectorKeyId{
 				Alg:    HashAlg(crypto.SHA256),
 				Salt:   testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
 				Digest: testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
@@ -84,13 +84,13 @@ func (s *platformSuite) TestRecoverKeys(c *C) {
 
 func (s *platformSuite) TestRecoverKeysDifferentKey(c *C) {
 	s.testRecoverKeys(c, &testRecoverKeysParams{
-		platformKeys: [][]byte{testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")},
-		generation:   2,
+		protectorKeys: [][]byte{testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")},
+		generation:    2,
 		keyData: &KeyData{
 			Version: 1,
 			Salt:    testutil.DecodeHexString(c, "dab12d7fa9c4dfb05bcc70bbd3d56ff87d5658c2f42e9e94e6273173a9d09316"),
 			Nonce:   testutil.DecodeHexString(c, "89b9b05919c41170f32cb001"),
-			PlatformKeyID: PlatformKeyId{
+			ProtectorKeyID: ProtectorKeyId{
 				Alg:    HashAlg(crypto.SHA256),
 				Salt:   testutil.DecodeHexString(c, "32b030249e7b9c614d160be5985a031654c9bba87842c40e8d1b7f8adf0b277e"),
 				Digest: testutil.DecodeHexString(c, "777cae054f1c5103149f5e30152fad0b197b3f0bb4b801327307aca50a02acff"),
@@ -101,15 +101,15 @@ func (s *platformSuite) TestRecoverKeysDifferentKey(c *C) {
 	})
 }
 
-func (s *platformSuite) TestRecoverKeysDifferentPlatformKey(c *C) {
+func (s *platformSuite) TestRecoverKeysDifferentProtectorKey(c *C) {
 	s.testRecoverKeys(c, &testRecoverKeysParams{
-		platformKeys: [][]byte{testutil.DecodeHexString(c, "1d3ae75ec26e284ab2f032256202d653025f2a1969d956a7c3b582aa368db198")},
-		generation:   2,
+		protectorKeys: [][]byte{testutil.DecodeHexString(c, "1d3ae75ec26e284ab2f032256202d653025f2a1969d956a7c3b582aa368db198")},
+		generation:    2,
 		keyData: &KeyData{
 			Version: 1,
 			Salt:    testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
 			Nonce:   testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-			PlatformKeyID: PlatformKeyId{
+			ProtectorKeyID: ProtectorKeyId{
 				Alg:    HashAlg(crypto.SHA256),
 				Salt:   testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
 				Digest: testutil.DecodeHexString(c, "a7d200c3951659d5132db221a376cfd937d65e6e991e651b62fbed48855efeaf"),
@@ -120,9 +120,9 @@ func (s *platformSuite) TestRecoverKeysDifferentPlatformKey(c *C) {
 	})
 }
 
-func (s *platformSuite) TestRecoverKeysMultiplePlatformKeys(c *C) {
+func (s *platformSuite) TestRecoverKeysMultipleProtectorKeys(c *C) {
 	s.testRecoverKeys(c, &testRecoverKeysParams{
-		platformKeys: [][]byte{
+		protectorKeys: [][]byte{
 			testutil.DecodeHexString(c, "1d3ae75ec26e284ab2f032256202d653025f2a1969d956a7c3b582aa368db198"),
 			testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"),
 		},
@@ -131,7 +131,7 @@ func (s *platformSuite) TestRecoverKeysMultiplePlatformKeys(c *C) {
 			Version: 1,
 			Salt:    testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
 			Nonce:   testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-			PlatformKeyID: PlatformKeyId{
+			ProtectorKeyID: ProtectorKeyId{
 				Alg:    HashAlg(crypto.SHA256),
 				Salt:   testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
 				Digest: testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
@@ -147,7 +147,7 @@ func (s *platformSuite) TestRecoverKeysInvalidKDFAlg(c *C) {
 		Version: 1,
 		Salt:    testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
 		Nonce:   testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		PlatformKeyID: PlatformKeyId{
+		ProtectorKeyID: ProtectorKeyId{
 			Alg:    HashAlg(crypto.SHA256),
 			Salt:   testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
 			Digest: testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
@@ -170,12 +170,12 @@ func (s *platformSuite) TestRecoverKeysInvalidKDFAlg(c *C) {
 	c.Check(phe.Type, Equals, secboot.PlatformHandlerErrorInvalidData)
 }
 
-func (s *platformSuite) TestRecoverKeysNoPlatformKey(c *C) {
+func (s *platformSuite) TestRecoverKeysNoProtectorKey(c *C) {
 	kd := &KeyData{
 		Version: 1,
 		Salt:    testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
 		Nonce:   testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		PlatformKeyID: PlatformKeyId{
+		ProtectorKeyID: ProtectorKeyId{
 			Alg:    HashAlg(crypto.SHA256),
 			Salt:   testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
 			Digest: testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
@@ -191,7 +191,7 @@ func (s *platformSuite) TestRecoverKeysNoPlatformKey(c *C) {
 		KDFAlg:        crypto.SHA256,
 		AuthMode:      secboot.AuthModeNone,
 	}, nil)
-	c.Check(err, ErrorMatches, `cannot select platform key: no key available`)
+	c.Check(err, ErrorMatches, `cannot select protector key: no key available`)
 
 	var phe *secboot.PlatformHandlerError
 	c.Assert(errors.As(err, &phe), testutil.IsTrue)
@@ -199,14 +199,14 @@ func (s *platformSuite) TestRecoverKeysNoPlatformKey(c *C) {
 }
 
 func (s *platformSuite) TestRecoverKeysCannotOpen(c *C) {
-	SetPlatformKeys(testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"))
-	defer SetPlatformKeys(nil)
+	SetProtectorKeys(testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1"))
+	defer SetProtectorKeys(nil)
 
 	kd := &KeyData{
 		Version: 1,
 		Salt:    testutil.DecodeHexString(c, "d4b0b6fa2ceefabaf21f88ea42cfb8e353835ad9c190449cc01a5d275ddc84cb"),
 		Nonce:   testutil.DecodeHexString(c, "078535cc101b9d12d9b8f40e"),
-		PlatformKeyID: PlatformKeyId{
+		ProtectorKeyID: ProtectorKeyId{
 			Alg:    HashAlg(crypto.SHA256),
 			Salt:   testutil.DecodeHexString(c, "dada8164ea0d62f7fc22d09cc34bd43404554bb5ffc51937d546c9a97d68e2fe"),
 			Digest: testutil.DecodeHexString(c, "119812533946d04cd3fe72626f61cf364877a8f1a6663ce8f0604da52cf0b8f3"),
@@ -234,11 +234,11 @@ type platformSuiteIntegrated struct{}
 var _ = Suite(&platformSuiteIntegrated{})
 
 func (s *platformSuiteIntegrated) TestRecoverKeys(c *C) {
-	platformKey := testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")
-	SetPlatformKeys(platformKey)
-	defer SetPlatformKeys(nil)
+	protectorKey := testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")
+	SetProtectorKeys(protectorKey)
+	defer SetProtectorKeys(nil)
 
-	kd, expectedPrimaryKey, expectedUnlockKey, err := NewProtectedKey(rand.Reader, platformKey, nil)
+	kd, expectedPrimaryKey, expectedUnlockKey, err := NewProtectedKey(rand.Reader, protectorKey, nil)
 	c.Assert(err, IsNil)
 
 	unlockKey, primaryKey, err := kd.RecoverKeys()
@@ -247,14 +247,14 @@ func (s *platformSuiteIntegrated) TestRecoverKeys(c *C) {
 	c.Check(primaryKey, DeepEquals, expectedPrimaryKey)
 }
 
-func (s *platformSuiteIntegrated) TestRecoverKeysNoPlatformKey(c *C) {
-	platformKey := testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")
+func (s *platformSuiteIntegrated) TestRecoverKeysNoProtectorKey(c *C) {
+	protectorKey := testutil.DecodeHexString(c, "8f13251b23450e1d184facfd28752c14c26439fce2765ecd92ff4b060713b5d1")
 
-	kd, _, _, err := NewProtectedKey(rand.Reader, platformKey, nil)
+	kd, _, _, err := NewProtectedKey(rand.Reader, protectorKey, nil)
 	c.Assert(err, IsNil)
 
 	_, _, err = kd.RecoverKeys()
-	c.Check(err, ErrorMatches, `invalid key data: cannot select platform key: no key available`)
+	c.Check(err, ErrorMatches, `invalid key data: cannot select protector key: no key available`)
 
 	var e *secboot.InvalidKeyDataError
 	c.Check(errors.As(err, &e), testutil.IsTrue)


### PR DESCRIPTION
"Platform" is a bit overloaded in this package, eg, there is a
`secboot.PlatformKeyData` type already and EFI has a "Platform Key" as
well.