### PR TITLE
various: update github.com/canonical/tcglog-parser

### DIFF
--- a/efi/fw_load_handler_test.go
+++ b/efi/fw_load_handler_test.go
@@ -547,9 +547,9 @@ func (s *fwLoadHandlerSuite) testMeasureImageStartErrBadLogSeparatorError(c *C, 
 	log := efitest.NewLog(c, &efitest.LogOptions{
 		Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA1}})
 	for i, event := range log.Events {
-		if event.PCRIndex == tcglog.PCRIndex(pcr) && event.EventType == tcglog.EventTypeSeparator {
+		if event.PCRIndex == pcr && event.EventType == tcglog.EventTypeSeparator {
 			// Overwrite the event data with a mock error event
-			log.Events[i].Data = tcglog.NewErrorSeparatorEventData([]byte{0x50, 0x10, 0x00, 0x00})
+			log.Events[i].Data = &tcglog.SeparatorEventData{Value: tcglog.SeparatorEventErrorValue, ErrorInfo: []byte{0x50, 0x10, 0x00, 0x00}}
 			break
 		}
 	}
@@ -588,7 +588,7 @@ func (s *fwLoadHandlerSuite) testMeasureImageStartErrBadLogInvalidSeparator(c *C
 	log := efitest.NewLog(c, &efitest.LogOptions{
 		Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA1}})
 	for i, event := range log.Events {
-		if event.PCRIndex == tcglog.PCRIndex(pcr) && event.EventType == tcglog.EventTypeSeparator {
+		if event.PCRIndex == pcr && event.EventType == tcglog.EventTypeSeparator {
 			// Overwrite the event data with a mock error event
 			log.Events[i].Data = &mockErrLogData{errors.New("data is the wrong size")}
 			break
@@ -629,7 +629,7 @@ func (s *fwLoadHandlerSuite) testMeasureImageStartErrBadLogMissingSeparator(c *C
 	log := efitest.NewLog(c, &efitest.LogOptions{
 		Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA1}})
 	for i, event := range log.Events {
-		if event.PCRIndex == tcglog.PCRIndex(pcr) && event.EventType == tcglog.EventTypeSeparator {
+		if event.PCRIndex == pcr && event.EventType == tcglog.EventTypeSeparator {
 			events := log.Events[:i]
 			if len(log.Events) > i+1 {
 				events = append(events, log.Events[i+1:]...)

--- a/efi/preinstall/check_fw_protections.go
+++ b/efi/preinstall/check_fw_protections.go
@@ -68,7 +68,7 @@ func checkSecureBootPolicyPCRForDegradedFirmwareSettings(log *tcglog.Log) error 
 		event := events[0]
 		events = events[1:]
 
-		if event.PCRIndex != tcglog.PCRIndex(internal_efi.SecureBootPolicyPCR) {
+		if event.PCRIndex != internal_efi.SecureBootPolicyPCR {
 			continue
 		}
 

--- a/efi/preinstall/check_fw_protections_test.go
+++ b/efi/preinstall/check_fw_protections_test.go
@@ -85,7 +85,7 @@ func (s *fwProtectionsSuite) TestCheckSecureBootPolicyPCRForDegradedSettingsDMAP
 func (s *fwProtectionsSuite) TestCheckSecureBootPolicyPCRForDegradedSettingsErrUnexpectedData(c *C) {
 	log := efitest.NewLog(c, &efitest.LogOptions{FirmwareDebugger: true})
 	for _, ev := range log.Events {
-		if ev.PCRIndex != tcglog.PCRIndex(internal_efi.SecureBootPolicyPCR) {
+		if ev.PCRIndex != internal_efi.SecureBootPolicyPCR {
 			continue
 		}
 		ev.Data = tcglog.EFICallingEFIApplicationEvent
@@ -97,7 +97,7 @@ func (s *fwProtectionsSuite) TestCheckSecureBootPolicyPCRForDegradedSettingsErrU
 func (s *fwProtectionsSuite) TestCheckSecureBootPolicyPCRForDegradedSettingsErrUnexpectedType(c *C) {
 	log := efitest.NewLog(c, &efitest.LogOptions{FirmwareDebugger: true})
 	for _, ev := range log.Events {
-		if ev.PCRIndex != tcglog.PCRIndex(internal_efi.SecureBootPolicyPCR) {
+		if ev.PCRIndex != internal_efi.SecureBootPolicyPCR {
 			continue
 		}
 		ev.EventType = tcglog.EventTypeAction

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210315104021-ead800bbf9a0
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
 	github.com/canonical/go-tpm2 v1.7.6
-	github.com/canonical/tcglog-parser v0.0.0-20240726104243-6363e875afc6
+	github.com/canonical/tcglog-parser v0.0.0-20240820013904-60cf7cbc7c5d
 	github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb
 	github.com/snapcore/snapd v0.0.0-20220714152900-4a1f4c93fc85
 	golang.org/x/crypto v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61/go.mod h1:vG41hd
 github.com/canonical/go-tpm2 v1.7.6 h1:9k9OAEEp9xKp4h2WJwfTUNivblJi4L5Wjx7Q/LkSTSQ=
 github.com/canonical/go-tpm2 v1.7.6/go.mod h1:Dz0PQRmoYrmk/4BLILjRA+SFzuqEo1etAvYeAJiMhYU=
 github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2/go.mod h1:QoW2apR2tBl6T/4czdND/EHjL1Ia9cCmQnIj9Xe0Kt8=
-github.com/canonical/tcglog-parser v0.0.0-20240726104243-6363e875afc6 h1:WcR9HTKI1uiKZXpfbQ33Qjr5uGfBontkpX3aQJauF/E=
-github.com/canonical/tcglog-parser v0.0.0-20240726104243-6363e875afc6/go.mod h1:eDAzszT5fmIHIjTMTsT0nTtZ+GnZb14tvi1h45Njk3g=
+github.com/canonical/tcglog-parser v0.0.0-20240820013904-60cf7cbc7c5d h1:v3gTMnOF/eT79eZnUSbHR18IJqHAXUog5SwiPn+HRXk=
+github.com/canonical/tcglog-parser v0.0.0-20240820013904-60cf7cbc7c5d/go.mod h1:ywdPBqUGkuuiitPpVWCfilf2/gq+frhq4CNiNs9KyHU=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=

--- a/internal/efitest/log.go
+++ b/internal/efitest/log.go
@@ -62,7 +62,7 @@ func (d bytesHashData) Write(w io.Writer) error {
 }
 
 type logEvent struct {
-	pcrIndex  tcglog.PCRIndex
+	pcrIndex  tpm2.Handle
 	eventType tcglog.EventType
 	data      tcglog.EventData
 }
@@ -131,7 +131,7 @@ func NewLog(c *C, opts *LogOptions) *tcglog.Log {
 		{
 			PCRIndex:  0,
 			EventType: tcglog.EventTypeNoAction,
-			Digests:   tcglog.DigestMap{tpm2.HashAlgorithmSHA1: make(tcglog.Digest, tpm2.HashAlgorithmSHA1.Size())},
+			Digests:   tcglog.DigestMap{tpm2.HashAlgorithmSHA1: make(tpm2.Digest, tpm2.HashAlgorithmSHA1.Size())},
 			Data: &tcglog.SpecIdEvent03{
 				SpecVersionMajor: 2,
 				UintnSize:        2,
@@ -147,7 +147,7 @@ func NewLog(c *C, opts *LogOptions) *tcglog.Log {
 			Data:      &tcglog.StartupLocalityEventData{StartupLocality: opts.StartupLocality},
 		}
 		for _, alg := range opts.Algorithms {
-			ev.Digests[alg] = make(tcglog.Digest, alg.Size())
+			ev.Digests[alg] = make(tpm2.Digest, alg.Size())
 		}
 		builder.events = append(builder.events, ev)
 	}
@@ -401,7 +401,7 @@ func NewLog(c *C, opts *LogOptions) *tcglog.Log {
 			eventType: tcglog.EventTypeEFIAction,
 			data:      data})
 	}
-	for _, pcr := range []tcglog.PCRIndex{0, 1, 2, 3, 4, 5, 6} {
+	for _, pcr := range []tpm2.Handle{0, 1, 2, 3, 4, 5, 6} {
 		data := &tcglog.SeparatorEventData{Value: tcglog.SeparatorEventNormalValue}
 		builder.hashLogExtendEvent(c, data, &logEvent{
 			pcrIndex:  pcr,


### PR DESCRIPTION
github.com/canonical/tcglog-parser defined its own types for PCR indides
and digests, which resulted in a bunch of pointless conversions between
these and go-tpm2 equivalent types in packages that depended on both of
these, despite the fact that tcglog-parser already depends on go-tpm2.

I've removed the tcglog-parser type definitions in master and updated it
here which allows us to remove a fair few type conversions.