### PR TITLE
Add WithExternalUnlockKey option

### DIFF
--- a/activate_external_keys.go
+++ b/activate_external_keys.go
@@ -52,3 +52,9 @@ type externalKeyData struct {
 	r    KeyDataReader // nil when WithExternalKeyData is used.
 	data *KeyData      // nil when WithExternalKeyDataFromReader is used.
 }
+
+type externalUnlockKey struct {
+	name string
+	key  DiskUnlockKey
+	src  ExternalUnlockKeySource
+}

--- a/activate_options.go
+++ b/activate_options.go
@@ -129,6 +129,10 @@ const (
 	// to supply extra key metadata that isn't part of the container header.
 	externalKeyDataKey activateConfigKey = "external-key-data"
 
+	// externalUnlockKey is used by WithExternalUnlockKey to supply an externally
+	// recovered unlock key that can be used to unlock a container.
+	externalUnlockKeyKey activateConfigKey = "external-unlock-key"
+
 	// keyringDescPrefixKey is used by WithKeyringDescriptionPrefix to customize the
 	// prefix of the description for keys added to the kernel keyring during storage
 	// container unlocking.
@@ -267,6 +271,36 @@ func WithExternalKeyDataFromReader(name string, r KeyDataReader) ActivateOption 
 		val: &externalKeyData{
 			name: name,
 			r:    r,
+		},
+	}
+}
+
+// ExternalUnlockKeySource provides a hint about where a key supplied to
+// [WithExternalUnlockKey] comes from.
+type ExternalUnlockKeySource int
+
+const (
+	// ExternalUnlockKeyFromPlatformDevice indicates that a key was recovered
+	// from some platform device.
+	ExternalUnlockKeyFromPlatformDevice ExternalUnlockKeySource = iota
+
+	// ExternalUnlockKeyFromStorageContainer indicates that a key was recovered
+	// from some encrypted storage container.
+	ExternalUnlockKeyFromStorageContainer
+)
+
+// WithExternalUnlockKey makesit possible for callers of [ActivateContext.ActivateContainer]
+// to supply plain unlock keys that can be used to try to unlock the storage container. These
+// keys have a hardcoded priority of 100 so that they are tried before [StorageContainer]
+// keyslots with the default priority (0) and no user authentication. External keys are tried
+// in order of name. This option can be supplied multiple times.
+func WithExternalUnlockKey(name string, key DiskUnlockKey, src ExternalUnlockKeySource) ActivateOption {
+	return &genericSliceOption[*externalUnlockKey]{
+		key: externalUnlockKeyKey,
+		val: &externalUnlockKey{
+			name: name,
+			key:  key,
+			src:  src,
 		},
 	}
 }

--- a/activate_options_test.go
+++ b/activate_options_test.go
@@ -292,6 +292,37 @@ func (*activateOptionsSuite) TestWithExternalKeyDataAndWithExternalKeyDataFromRe
 	})
 }
 
+func (*activateOptionsSuite) TestWithExternalUnlockKey1(c *C) {
+	cfg := make(mockActivateConfig)
+
+	key := testutil.DecodeHexString(c, "442232215cf79f2fbc6d5c4de44f1b1c48a0d68c6edc7639b28777d7b2a3c243")
+	opt := WithExternalUnlockKey("foo", key, ExternalUnlockKeyFromPlatformDevice)
+	opt.ApplyOptionToConfig(cfg)
+
+	v, exists := ActivateConfigGet[[]*ExternalUnlockKey](cfg, ExternalUnlockKeyKey)
+	c.Check(exists, testutil.IsTrue)
+	c.Check(v, DeepEquals, []*ExternalUnlockKey{NewExternalUnlockKey("foo", key, ExternalUnlockKeyFromPlatformDevice)})
+}
+
+func (*activateOptionsSuite) TestWithExternalUnlockKey2(c *C) {
+	cfg := make(mockActivateConfig)
+
+	key1 := testutil.DecodeHexString(c, "442232215cf79f2fbc6d5c4de44f1b1c48a0d68c6edc7639b28777d7b2a3c243")
+	opt := WithExternalUnlockKey("foo", key1, ExternalUnlockKeyFromStorageContainer)
+	opt.ApplyOptionToConfig(cfg)
+
+	key2 := testutil.DecodeHexString(c, "1f11ea11681129341720cfc1fe475df5fa7873bcd5a020cb7eb0eef5399ba096")
+	opt = WithExternalUnlockKey("bar", key2, ExternalUnlockKeyFromStorageContainer)
+	opt.ApplyOptionToConfig(cfg)
+
+	v, exists := ActivateConfigGet[[]*ExternalUnlockKey](cfg, ExternalUnlockKeyKey)
+	c.Check(exists, testutil.IsTrue)
+	c.Check(v, DeepEquals, []*ExternalUnlockKey{
+		NewExternalUnlockKey("foo", key1, ExternalUnlockKeyFromStorageContainer),
+		NewExternalUnlockKey("bar", key2, ExternalUnlockKeyFromStorageContainer),
+	})
+}
+
 func (*activateOptionsSuite) TestWithKeyringDescriptionPrefix1(c *C) {
 	cfg := make(mockActivateConfig)
 

--- a/export_test.go
+++ b/export_test.go
@@ -41,6 +41,7 @@ const (
 	AuthRequestorKey                = authRequestorKey
 	AuthRequestorUserVisibleNameKey = authRequestorUserVisibleNameKey
 	ExternalKeyDataKey              = externalKeyDataKey
+	ExternalUnlockKeyKey            = externalUnlockKeyKey
 	KeyringDescPrefixKey            = keyringDescPrefixKey
 	KeyringKeyPurposeAuxiliary      = keyringKeyPurposeAuxiliary
 	LegacyKeyringKeyDescPathsKey    = legacyKeyringKeyDescPathsKey
@@ -72,6 +73,7 @@ type (
 	ActivateOneContainerStateMachine      = activateOneContainerStateMachine
 	ActivateOneContainerStateMachineFlags = activateOneContainerStateMachineFlags
 	ExternalKeyData                       = externalKeyData
+	ExternalUnlockKey                     = externalUnlockKey
 	KdfParams                             = kdfParams
 	ProtectedKeys                         = protectedKeys
 )
@@ -325,6 +327,14 @@ func NewExternalKeyData(name string, r KeyDataReader, data *KeyData) *externalKe
 		name: name,
 		r:    r,
 		data: data,
+	}
+}
+
+func NewExternalUnlockKey(name string, key DiskUnlockKey, src ExternalUnlockKeySource) *externalUnlockKey {
+	return &externalUnlockKey{
+		name: name,
+		key:  key,
+		src:  src,
 	}
 }
 


### PR DESCRIPTION
This adds a new `WithExternalUnlockKey` option which provides a way to
supply a plain unlock key that can be used to attempt to unlock a
storage container.

External unlock keys don't have a primary key. In order to demonstrate
that a storage container is bound to those that have already been
unlocked, the caller must declare that the unlock key was recovered from
an already unlocked storage container, using the
`ExternalUnlockKeyFromStorageContainer` enum.