### PR TITLE
Add public API CheckPassphraseEntropy() that calculates entropy

### DIFF
--- a/entropy.go
+++ b/entropy.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	gpv "github.com/canonical/go-password-validator"
+)
+
+type PassphraseEntropyStats struct {
+	SymbolPoolSize  uint32
+	NumberOfSymbols uint32
+	EntropyBits     uint32
+}
+
+// CheckPassphraseEntropy calculates entropy for PINs and passphrases (PINs will be supplied as a numeric passphrase).
+func CheckPassphraseEntropy(passphrase string) (*PassphraseEntropyStats, error) {
+	stats := &PassphraseEntropyStats{}
+	stats.SymbolPoolSize = uint32(gpv.GetBase(passphrase))
+	stats.NumberOfSymbols = uint32(gpv.GetLength(passphrase))
+	stats.EntropyBits = uint32(gpv.GetEntropy(passphrase))
+	return stats, nil
+}

--- a/entropy_test.go
+++ b/entropy_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	. "github.com/snapcore/secboot"
+	. "gopkg.in/check.v1"
+)
+
+type entropySuite struct{}
+
+var _ = Suite(&entropySuite{})
+
+func (t *entropySuite) TestCheckPassphraseEntropy1234(c *C) {
+	stats, err := CheckPassphraseEntropy("1234")
+	c.Check(err, IsNil)
+	c.Assert(stats.SymbolPoolSize, Equals, uint32(10)) // 10 digits
+	c.Assert(stats.NumberOfSymbols, Equals, uint32(2)) // runs of more than 2 from the digits set get compressed
+	c.Assert(stats.EntropyBits, Equals, uint32(6))     // log2(10^2)
+}
+
+func (t *entropySuite) TestCheckPassphraseEntropy194753(c *C) {
+	stats, err := CheckPassphraseEntropy("194753")
+	c.Check(err, IsNil)
+	c.Assert(stats.SymbolPoolSize, Equals, uint32(10)) // 10 digits
+	c.Assert(stats.NumberOfSymbols, Equals, uint32(6)) // 6 non-identical chars not in proximity set order
+	c.Assert(stats.EntropyBits, Equals, uint32(19))    // log2(10^6)
+}
+
+func (t *entropySuite) TestCheckPassphraseEntropyPassword1(c *C) {
+	stats, err := CheckPassphraseEntropy("password1")
+	c.Check(err, IsNil)
+	c.Assert(stats.SymbolPoolSize, Equals, uint32(36)) // 26 lowercase letters + 10 digits
+	c.Assert(stats.NumberOfSymbols, Equals, uint32(9)) // only "as" in proximity set order but that's <= 2, so 9 chars
+	c.Assert(stats.EntropyBits, Equals, uint32(46))    // log2(36^9)
+}
+
+func (t *entropySuite) TestCheckPassphraseEntropyLParenFoobarDollar(c *C) {
+	stats, err := CheckPassphraseEntropy("(Foobar$")
+	c.Check(err, IsNil)
+	c.Assert(stats.SymbolPoolSize, Equals, uint32(79)) // 26 lowercase letters + 26 uppercase letters + $ in set of 5 chars + ( in set of 22 chars
+	c.Assert(stats.NumberOfSymbols, Equals, uint32(8)) // nothing in proximity set order
+	c.Assert(stats.EntropyBits, Equals, uint32(50))    // log2(79^8)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/canonical/cpuid v0.0.0-20220614022739-219e067757cb
 	github.com/canonical/go-efilib v1.4.1
 	github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9
+	github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3
 	github.com/canonical/go-tpm2 v1.12.2
 	github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/canonical/go-efilib v1.4.1 h1:/VMNCypz+iVmnNuMcsm7WvmDMI1ObkEP2W1h8Ls
 github.com/canonical/go-efilib v1.4.1/go.mod h1:n0Ttsy1JuHAvqaFbZBs6PAzoiiJdfkHsAmDOEbexYEQ=
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9 h1:Twk1ZSTWRClfGShP16ePf2JIiayqWS4ix1rkAR6baag=
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9/go.mod h1:IneQ5/yQcfPXrGekEXpR6yeea55ZD24N5+kHzeDseOM=
+github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54 h1:JO3wAsxjrvQDf/X3q4RLIdzDCWrFjzhwUmCKrhnrIO8=
+github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54/go.mod h1:Vy3kTKlJTJ7gav1xGV9Bek08cUsh90hK7pK7mY34GnU=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=


### PR DESCRIPTION
Returns the estimated symbol pool size, number of symbol (taking into account runs of identical, and nearby chars), and the actual base2 entropy.