### PR TITLE
efi/preinstall,tpm2: Clean up handling of DA lockouts 

### DIFF
--- a/efi/preinstall/checks_test.go
+++ b/efi/preinstall/checks_test.go
@@ -22,12 +22,14 @@ package preinstall_test
 import (
 	"context"
 	"crypto"
+	"crypto/rand"
 	"errors"
 	"io"
 
 	"github.com/canonical/cpuid"
 	efi "github.com/canonical/go-efilib"
 	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/objectutil"
 	tpm2_testutil "github.com/canonical/go-tpm2/testutil"
 	secboot_efi "github.com/snapcore/secboot/efi"
 	. "github.com/snapcore/secboot/efi/preinstall"
@@ -2639,6 +2641,187 @@ C7E003CB
 	c.Check(errors.Is(warning, ErrNoDeployedMode), testutil.IsTrue)
 }
 
+func (s *runChecksSuite) TestRunChecksGoodTPMLockout(c *C) {
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		prepare: func() {
+			// Trip the DA logic by setting newMaxTries to 0. This also prevents
+			// the lockout hierarchy availability test from clearing the lockout,
+			// although that test does still run.
+			c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
+		},
+		flags: PermitNoPlatformConfigProfileSupport | PermitNoDriversAndAppsConfigProfileSupport | PermitNoBootManagerConfigProfileSupport,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(warnings, HasLen, 4)
+
+	warning := warnings[0]
+	c.Check(warning, ErrorMatches, `error with TPM2 device: TPM is in DA lockout mode`)
+	var tde *TPM2DeviceError
+	c.Assert(errors.As(warning, &tde), testutil.IsTrue)
+	c.Check(errors.Is(tde, ErrTPMLockout), testutil.IsTrue)
+
+	warning = warnings[1]
+	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
+	var pce *PlatformConfigPCRError
+	c.Check(errors.As(warning, &pce), testutil.IsTrue)
+
+	warning = warnings[2]
+	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
+	var dce *DriversAndAppsConfigPCRError
+	c.Check(errors.As(warning, &dce), testutil.IsTrue)
+
+	warning = warnings[3]
+	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
+	var bmce *BootManagerConfigPCRError
+	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+}
+
+func (s *runChecksSuite) TestRunChecksGoodPostInstallLockoutAvailabilityCheckSkipped(c *C) {
+	meiAttrs := map[string][]byte{
+		"fw_ver": []byte(`0:16.1.27.2176
+0:16.1.27.2176
+0:16.0.15.1624
+`),
+		"fw_status": []byte(`94000245
+09F10506
+00000020
+00004000
+00041F03
+C7E003CB
+`),
+	}
+	devices := map[string][]internal_efi.SysfsDevice{
+		"iommu": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("dmar0", "/sys/devices/virtual/iommu/dmar0", "iommu", nil),
+			efitest.NewMockSysfsDevice("dmar1", "/sys/devices/virtual/iommu/dmar1", "iommu", nil),
+		},
+		"mei": []internal_efi.SysfsDevice{
+			efitest.NewMockSysfsDevice("mei0", "/sys/devices/pci0000:00/0000:00:16.0/mei/mei0", "mei", meiAttrs),
+		},
+	}
+
+	warnings, err := s.testRunChecks(c, &testRunChecksParams{
+		env: efitest.NewMockHostEnvironmentWithOpts(
+			efitest.WithVirtMode(internal_efi.VirtModeNone, internal_efi.DetectVirtModeAll),
+			efitest.WithTPMDevice(tpm2_testutil.NewTransportBackedDevice(s.Transport, false, 1)),
+			efitest.WithLog(efitest.NewLog(c, &efitest.LogOptions{Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256}})),
+			efitest.WithAMD64Environment("GenuineIntel", []uint64{cpuid.SDBG, cpuid.SMX}, 4, map[uint32]uint64{0xc80: 0x40000000, 0x13a: (3 << 1)}),
+			efitest.WithSysfsDevices(devices),
+			efitest.WithMockVars(efitest.MockVars{
+				{Name: "AuditMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "BootCurrent", GUID: efi.GlobalVariable}:            &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x3, 0x0}},
+				{Name: "BootOptionSupport", GUID: efi.GlobalVariable}:      &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x13, 0x03, 0x00, 0x00}},
+				{Name: "DeployedMode", GUID: efi.GlobalVariable}:           &efitest.VarEntry{Attrs: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x1}},
+				{Name: "SetupMode", GUID: efi.GlobalVariable}:              &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x0}},
+				{Name: "OsIndicationsSupported", GUID: efi.GlobalVariable}: &efitest.VarEntry{Attrs: efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess, Payload: []byte{0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			}.SetSecureBoot(true).SetPK(c, efitest.NewSignatureListX509(c, snakeoilCert, efi.MakeGUID(0x03f66fa4, 0x5eee, 0x479c, 0xa408, [...]uint8{0xc4, 0xdc, 0x0a, 0x33, 0xfc, 0xde})))),
+		),
+		tpmPropertyModifiers: map[tpm2.Property]uint32{
+			tpm2.PropertyNVCountersMax:     0,
+			tpm2.PropertyPSFamilyIndicator: 1,
+			tpm2.PropertyManufacturer:      uint32(tpm2.TPMManufacturerINTC),
+		},
+		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
+		prepare: func() {
+			// Take ownership of the lockout hierarchy
+			s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
+		},
+		flags: PermitNoPlatformConfigProfileSupport | PermitNoDriversAndAppsConfigProfileSupport | PermitNoBootManagerConfigProfileSupport | PostInstallChecks,
+		loadedImages: []secboot_efi.Image{
+			&mockImage{
+				contents: []byte("mock shim executable"),
+				digest:   testutil.DecodeHexString(c, "25e1b08db2f31ff5f5d2ea53e1a1e8fda6e1d81af4f26a7908071f1dec8611b7"),
+				signatures: []*efi.WinCertificateAuthenticode{
+					efitest.ReadWinCertificateAuthenticodeDetached(c, shimUbuntuSig4),
+				},
+			},
+			&mockImage{contents: []byte("mock grub executable"), digest: testutil.DecodeHexString(c, "d5a9780e9f6a43c2e53fe9fda547be77f7783f31aea8013783242b040ff21dc0")},
+			&mockImage{contents: []byte("mock kernel executable"), digest: testutil.DecodeHexString(c, "2ddfbd91fa1698b0d133c38ba90dbba76c9e08371ff83d03b5fb4c2e56d7e81f")},
+		},
+		expectedPcrAlg:            tpm2.HashAlgorithmSHA256,
+		expectedUsedSecureBootCAs: []*X509CertificateID{NewX509CertificateID(testutil.ParseCertificate(c, msUefiCACert))},
+		expectedFlags:             NoPlatformConfigProfileSupport | NoDriversAndAppsConfigProfileSupport | NoBootManagerConfigProfileSupport,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(warnings, HasLen, 4)
+
+	warning := warnings[0]
+	c.Check(warning, ErrorMatches, `availability of TPM's lockout hierarchy was not checked because the lockout hierarchy has an authorization value set`)
+	c.Check(errors.Is(warning, ErrTPMLockoutAvailabilityNotChecked), testutil.IsTrue)
+
+	warning = warnings[1]
+	c.Check(warning, ErrorMatches, `error with platform config \(PCR1\) measurements: generating profiles for PCR 1 is not supported yet`)
+	var pce *PlatformConfigPCRError
+	c.Check(errors.As(warning, &pce), testutil.IsTrue)
+
+	warning = warnings[2]
+	c.Check(warning, ErrorMatches, `error with drivers and apps config \(PCR3\) measurements: generating profiles for PCR 3 is not supported yet`)
+	var dce *DriversAndAppsConfigPCRError
+	c.Check(errors.As(warning, &dce), testutil.IsTrue)
+
+	warning = warnings[3]
+	c.Check(warning, ErrorMatches, `error with boot manager config \(PCR5\) measurements: generating profiles for PCR 5 is not supported yet`)
+	var bmce *BootManagerConfigPCRError
+	c.Check(errors.As(warning, &bmce), testutil.IsTrue)
+}
 func (s *runChecksSuite) TestRunChecksBadVirtualMachine(c *C) {
 	_, err := s.testRunChecks(c, &testRunChecksParams{
 		env: efitest.NewMockHostEnvironmentWithOpts(
@@ -2687,7 +2870,6 @@ func (s *runChecksSuite) TestRunChecksBadTPM2DeviceDisabled(c *C) {
 			// Disable owner and endorsement hierarchies
 			c.Assert(s.TPM.HierarchyControl(s.TPM.OwnerHandleContext(), tpm2.HandleOwner, false, nil), IsNil)
 			c.Assert(s.TPM.HierarchyControl(s.TPM.EndorsementHandleContext(), tpm2.HandleEndorsement, false, nil), IsNil)
-
 		},
 	})
 	c.Check(err, ErrorMatches, `error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware`)
@@ -2697,7 +2879,9 @@ func (s *runChecksSuite) TestRunChecksBadTPM2DeviceDisabled(c *C) {
 }
 
 func (s *runChecksSuite) TestRunChecksBadTPMOwnedHierarchiesAndLockedOut(c *C) {
-	// Test case with more than TPM error.
+	// Test case with more than one TPM error - in this case, one of the errors
+	// is ErrTPMLockout which is converted to a warning and suppressed unless
+	// RunChecks completes with success.
 	meiAttrs := map[string][]byte{
 		"fw_ver": []byte(`0:16.1.27.2176
 0:16.1.27.2176
@@ -2737,33 +2921,36 @@ C7E003CB
 		},
 		enabledBanks: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256},
 		prepare: func() {
-			// Trip the DA logic by setting newMaxTries to 0
-			c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 0, 10000, 10000, nil), IsNil)
+			// Trip the DA logic by triggering an auth failure with a DA protected
+			// resource.
+			c.Assert(s.TPM.DictionaryAttackParameters(s.TPM.LockoutHandleContext(), 1, 10000, 10000, nil), IsNil)
+			pub, sensitive, err := objectutil.NewSealedObject(rand.Reader, []byte("foo"), []byte("5678"))
+			c.Assert(err, IsNil)
+			key, err := s.TPM.LoadExternal(sensitive, pub, tpm2.HandleNull)
+			c.Assert(err, IsNil)
+			key.SetAuthValue(nil)
+			_, err = s.TPM.Unseal(key, nil)
+			c.Check(tpm2.IsTPMSessionError(err, tpm2.ErrorAuthFail, tpm2.CommandUnseal, 1), testutil.IsTrue)
 
-			// Take ownership of the storage hierarchy
-			s.HierarchyChangeAuth(c, tpm2.HandleOwner, []byte("1234"))
+			// Take ownership of the lockout hierarchy
+			s.HierarchyChangeAuth(c, tpm2.HandleLockout, []byte("1234"))
 		},
 		flags: PermitNoPlatformConfigProfileSupport | PermitNoDriversAndAppsConfigProfileSupport | PermitNoBootManagerCodeProfileSupport | PermitNoBootManagerConfigProfileSupport | PermitNoSecureBootPolicyProfileSupport,
 	})
-	c.Check(err, ErrorMatches, `2 errors detected:
-- error with TPM2 device: one or more of the TPM hierarchies is already owned:
-  - TPM_RH_OWNER has an authorization value
-- error with TPM2 device: TPM is in DA lockout mode
+	c.Check(err, ErrorMatches, `error with TPM2 device: one or more of the TPM hierarchies is already owned:
+- TPM_RH_LOCKOUT has an authorization value
 `)
 
 	var ce CompoundError
 	c.Assert(err, Implements, &ce)
 	ce = err.(CompoundError)
 	errs := ce.Unwrap()
-	c.Assert(errs, HasLen, 2)
+	c.Assert(errs, HasLen, 1)
 
 	var te *TPM2DeviceError
 	c.Assert(errors.As(errs[0], &te), testutil.IsTrue)
 	var ohe *TPM2OwnedHierarchiesError
 	c.Check(errors.As(te, &ohe), testutil.IsTrue)
-
-	c.Assert(errors.As(errs[1], &te), testutil.IsTrue)
-	c.Check(errors.Is(te, ErrTPMLockout), testutil.IsTrue)
 }
 
 func (s *runChecksSuite) TestRunChecksBadInvalidPCR0Value(c *C) {

--- a/efi/preinstall/error_kinds.go
+++ b/efi/preinstall/error_kinds.go
@@ -104,14 +104,6 @@ const (
 	// type describes the JSON format of the argument.
 	ErrorKindTPMHierarchiesOwned ErrorKind = "tpm-hierarchies-owned"
 
-	// ErrorKindTPMDeviceLockout indicates that the TPM's dictionary attack
-	// logic is currently triggered, preventing the use of any DA protected
-	// resources. This only applies to DA protected resources other than the
-	// lockout hierarchy. This will be accompanied with an argument of the type
-	// TPMDeviceLockoutArgs. The TPMDeviceLockoutArgs type describes the JSON format
-	// of the argument.
-	ErrorKindTPMDeviceLockout ErrorKind = "tpm-device-lockout"
-
 	// ErrorKindTPMDeviceLockoutLockedOut indicates that the TPM's lockout hierarchy
 	// is currently unavailable because it is locked out. This is not the same as
 	// ErrorKindTPMDeviceLockout. As there is no way to test for this other than

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -290,14 +290,16 @@ var (
 	// device available.
 	ErrNoTPM2Device = internal_efi.ErrNoTPM2Device
 
-	// ErrTPMLockout is returned wrapped in TPM2DeviceError if the TPM is in DA
-	// lockout mode. This only applies to the protection that is provided to DA protected
-	// resources other than the lockout hierarchy. This is checked after verifying that
-	// the authorization value for the lockout hierarchy is empty, so it may be easy to
-	// clear this using the TPM2_DictionaryAttackLockReset command as long as the lockout
-	// hierarchy is available. The alternative is to wait for the lockout to clear, the time
-	// of which depends on the pre-programmed lockoutInterval. This test only runs during
-	// pre-install, and not if the PostInstall flag is passed to RunChecks.
+	// ErrTPMLockout is returned wrapped in TPM2DeviceError as a warning if the TPM is in
+	// DA lockout mode. This only applies to the protection that is provided to DA protected
+	// resources other than the lockout hierarchy. This error is only returned as a warning
+	// because the failedTries counter should be reset to zero as part of the install
+	// process (eg, via a subsequent call to [secboot_tpm2.Connection.EnsureProvisioned])
+	// and should be reset to zero as part of a successful boot. If the lockout hierarchy
+	// cannot be used, ErrTPMLockoutLockedOut will be returned for that. If there is no
+	// authorization value for the lockout hierarchy and the lockout hierarchy is available
+	// when RunChecks is called, a DA lockout will be cleared as part of the checks and this
+	// error will not be returned.
 	ErrTPMLockout = errors.New("TPM is in DA lockout mode")
 
 	// ErrTPMLockoutLockoutOut is returned wrapped in TPM2DeviceError if the TPM's
@@ -310,9 +312,13 @@ var (
 	// TPM2_DictionaryAttackLockReset command. If this operation fails with TPM_RC_LOCKOUT
 	// then this error will be returned to indicate that the lockout hierarchy is unavailable
 	// due to it being locked out. It will remain locked out for the pre-programmed
-	// lockoutRecovery time, or until the TPM is cleared using the platform hierarchy. This
-	// test only runs during pre-install, and not if the PostInstall flag is passed to RunChecks.
+	// lockoutRecovery time, or until the TPM is cleared using the platform hierarchy.
 	ErrTPMLockoutLockedOut = errors.New("TPM's lockout hierarchy is unavailable because it is locked out")
+
+	// ErrTPMLockoutAvailabilityNotChecked is returned as a warning if the availability of
+	// the lockout hierarchy cannot be checked because the lockout hierarchy has a non-empty
+	// authorization value.
+	ErrTPMLockoutAvailabilityNotChecked = errors.New("availability of TPM's lockout hierarchy was not checked because the lockout hierarchy has an authorization value set")
 
 	// ErrTPMInsufficientNVCounters is returned wrapped in TPM2DeviceError if there are
 	// insufficient NV counters available for PCR policy revocation. If this is still

--- a/efi/preinstall/tpm_util.go
+++ b/efi/preinstall/tpm_util.go
@@ -68,29 +68,6 @@ func isTPMCommunicationError(err error) (yes bool) {
 	return errors.As(err, &e)
 }
 
-// TPMDeviceLockoutArgs are the arguments associated with errors with an [ErrorKind]
-// of ErrorKindTPMDeviceLockout.
-type TPMDeviceLockoutArgs struct {
-	// IntervalDuration is the maximum amount of time it will
-	// take for the lockout counter to reduce by one so that the lockout
-	// clears, although it will only take a single authorization failure
-	// to trigger the lockout again.
-	IntervalDuration time.Duration `json:"interval-duration"`
-
-	// TotalDuration is the maximum amount of time it will
-	// take for the lockout counter to reduce to zero.
-	TotalDuration time.Duration `json:"total-duration"`
-}
-
-// IsValid indicates whether these arguments are valid. In order to be valid,
-// each member must be a modulus of 1 second and not negative
-func (a *TPMDeviceLockoutArgs) IsValid() bool {
-	if a.IntervalDuration%time.Second != 0 || a.IntervalDuration < 0 {
-		return false
-	}
-	return a.TotalDuration%time.Second == 0 && a.TotalDuration >= 0
-}
-
 // TPMDeviceLockoutRecoveryArg is the argument associated with errors with an [ErrorKind]
 // of ErrorKindTPMDeviceLockoutLockedOut.
 type TPMDeviceLockoutRecoveryArg time.Duration

--- a/efi/preinstall/tpm_util_test.go
+++ b/efi/preinstall/tpm_util_test.go
@@ -32,38 +32,6 @@ type tpmutilSuite struct{}
 
 var _ = Suite(&tpmutilSuite{})
 
-func (*tpmutilSuite) TestDeviceLockoutArgsIsValidTrue(c *C) {
-	args := TPMDeviceLockoutArgs{
-		IntervalDuration: 2 * time.Hour,
-		TotalDuration:    64 * time.Hour,
-	}
-	c.Check(args.IsValid(), testutil.IsTrue)
-}
-
-func (*tpmutilSuite) TestDeviceLockoutArgsIsValidNotMod1False1(c *C) {
-	args := TPMDeviceLockoutArgs{
-		IntervalDuration: (2 * time.Hour) + (15625 * time.Millisecond),
-		TotalDuration:    (64 * time.Hour) + time.Second,
-	}
-	c.Check(args.IsValid(), testutil.IsFalse)
-}
-
-func (*tpmutilSuite) TestDeviceLockoutArgsIsValidNotMod1False2(c *C) {
-	args := TPMDeviceLockoutArgs{
-		IntervalDuration: 2 * time.Hour,
-		TotalDuration:    (64 * time.Hour) + (2 * time.Microsecond),
-	}
-	c.Check(args.IsValid(), testutil.IsFalse)
-}
-
-func (*tpmutilSuite) TestDeviceLockoutArgsIsValidNegativeFalse1(c *C) {
-	args := TPMDeviceLockoutArgs{
-		IntervalDuration: -2 * time.Hour,
-		TotalDuration:    64 * time.Hour,
-	}
-	c.Check(args.IsValid(), testutil.IsFalse)
-}
-
 func (*tpmutilSuite) TestDeviceLockoutRecoveryArgJSON(c *C) {
 	arg := TPMDeviceLockoutRecoveryArg(24 * time.Hour)
 	data, err := json.Marshal(arg)


### PR DESCRIPTION
This makes various changes to the checks of the TPM's dictionary attack
protection and the availability of the TPM's lockout hierarchy:
- Both checks now run in all modes, rather than only during pre-install.
- The ordering has changed - the check for the availability of the
  lockout hierarchy executes first now. This check has the side-effect
  of clearing a DA lockout if it can execute successfully (ie, the
  lockout hierarchy is available and has an empty authorization value),
  suppressing any `ErrTPMLockout` error.
- There is now a `ErrTPMLockoutAvailabilityNotChecked` error that is
  returned as a warning in the `Warnings` field of `CheckResult` if the
  check for the availability of the lockout hierarchy cannot run because
  the lockout hierarchy has a non-empty authorization value.
- `tpm2.Connection.EnsureProvisioned` now resets the TPM's dictionary
  attack protection using `TPM2_DictionaryAttackLockReset` as long as it
  is able to use the lockout hierarchy.
- As a DA lockout should be cleared during installation (eg, by calling
  `tpm2.Connection.EnsureProvisioned`) and as part of a normal boot
  sequence, `ErrTPMLockout` is now only ever returned as a warning as part
  of the `Warnings` field of `CheckResult` as it shouldn't block an install
  from proceeding. As a consequence, the associated `ErrorKind`
  (`ErrorKindTPMDeviceLockout`) and argument struct (`TPMDeviceLockoutArgs`)
  are no longer needed. If it is not possible to clear a DA lockout
  during install or after a normal boot because the lockout hierarchy is
  not available, a `ErrTPMLockoutLockedOut` error will be returned from
  the checks if the test can run.

This kind of fixes https://github.com/canonical/secboot/issues/433 but not as the original description is written -
see the second comment.

In the future, I will adjust the public API to support snapd supplying
the authorization for the lockout hierarchy, so that the lockout
hierarchy availability check can execute even before a factory reset.