### PR TITLE
 efi/preinstall: add method to get pcr option flags from the checks context

### DIFF
--- a/efi/preinstall/checks_context.go
+++ b/efi/preinstall/checks_context.go
@@ -811,6 +811,12 @@ func (c *RunChecksContext) Result() *CheckResult {
 	return c.result
 }
 
+// ProfileOpts returns the [PCRProfileOptionsFlags] that were specified when this
+// context was created with [NewRunChecksContext].
+func (c *RunChecksContext) ProfileOpts() PCRProfileOptionsFlags {
+	return c.profileOpts
+}
+
 // Run will run the specified action, and if that completes successfully will run another
 // iteration of [RunChecks] and test the result against the preferred [WithAutoTCGPCRProfile]
 // configuration. On success, this will return the CheckResult. On failure, this will return

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -205,6 +205,7 @@ func (s *runChecksContextSuite) testRun(c *C, params *testRunChecksContextRunPar
 	c.Check(result.Warnings, ErrorMatches, params.expectedWarningsMatch)
 
 	c.Check(ctx.Result(), DeepEquals, result)
+	c.Check(ctx.ProfileOpts(), DeepEquals, params.profileOpts)
 
 	return nil
 }


### PR DESCRIPTION
Add method to get pcr option flags from the checks context. This provides a simple way for snapd to extract the pcr options from the context whenever all errors are resolved.

This is a follow-up of https://github.com/canonical/secboot/pull/474.
See: https://github.com/canonical/secboot/pull/474#discussion_r2576866748

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35889