### PR TITLE
efi/fw_load_handler.go: copy variables for disable deployed mode

### DIFF
--- a/efi/vars_test.go
+++ b/efi/vars_test.go
@@ -142,6 +142,13 @@ func withSecureBootDisabled() mockVarsConfig {
 	}
 }
 
+func withDeployedModeDisabled() mockVarsConfig {
+	return func(c *C, vars efitest.MockVars) {
+		vars.AddVar("DeployedMode", efi.GlobalVariable, efi.AttributeBootserviceAccess|efi.AttributeRuntimeAccess, []byte{0})
+		vars.AddVar("AuditMode", efi.GlobalVariable, efi.AttributeBootserviceAccess|efi.AttributeRuntimeAccess, []byte{0})
+	}
+}
+
 type mockVarsConfig func(*C, efitest.MockVars)
 
 func makeMockVars(c *C, confs ...mockVarsConfig) efitest.MockVars {


### PR DESCRIPTION
In case of Ubuntu Core with deployed mode disabled using UEFI 2.5, then AuditMode and DeployedMode will be measured. Preinstall check is not in use. We have allowed this prior to snapd 2.71, and we should allow users to update passed it.