### PR TITLE
preinstall: Add checks for TPM2 device

### DIFF
--- a/efi/preinstall/check_tpm.go
+++ b/efi/preinstall/check_tpm.go
@@ -30,10 +30,16 @@ const (
 	pcClientClass uint32 = 0x00000001
 )
 
+// checkTPM2DeviceFlags are passed to openAndCheckTPM2Device
 type checkTPM2DeviceFlags int
 
 const (
+	// checkTPM2DeviceInVM indicates that the current environment is a
+	// virtual machine.
 	checkTPM2DeviceInVM checkTPM2DeviceFlags = 1 << iota
+
+	// checkTPM2DevicePostInstall indicates that this function is being
+	// executed post-install as opposed to pre-install.
 	checkTPM2DevicePostInstall
 )
 

--- a/efi/preinstall/check_tpm.go
+++ b/efi/preinstall/check_tpm.go
@@ -1,0 +1,175 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall
+
+import (
+	"fmt"
+
+	"github.com/canonical/go-tpm2"
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+const (
+	pcClientClass uint32 = 0x00000001
+)
+
+type checkTPM2DeviceFlags int
+
+const (
+	checkTPM2DeviceInVM checkTPM2DeviceFlags = 1 << iota
+	checkTPM2DevicePostInstall
+)
+
+// openAndCheckTPM2Device opens the default TPM device for the associated environment and
+// performs some checks on it. It returns an open TPMContext and whether the TPM is a discrete
+// TPM if these checks are successful.
+func openAndCheckTPM2Device(env internal_efi.HostEnvironment, flags checkTPM2DeviceFlags) (tpm *tpm2.TPMContext, discreteTPM bool, err error) {
+	// Get a device from the supplied environment
+	device, err := env.TPMDevice()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Open it!
+	tpm, err = tpm2.OpenTPMDevice(device)
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot open TPM device: %w", err)
+	}
+	savedTpm := tpm
+	defer func() {
+		// Make sure it gets closed again if we return an error
+		if err == nil {
+			return
+		}
+		savedTpm.Close()
+	}()
+
+	// Make sure that the TPM is enabled. The firmware disables the TPM by disabling the
+	// storage and endorsement hierarchies. Of course, user-space can do this as well, although
+	// it requires a TPM reset to restore them anyway.
+	sc, err := tpm.GetCapabilityTPMProperty(tpm2.PropertyStartupClear)
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot obtain value for TPM_PT_STARTUP_CLEAR: %w", err)
+	}
+	const enabledMask = tpm2.AttrShEnable | tpm2.AttrEhEnable
+	if tpm2.StartupClearAttributes(sc)&enabledMask != enabledMask {
+		return nil, false, ErrTPMDisabled
+	}
+
+	perm, err := tpm.GetCapabilityTPMProperty(tpm2.PropertyPermanent)
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot obtain value for TPM_PT_PERMANENT: %w", err)
+	}
+
+	// Make sure that the DA lockout mode is not activated.
+	if tpm2.PermanentAttributes(perm)&tpm2.AttrInLockout > 0 {
+		return nil, false, ErrTPMLockout
+	}
+
+	// Make sure the lockout hierarchy auth value hasn't been set, unless we are
+	// being called in post-install mode.
+	if flags&checkTPM2DevicePostInstall == 0 {
+		if tpm2.PermanentAttributes(perm)&tpm2.AttrLockoutAuthSet > 0 {
+			return nil, false, ErrTPMLockoutAlreadyOwned
+		}
+	}
+	// Make sure the owner and endorsement hierarchy authorization values have never been set.
+	// We don't support this yet - this needs to be coordinated with snapd because snapd will need
+	// access to these values.
+	if tpm2.PermanentAttributes(perm)&(tpm2.AttrOwnerAuthSet|tpm2.AttrEndorsementAuthSet) > 0 {
+		// We don't support setting these at all yet
+		return nil, false, ErrUnsupportedTPMOwnership
+	}
+
+	// Check TPM2 device class. The class is associated with a TPM Profile (PTP) spec
+	// which says a lot about the TPM such as mandatory commands, algorithms, PCR banks
+	// and the minimum number of PCRs. In all honesty, we're only ever likely to see
+	// PC-Client devices here because that's basically all that exists, but check anyway
+	// just in case.
+	psFamily, err := tpm.GetCapabilityTPMProperty(tpm2.PropertyPSFamilyIndicator)
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot obtain value for TPM_PT_PS_FAMILY_INDICATOR: %w", err)
+	}
+	if psFamily != pcClientClass {
+		// swtpm sets TPM_PT_PS_FAMILY_INDICATOR to the same value as TPM_PT_FAMILY_INDICATOR,
+		// which is incorrect - the latter is "2.0" in ASCII with a NULL terminator and is used
+		// to indicate the major version of the TCG reference library supported by the TPM. The
+		// former indicates the class, as described earlier, and is 0 in the reference
+		// implementation and should be 1 for PC-Client. Permit this bug if we are running in a VM.
+		if flags&checkTPM2DeviceInVM == 0 {
+			// We're not in a VM, so expect the proper PC-Client value.
+			return nil, false, ErrNoPCClientTPM
+		}
+		// In a VM, make sure that the value of TPM_PT_PS_FAMILY_INDICATOR == TPM_PT_FAMILY_INDICATOR.
+		// I think that this is always the case, but we might need to add additional VM-specific quirks here.
+		family, err := tpm.GetCapabilityTPMProperty(tpm2.PropertyFamilyIndicator)
+		if err != nil {
+			return nil, false, fmt.Errorf("cannot obtain value for TPM_PT_FAMILY_INDICATOR: %w", err)
+		}
+		if family != psFamily {
+			// This doesn't have the swtpm quirk, so we have no idea what sort of vTPM we have
+			// at this point - just return an error because we aren't going to check for every
+			// individual TPM feature.
+			return nil, false, ErrNoPCClientTPM
+		}
+	}
+
+	// Make sure we have enough NV counters for PCR policy revocation. We need at least 2 (1 normally, and
+	// an extra 1 during reprovision). The platform firmware may use up some of the allocation.
+	nvCountersMax, err := tpm.GetCapabilityTPMProperty(tpm2.PropertyNVCountersMax)
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot obtain value for TPM_NV_COUNTERS_MAX: %w", err)
+	}
+	if nvCountersMax > 0 {
+		// If the TPM returns 0, there are no limits to the number of counters other than
+		// available NV storage. Obtain the number of active counters.
+		nvCounters, err := tpm.GetCapabilityTPMProperty(tpm2.PropertyNVCounters)
+		if err != nil {
+			return nil, false, fmt.Errorf("cannot obtain value for TPM_NV_COUNTERS_MAX: %w", err)
+		}
+		required := uint32(1) // extra index for re-provision
+		if flags&checkTPM2DevicePostInstall == 0 {
+			// This is pre-install, so we need the initial index for provision
+			required += 1
+		}
+		if (nvCountersMax - nvCounters) < required {
+			return nil, false, ErrTPMInsufficientNVCounters
+		}
+	}
+
+	// Determine whether we have a discrete TPM by querying the manufacturer.
+	// Assume that Intel is firmware (ie, Intel PTT) and everything else is discrete
+	// unless we are in a VM.
+	// TODO: Investigate whether this is the best way to detect a discrete TPM.
+	//  There may be more than Intel PTT in the firmware world, eg, AMD might have
+	//  its own and ARM devices with UEFI firmware implementations may have
+	//  firmware based TPMs running in a TEE. I suspect this is not the best way to
+	//  do this but is ok for an initial implementation.
+	manufacturer, err := tpm.GetManufacturer()
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot obtain value for TPM_PT_MANUFACTURER: %w", err)
+	}
+
+	discreteTPM = manufacturer != tpm2.TPMManufacturerINTC
+	if flags&checkTPM2DeviceInVM > 0 {
+		discreteTPM = false
+	}
+	return tpm, discreteTPM, nil
+}

