### PR TITLE
preinstall: Rename TCG log phases

### DIFF
--- a/efi/preinstall/check_pcr4.go
+++ b/efi/preinstall/check_pcr4.go
@@ -122,7 +122,7 @@ NextEvent:
 		}
 
 		switch phase {
-		case tcglogPhasePreOSBeforeMeasureSecureBootConfig, tcglogPhasePreOSAfterMeasureSecureBootConfig, tcglogPhasePreOSAfterMeasureSecureBootConfigUnterminated:
+		case tcglogPhaseFirmwareLaunch, tcglogPhasePreOSThirdPartyDispatch, tcglogPhasePreOSThirdPartyDispatchUnterminated:
 			if ev.PCRIndex != internal_efi.BootManagerCodePCR {
 				// Not PCR4
 				continue NextEvent
@@ -161,7 +161,7 @@ NextEvent:
 				// verifying this because we just copy the events into the profile.
 				if ev.Data == tcglog.EFICallingEFIApplicationEvent {
 					// This is the signal from BDS that we're about to hand over to the OS.
-					if phase == tcglogPhasePreOSBeforeMeasureSecureBootConfig {
+					if phase == tcglogPhaseFirmwareLaunch {
 						return 0, fmt.Errorf("unexpected %v event %q (before secure boot config was measured)", ev.EventType, ev.Data)
 					}
 					if omitBootDeviceEventsSeen {
@@ -195,7 +195,7 @@ NextEvent:
 				// device path, if it's reachable from the OS. Although this also suffers from a similar
 				// variation of the issue described above - that path could have been updated between
 				// booting and now.
-				if phase == tcglogPhasePreOSBeforeMeasureSecureBootConfig {
+				if phase == tcglogPhaseFirmwareLaunch {
 					// Application launches before the secure boot configuration has been measured is a bug.
 					return 0, fmt.Errorf("encountered pre-OS %v event for %v before secure boot configuration has been measured", ev.EventType, ev.Data.(*tcglog.EFIImageLoadEvent).DevicePath)
 				}

--- a/efi/preinstall/check_pcr7.go
+++ b/efi/preinstall/check_pcr7.go
@@ -466,7 +466,7 @@ NextEvent:
 		}
 
 		switch phase {
-		case tcglogPhasePreOSMeasuringSecureBootConfig:
+		case tcglogPhaseMeasuringSecureBootConfig:
 			if ev.PCRIndex != internal_efi.SecureBootPolicyPCR {
 				// Not PCR7
 				continue NextEvent
@@ -552,7 +552,7 @@ NextEvent:
 				// Anything that isn't EV_EFI_VARIABLE_DRIVER_CONFIG ends up here.
 				return nil, fmt.Errorf("unexpected %v event %q whilst measuring config", ev.EventType, ev.Data)
 			}
-		case tcglogPhasePreOSAfterMeasureSecureBootConfig:
+		case tcglogPhasePreOSThirdPartyDispatch:
 			if len(configs) > 0 {
 				// We've transitioned to a phase where components can be loaded and verified but we haven't
 				// measured all of the secure boot variables. We'll fail to generate a valid policy with
@@ -728,7 +728,7 @@ NextEvent:
 				// Anything that isn't EV_EFI_VARIABLE_AUTHORITY ends up here.
 				return nil, fmt.Errorf("unexpected %v event %q whilst measuring verification", ev.EventType, ev.Data)
 			}
-		case tcglogPhasePreOSAfterMeasureSecureBootConfigUnterminated:
+		case tcglogPhasePreOSThirdPartyDispatchUnterminated:
 			if ev.PCRIndex == internal_efi.SecureBootPolicyPCR {
 				return nil, fmt.Errorf("unexpected %v event in PCR7 after measuring config but before transitioning to OS-present", ev.EventType)
 			}


### PR DESCRIPTION
This doesn't change any functionality - it just renames the existing
phase descriptors to better reflect what they do. This is in preparation
to refactoring this as part of the fix for https://github.com/canonical/secboot/issues/410.