--- a/efi/preinstall/check_tpm_test.go
+++ b/efi/preinstall/check_tpm_test.go
@@ -1,0 +1,295 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preinstall_test
+
+import (
+	"bytes"
+
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
+	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
+	. "github.com/snapcore/secboot/efi/preinstall"
+	"github.com/snapcore/secboot/internal/efitest"
+	"github.com/snapcore/secboot/internal/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type tpmSuite struct {
+	tpm2_testutil.TPMSimulatorTest
+}
+
+var _ = Suite(&tpmSuite{})
+
+// addTPMPropertyModifiers permits the test to run with well-known property values
+func (s *tpmSuite) addTPMPropertyModifiers(c *C, overrides map[tpm2.Property]uint32) {
+	s.Transport.ResponseIntercept = func(cmdCode tpm2.CommandCode, cmdHandles tpm2.HandleList, cmdAuthArea []tpm2.AuthCommand, cpBytes []byte, rsp *bytes.Buffer) {
+		// Check we have the right command code
+		if cmdCode != tpm2.CommandGetCapability {
+			return
+		}
+		// TPM2_GetCapability has no command handles
+		c.Assert(cmdHandles, HasLen, 0)
+
+		// Test the command parameters
+		var capability tpm2.Capability
+		var property uint32
+		var propertyCount uint32
+		_, err := mu.UnmarshalFromBytes(cpBytes, &capability, &property, &propertyCount)
+		c.Assert(err, IsNil)
+		if capability != tpm2.CapabilityTPMProperties {
+			return
+		}
+
+		// Unpack the response
+		rc, rpBytes, rAuthArea, err := tpm2.ReadResponsePacket(rsp, nil)
+		c.Assert(err, IsNil)
+		if rc != tpm2.ResponseSuccess {
+			// Do nothing if the TPM didn't return success
+			return
+		}
+
+		// Unpack the response parameters
+		var moreData bool
+		var capabilityData *tpm2.CapabilityData
+		_, err = mu.UnmarshalFromBytes(rpBytes, &moreData, &capabilityData)
+		c.Assert(err, IsNil)
+		c.Assert(capabilityData.Capability, Equals, tpm2.CapabilityTPMProperties)
+
+		// Override the response parameters
+		for i := range capabilityData.Data.TPMProperties {
+			newValue, exists := overrides[capabilityData.Data.TPMProperties[i].Property]
+			if !exists {
+				continue
+			}
+			capabilityData.Data.TPMProperties[i].Value = newValue
+		}
+
+		// Repack the response parameters
+		rpBytes = mu.MustMarshalToBytes(moreData, capabilityData)
+
+		// Repack the response
+		rsp.Reset()
+		c.Check(tpm2.WriteResponsePacket(rsp, rc, nil, rpBytes, rAuthArea), IsNil)
+	}
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersDiscreteTPM(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyNVCountersMax:     0,
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, IsNil)
+	c.Assert(tpm, NotNil)
+	var tmpl tpm2_testutil.TransportWrapper
+	c.Assert(tpm.Transport(), Implements, &tmpl)
+	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
+	c.Check(discreteTPM, testutil.IsTrue)
+	c.Check(dev.NumberOpen(), Equals, int(1))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMInfiniteCountersFWTPM(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyNVCountersMax:     0,
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, IsNil)
+	c.Assert(tpm, NotNil)
+	var tmpl tpm2_testutil.TransportWrapper
+	c.Assert(tpm.Transport(), Implements, &tmpl)
+	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
+	c.Check(discreteTPM, testutil.IsFalse)
+	c.Check(dev.NumberOpen(), Equals, int(1))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallNoVMFiniteCountersDiscreteTPM(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyNVCountersMax:     6,
+		tpm2.PropertyNVCounters:        4,
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, IsNil)
+	c.Assert(tpm, NotNil)
+	var tmpl tpm2_testutil.TransportWrapper
+	c.Assert(tpm.Transport(), Implements, &tmpl)
+	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
+	c.Check(discreteTPM, testutil.IsTrue)
+	c.Check(dev.NumberOpen(), Equals, int(1))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPostInstallNoVMFiniteCountersDiscreteTPM(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyNVCountersMax:     6,
+		tpm2.PropertyNVCounters:        5,
+		tpm2.PropertyPSFamilyIndicator: 1,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerNTC),
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	c.Check(err, IsNil)
+	c.Assert(tpm, NotNil)
+	var tmpl tpm2_testutil.TransportWrapper
+	c.Assert(tpm.Transport(), Implements, &tmpl)
+	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
+	c.Check(discreteTPM, testutil.IsTrue)
+	c.Check(dev.NumberOpen(), Equals, int(1))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceGoodPreInstallVMInfiniteCounters(c *C) {
+	family, err := s.TPM.GetCapabilityTPMProperty(tpm2.PropertyFamilyIndicator)
+	c.Assert(err, IsNil)
+
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyNVCountersMax:     0,
+		tpm2.PropertyPSFamilyIndicator: family,
+		tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerMSFT),
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	tpm, discreteTPM, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
+	c.Check(err, IsNil)
+	c.Assert(tpm, NotNil)
+	var tmpl tpm2_testutil.TransportWrapper
+	c.Assert(tpm.Transport(), Implements, &tmpl)
+	c.Check(tpm.Transport().(tpm2_testutil.TransportWrapper).Unwrap(), Equals, s.Transport)
+	c.Check(discreteTPM, testutil.IsFalse)
+	c.Check(dev.NumberOpen(), Equals, int(1))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceNoTPM(c *C) {
+	env := efitest.NewMockHostEnvironmentWithOpts()
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrNoTPM2Device)
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceDisabled(c *C) {
+	// Disable owner and endorsement hierarchies
+	c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
+	c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrTPMDisabled)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceLockout(c *C) {
+	// Trip the DA logic by setting newMaxTries to 0
+	c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrTPMLockout)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwned(c *C) {
+	// Set the lockout hierarchy auth value so we get an error indicating that the TPM is already owned.
+	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.LockoutHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrTPMLockoutAlreadyOwned)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceAlreadyOwned2(c *C) {
+	// Set the owner hierarchy auth value and run the post-install test. We get an error indicating that the TPM is already owned
+	// because we don't support setting this value yet, but should in the value (setting this needs to be coordinated with snapd)
+	c.Assert(s.TPM.HierarchyChangeAuth(s.TPM.OwnerHandleContext(), []byte{1, 2, 3, 4}, nil), IsNil)
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	c.Check(err, Equals, ErrUnsupportedTPMOwnership)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClient(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 2, // This is defined as PDA in the reference library specs
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrNoPCClientTPM)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceIsNotPCClientWithSWTPMWorkaround(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyPSFamilyIndicator: 2, // This is defined as PDA in the reference library specs
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DeviceInVM)
+	c.Check(err, Equals, ErrNoPCClientTPM)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceInsufficientNVCountersPreInstall(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyNVCountersMax:     6,
+		tpm2.PropertyNVCounters:        5,
+		tpm2.PropertyPSFamilyIndicator: 1,
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, 0)
+	c.Check(err, Equals, ErrTPMInsufficientNVCounters)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}
+
+func (s *tpmSuite) TestOpenAndCheckTPM2DeviceInsufficientNVCountersPostInstall(c *C) {
+	s.addTPMPropertyModifiers(c, map[tpm2.Property]uint32{
+		tpm2.PropertyNVCountersMax:     6,
+		tpm2.PropertyNVCounters:        6,
+		tpm2.PropertyPSFamilyIndicator: 1,
+	})
+
+	dev := tpm2_testutil.NewTransportBackedDevice(s.Transport, false)
+	env := efitest.NewMockHostEnvironmentWithOpts(efitest.WithTPMDevice(dev))
+	_, _, err := OpenAndCheckTPM2Device(env, CheckTPM2DevicePostInstall)
+	c.Check(err, Equals, ErrTPMInsufficientNVCounters)
+	c.Check(dev.NumberOpen(), Equals, int(0))
+}

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -19,7 +19,13 @@
 
 package preinstall
 
-import "errors"
+import (
+	"errors"
+
+	internal_efi "github.com/snapcore/secboot/internal/efi"
+)
+
+// Errors related to checking platform firmware protections.
 
 // NoHardwareRootOfTrustError is returned wrapped from [RunChecks] if the platform
 // firmware is not protected by a hardware root-of-trust. This won't be returned if
@@ -74,4 +80,51 @@ var (
 	// has a debugging endpoint enabled. This won't be returned if the PermitVirtualMachine
 	// flag is supplied to RunChecks and the current environment is a virtual machine.
 	ErrUEFIDebuggingEnabled = errors.New("the platform firmware contains a debugging endpoint enabled")
+)
+
+// Errors related to checking the TPM device.
+
+var (
+	// ErrNoTPM2Device is returned wrapped from RunChecks if there is no
+	// TPM2 device available.
+	ErrNoTPM2Device = internal_efi.ErrNoTPM2Device
+
+	// ErrTPMLockout is returned wrapped from RunChecks if the TPM is in DA
+	// lockout mode. If the existing lockout hierarchy authorization value is not
+	// known then the TPM will most likely need to be cleared in order to fix this.
+	ErrTPMLockout = errors.New("TPM is in DA lockout mode")
+
+	// ErrTPMLockoutAlreadyOwned is returned wrapped from RunChecks if the authorization
+	// value for the lockout hierarchy is already set but the PostInstallChecks flag isn't
+	// supplied. If the lockout hierarchy is set at pre-install time, then the TPM will
+	// most likely need to be cleared.
+	ErrTPMLockoutAlreadyOwned = errors.New("TPM lockout hierarchy is already owned")
+
+	// ErrUnsupportedTPMOwnership is returned wrapped from RunChecks if the authorization
+	// value for the owner or endorsement hierarchies are set, which currently isn't
+	// supported by snapd. Snapd needs the use of both of these hierarchies, so if we
+	// want to support something other than snapd taking ownership of these in the future,
+	// this will need coordination with snapd.
+	// Unless the authorization values are known, clearing this will most likely require
+	// the TPM to be cleared.
+	ErrUnsupportedTPMOwnership = errors.New("either the TPM's storage or endorsement hierarchy is owned and this isn't currently supported")
+
+	// ErrTPMInsufficientNVCounters is returned wrapped from RunChecks if there are
+	// insufficient NV counters available for PCR policy revocation. If this is still
+	// the case after a TPM clear then it means that the platform firmware is using
+	// most of the allocation of available counters for itself, and maybe the
+	// feature needs to be disabled by snapd.
+	ErrTPMInsufficientNVCounters = errors.New("insufficient NV counters available")
+
+	// ErrNoPCClientTPM is returned wrapped from RunChecks if a TPM2 device exists
+	// but it doesn't claim to be meet the requirements for PC-Client. Note that swtpm
+	// used by VM's don't behave correctly here, so we account for that instead of
+	// returning an error.
+	ErrNoPCClientTPM = errors.New("TPM2 device is present but it is not a PC-Client TPM")
+
+	// ErrTPMDisabled is returned wrapped from RunChecks if a TPM2 device exists but
+	// it is currently disabled. It can be reenabled by the firmware by making use of the
+	// [github.com/canonical/go-tpm2/ppi.PPI] interface, obtained by using
+	// [github.com/canonical/go-tpm2/linux/RawDevice.PhysicalPresenceInterface].
+	ErrTPMDisabled = errors.New("TPM2 device is present but is currently disabled by the platform firmware")
 )

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -20,21 +20,24 @@
 package preinstall
 
 type (
-	CpuVendor        = cpuVendor
-	DetectVirtResult = detectVirtResult
-	MeVersion        = meVersion
+	CheckTPM2DeviceFlags = checkTPM2DeviceFlags
+	CpuVendor            = cpuVendor
+	DetectVirtResult     = detectVirtResult
+	MeVersion            = meVersion
 )
 
 const (
-	CpuVendorIntel  = cpuVendorIntel
-	CpuVendorAMD    = cpuVendorAMD
-	DetectVirtNone  = detectVirtNone
-	DetectVirtVM    = detectVirtVM
-	MeFamilyUnknown = meFamilyUnknown
-	MeFamilySps     = meFamilySps
-	MeFamilyTxe     = meFamilyTxe
-	MeFamilyMe      = meFamilyMe
-	MeFamilyCsme    = meFamilyCsme
+	CheckTPM2DeviceInVM        = checkTPM2DeviceInVM
+	CheckTPM2DevicePostInstall = checkTPM2DevicePostInstall
+	CpuVendorIntel             = cpuVendorIntel
+	CpuVendorAMD               = cpuVendorAMD
+	DetectVirtNone             = detectVirtNone
+	DetectVirtVM               = detectVirtVM
+	MeFamilyUnknown            = meFamilyUnknown
+	MeFamilySps                = meFamilySps
+	MeFamilyTxe                = meFamilyTxe
+	MeFamilyMe                 = meFamilyMe
+	MeFamilyCsme               = meFamilyCsme
 )
 
 var (
@@ -46,6 +49,7 @@ var (
 	CheckSecureBootPolicyPCRForDegradedFirmwareSettings = checkSecureBootPolicyPCRForDegradedFirmwareSettings
 	DetectVirtualization                                = detectVirtualization
 	DetermineCPUVendor                                  = determineCPUVendor
+	OpenAndCheckTPM2Device                              = openAndCheckTPM2Device
 	ReadIntelHFSTSRegistersFromMEISysfs                 = readIntelHFSTSRegistersFromMEISysfs
 	ReadIntelMEVersionFromMEISysfs                      = readIntelMEVersionFromMEISysfs
 )

--- a/efi/preinstall/preinstall_test.go
+++ b/efi/preinstall/preinstall_test.go
@@ -20,9 +20,39 @@
 package preinstall_test
 
 import (
+	"flag"
+	"fmt"
+	"os"
 	"testing"
 
+	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 	. "gopkg.in/check.v1"
 )
 
+func init() {
+	tpm2_testutil.AddCommandLineFlags()
+}
+
 func Test(t *testing.T) { TestingT(t) }
+
+func TestMain(m *testing.M) {
+	// Provide a way for run-tests to configure this in a way that
+	// can be ignored by other suites
+	if _, ok := os.LookupEnv("USE_MSSIM"); ok {
+		tpm2_testutil.TPMBackend = tpm2_testutil.TPMBackendMssim
+	}
+
+	flag.Parse()
+	os.Exit(func() int {
+		if tpm2_testutil.TPMBackend == tpm2_testutil.TPMBackendMssim {
+			simulatorCleanup, err := tpm2_testutil.LaunchTPMSimulator(nil)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Cannot launch TPM simulator: %v\n", err)
+				return 1
+			}
+			defer simulatorCleanup()
+		}
+
+		return m.Run()
+	}())
+}


### PR DESCRIPTION
This adds checks that we have a TPM2 device, that it is enabled, that it
is not in DA lockout mode, that it is not already owned by having an
authorization value for any of the 3 hierarchies we can use, that it is
a PC-Client device, and that it has enough spare NV counter indexes to
supprt PCR policy revocation. If the checks succeed, it returns a
`tpm2.TPMContext` that will be consumed by `RunChecks` for other tests, and
which will have to be closed later on.