### PR TITLE
efi/preinstall: Ignore drivers loaded from firmware volumes

### DIFF
--- a/efi/preinstall/check_pcr4.go
+++ b/efi/preinstall/check_pcr4.go
@@ -234,7 +234,6 @@ NextEvent:
 						}
 						if ok {
 							result.SysprepApps = append(result.SysprepApps, &LoadedImageInfo{
-								Format:         LoadedImageFormatPE,
 								Description:    opt.Description,
 								LoadOptionName: efi.FormatLoadOptionVariableName(efi.LoadOptionClassSysPrep, n),
 								DevicePath:     data.DevicePath,

--- a/efi/preinstall/check_pcr4_test.go
+++ b/efi/preinstall/check_pcr4_test.go
@@ -146,7 +146,6 @@ func (s *pcr4Suite) TestCheckBootManagerCodeMeasurementsGoodWithSysprepApp(c *C)
 		expectedResult: &BootManagerCodeResult{
 			SysprepApps: []*LoadedImageInfo{
 				{
-					Format:         LoadedImageFormatPE,
 					Description:    "Mock sysprep app",
 					LoadOptionName: "SysPrep0001",
 					DevicePath: efi.DevicePath{
@@ -215,7 +214,6 @@ func (s *pcr4Suite) TestCheckBootManagerCodeMeasurementsGoodWithSysprepAppSHA384
 		expectedResult: &BootManagerCodeResult{
 			SysprepApps: []*LoadedImageInfo{
 				{
-					Format:         LoadedImageFormatPE,
 					Description:    "Mock sysprep app",
 					LoadOptionName: "SysPrep0001",
 					DevicePath: efi.DevicePath{

--- a/efi/preinstall/checks_context_test.go
+++ b/efi/preinstall/checks_context_test.go
@@ -1642,7 +1642,6 @@ C7E003CB
 				c.Assert(errs, HasLen, 1)
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,
@@ -1878,7 +1877,6 @@ C7E003CB
 `)
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format:         LoadedImageFormatPE,
 						Description:    "Mock sysprep app",
 						LoadOptionName: "SysPrep0001",
 						DevicePath: efi.DevicePath{
@@ -2331,7 +2329,6 @@ C7E003CB
 
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,
@@ -2546,7 +2543,6 @@ C7E003CB
 
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,
@@ -2691,7 +2687,6 @@ C7E003CB
 
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,
@@ -5523,7 +5518,6 @@ C7E003CB
 
 	imageInfo := []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -5645,7 +5639,6 @@ C7E003CB
 `)
 	imageInfo := []*LoadedImageInfo{
 		{
-			Format:         LoadedImageFormatPE,
 			Description:    "Mock sysprep app",
 			LoadOptionName: "SysPrep0001",
 			DevicePath: efi.DevicePath{
@@ -6194,7 +6187,6 @@ C7E003CB
 
 	imageInfo := []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -6891,7 +6883,6 @@ C7E003CB
 				c.Check(errs, HasLen, 1)
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,
@@ -7015,7 +7006,6 @@ C7E003CB
 				c.Check(errs, HasLen, 1)
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,
@@ -7139,7 +7129,6 @@ C7E003CB
 				c.Check(errs, HasLen, 1)
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,
@@ -7266,7 +7255,6 @@ C7E003CB
 
 				imageInfo := []*LoadedImageInfo{
 					{
-						Format: LoadedImageFormatPE,
 						DevicePath: efi.DevicePath{
 							&efi.ACPIDevicePathNode{
 								HID: 0x0a0341d0,

--- a/efi/preinstall/checks_test.go
+++ b/efi/preinstall/checks_test.go
@@ -1604,7 +1604,6 @@ C7E003CB
 	c.Check(errors.As(warning, &adpe), testutil.IsTrue)
 	c.Check(adpe.Drivers, DeepEquals, []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -1727,7 +1726,6 @@ C7E003CB
 	c.Check(errors.As(warning, &adpe), testutil.IsTrue)
 	c.Check(adpe.Drivers, DeepEquals, []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -1860,7 +1858,6 @@ C7E003CB
 	c.Check(errors.As(warning, &spape), testutil.IsTrue)
 	c.Check(spape.Apps, DeepEquals, []*LoadedImageInfo{
 		{
-			Format:         LoadedImageFormatPE,
 			Description:    "Mock sysprep app",
 			LoadOptionName: "SysPrep0001",
 			DevicePath: efi.DevicePath{
@@ -2002,7 +1999,6 @@ C7E003CB
 	c.Check(errors.As(warning, &spape), testutil.IsTrue)
 	c.Check(spape.Apps, DeepEquals, []*LoadedImageInfo{
 		{
-			Format:         LoadedImageFormatPE,
 			Description:    "Mock sysprep app",
 			LoadOptionName: "SysPrep0001",
 			DevicePath: efi.DevicePath{
@@ -2385,7 +2381,6 @@ C7E003CB
 	c.Check(errors.As(warning, &adpe), testutil.IsTrue)
 	c.Check(adpe.Drivers, DeepEquals, []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -2512,7 +2507,6 @@ C7E003CB
 	c.Check(errors.As(warning, &adpe), testutil.IsTrue)
 	c.Check(adpe.Drivers, DeepEquals, []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -2630,7 +2624,6 @@ C7E003CB
 	c.Check(errors.As(warning, &adpe), testutil.IsTrue)
 	c.Check(adpe.Drivers, DeepEquals, []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -2760,7 +2753,6 @@ C7E003CB
 	c.Check(errors.As(warning, &adpe), testutil.IsTrue)
 	c.Check(adpe.Drivers, DeepEquals, []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -3859,7 +3851,6 @@ C7E003CB
 	c.Check(errors.As(errs[0], &adpe), testutil.IsTrue)
 	c.Check(adpe.Drivers, DeepEquals, []*LoadedImageInfo{
 		{
-			Format: LoadedImageFormatPE,
 			DevicePath: efi.DevicePath{
 				&efi.ACPIDevicePathNode{
 					HID: 0x0a0341d0,
@@ -3973,7 +3964,6 @@ C7E003CB
 	c.Check(errors.As(errs[0], &spape), testutil.IsTrue)
 	c.Check(spape.Apps, DeepEquals, []*LoadedImageInfo{
 		{
-			Format:         LoadedImageFormatPE,
 			Description:    "Mock sysprep app",
 			LoadOptionName: "SysPrep0001",
 			DevicePath: efi.DevicePath{

--- a/efi/preinstall/error_kinds_test.go
+++ b/efi/preinstall/error_kinds_test.go
@@ -36,12 +36,28 @@ var _ = Suite(&errorKindsSuite{})
 func (*errorKindsSuite) TestLoadedImagesInfoArgMarshal(c *C) {
 	arg := LoadedImagesInfoArg{
 		{
-			Format:    LoadedImageFormatBlob,
+			DevicePath: efi.DevicePath{
+				&efi.ACPIDevicePathNode{
+					HID: 0x0a0341d0,
+					UID: 0x0,
+				},
+				&efi.PCIDevicePathNode{
+					Function: 0x1c,
+					Device:   0x2,
+				},
+				&efi.PCIDevicePathNode{
+					Function: 0x0,
+					Device:   0x0,
+				},
+				&efi.MediaRelOffsetRangeDevicePathNode{
+					StartingOffset: 0x38,
+					EndingOffset:   0x11dff,
+				},
+			},
 			DigestAlg: tpm2.HashAlgorithmSHA256,
-			Digest:    testutil.DecodeHexString(c, "111ae52b17b2487348b3dabc80b895bc25e457ab0559270acaf34601a007729d"),
+			Digest:    testutil.DecodeHexString(c, "1e94aaed2ad59a4409f3230dca2ad8c03ef8e3fde77cc47dc7b81bb8b242f3e6"),
 		},
 		{
-			Format:         LoadedImageFormatPE,
 			Description:    "Mock sysprep app",
 			LoadOptionName: "SysPrep0001",
 			DevicePath: efi.DevicePath{
@@ -72,21 +88,37 @@ func (*errorKindsSuite) TestLoadedImagesInfoArgMarshal(c *C) {
 
 	data, err := json.Marshal(arg)
 	c.Check(err, IsNil)
-	c.Check(data, DeepEquals, []byte(`{"images":[{"format":"blob","device-path":{"string":"","bytes":"f/8EAA=="},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="},{"format":"pe","description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}]}`))
+	c.Check(data, DeepEquals, []byte(`{"images":[{"device-path":{"string":"\\PciRoot(0x0)\\Pci(0x2,0x1c)\\Pci(0x0,0x0)\\Offset(0x38,0x11dff)","bytes":"AgEMANBBAwoAAAAAAQEGABwCAQEGAAAABAgYAAAAAAA4AAAAAAAAAP8dAQAAAAAAf/8EAA=="},"digest-alg":"sha256","digest":"HpSq7SrVmkQJ8yMNyirYwD744/3nfMR9x7gbuLJC8+Y="},{"description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}]}`))
 }
 
 func (*errorKindsSuite) TestLoadedImagesInfoUnmarshal(c *C) {
-	data := []byte(`{"images":[{"format":"blob","device-path":{"string":"","bytes":"f/8EAA=="},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="},{"format":"pe","description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}]}`)
+	data := []byte(`{"images":[{"device-path":{"string":"\\PciRoot(0x0)\\Pci(0x2,0x1c)\\Pci(0x0,0x0)\\Offset(0x38,0x11dff)","bytes":"AgEMANBBAwoAAAAAAQEGABwCAQEGAAAABAgYAAAAAAA4AAAAAAAAAP8dAQAAAAAAf/8EAA=="},"digest-alg":"sha256","digest":"HpSq7SrVmkQJ8yMNyirYwD744/3nfMR9x7gbuLJC8+Y="},{"description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}]}`)
 	var arg LoadedImagesInfoArg
 	c.Check(json.Unmarshal(data, &arg), IsNil)
 	c.Check(arg, DeepEquals, LoadedImagesInfoArg{
 		{
-			Format:    LoadedImageFormatBlob,
+			DevicePath: efi.DevicePath{
+				&efi.ACPIDevicePathNode{
+					HID: 0x0a0341d0,
+					UID: 0x0,
+				},
+				&efi.PCIDevicePathNode{
+					Function: 0x1c,
+					Device:   0x2,
+				},
+				&efi.PCIDevicePathNode{
+					Function: 0x0,
+					Device:   0x0,
+				},
+				&efi.MediaRelOffsetRangeDevicePathNode{
+					StartingOffset: 0x38,
+					EndingOffset:   0x11dff,
+				},
+			},
 			DigestAlg: tpm2.HashAlgorithmSHA256,
-			Digest:    testutil.DecodeHexString(c, "111ae52b17b2487348b3dabc80b895bc25e457ab0559270acaf34601a007729d"),
+			Digest:    testutil.DecodeHexString(c, "1e94aaed2ad59a4409f3230dca2ad8c03ef8e3fde77cc47dc7b81bb8b242f3e6"),
 		},
 		{
-			Format:         LoadedImageFormatPE,
 			Description:    "Mock sysprep app",
 			LoadOptionName: "SysPrep0001",
 			DevicePath: efi.DevicePath{
@@ -117,13 +149,13 @@ func (*errorKindsSuite) TestLoadedImagesInfoUnmarshal(c *C) {
 }
 
 func (*errorKindsSuite) TestLoadedImagesInfoUnmarshalErrorInvalidValue(c *C) {
-	data := []byte(`{"images":[{"format":"blob","device-path":{"string":"","bytes":""},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="}]}`)
+	data := []byte(`{"images":[{"device-path":{"string":"","bytes":""},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="}]}`)
 	var arg LoadedImagesInfoArg
 	c.Check(json.Unmarshal(data, &arg), ErrorMatches, `cannot decode device path: cannot decode node 0: unexpected EOF`)
 }
 
 func (*errorKindsSuite) TestLoadedImagesInfoUnmarshalErrorMissingField(c *C) {
-	data := []byte(`{"foo":[{"format":"blob","device-path":{"string":"","bytes":"f/8EAA=="},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="}]}`)
+	data := []byte(`{"foo":[{"device-path":{"string":"\\PciRoot(0x0)\\Pci(0x2,0x1c)\\Pci(0x0,0x0)\\Offset(0x38,0x11dff)","bytes":"AgEMANBBAwoAAAAAAQEGABwCAQEGAAAABAgYAAAAAAA4AAAAAAAAAP8dAQAAAAAAf/8EAA=="},"digest-alg":"sha256","digest":"HpSq7SrVmkQJ8yMNyirYwD744/3nfMR9x7gbuLJC8+Y="}]}`)
 	var arg LoadedImagesInfoArg
 	c.Check(json.Unmarshal(data, &arg), ErrorMatches, `no "images" field`)
 }

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -576,60 +576,39 @@ func (e *DriversAndAppsPCRError) Unwrap() error {
 	return e.err
 }
 
-// LoadedImageFormat describes the format of a loaded image.
-type LoadedImageFormat string
-
-const (
-	// LoadedImageFormatPE is a PE image. These images are measured using the
-	// EV_EFI_BOOT_SERVICES_DRIVER, EV_EFI_RUNTIME_SERVICES_DRIVER and
-	// EV_EFI_BOOT_SERVICES_APPLICATION event types.
-	LoadedImageFormatPE LoadedImageFormat = "pe"
-
-	// LoadedImageFormatBlob is an opaque blob. These images are measured using
-	// the EV_EFI_PLATFORM_FIRMWARE_BLOB and EV_EFI_PLATFORM_FIRMWARE_BLOB2
-	// event types.
-	LoadedImageFormatBlob LoadedImageFormat = "blob"
-)
-
 type devicePathJSON struct {
 	String string `json:"string"`
 	Bytes  []byte `json:"bytes"`
 }
 
 type loadedImageInfoJSON struct {
-	Format         LoadedImageFormat `json:"format"`
-	Description    string            `json:"description,omitempty"`
-	LoadOptionName string            `json:"load-option-name,omitempty"`
-	DevicePath     devicePathJSON    `json:"device-path"`
-	DigestAlg      hashAlgorithmId   `json:"digest-alg"`
-	Digest         []byte            `json:"digest"`
+	Description    string          `json:"description,omitempty"`
+	LoadOptionName string          `json:"load-option-name,omitempty"`
+	DevicePath     devicePathJSON  `json:"device-path"`
+	DigestAlg      hashAlgorithmId `json:"digest-alg"`
+	Digest         []byte          `json:"digest"`
 }
 
 // LoadedImageInfo contains information about a loaded image, which may be a
 // driver or system preparation application.
 type LoadedImageInfo struct {
-	// Format is the format of the loaded image.
-	Format LoadedImageFormat
-
 	// Description is a human readable description of the loaded image,
 	// if there is one.
 	Description string
 
 	// LoadOptionName is the name of the EFI variable containing the
 	// associated EFI_LOAD_OPTION if there is one. This can be empty for
-	// option ROMs and is empty for firmware blobs.
+	// option ROMs.
 	LoadOptionName string
 
-	// DevicePath is the EFI device path of the loaded image if it is
-	// known.
+	// DevicePath is the EFI device path of the loaded image.
 	DevicePath efi.DevicePath
 
 	// DigestAlg is the algorithm of the digest in the Digest field.
 	DigestAlg tpm2.HashAlgorithmId
 
-	// Digest is the digest of the loaded image, using the algorithm
-	// specified in the DigestAlg field. When Format is LoadedImageFormatPE,
-	// this is the Authenticode digest.
+	// Digest is the Authenticode digest of the loaded image, using the
+	// algorithm specified in the DigestAlg field.
 	Digest tpm2.Digest
 }
 
@@ -641,7 +620,6 @@ func (i *LoadedImageInfo) MarshalJSON() ([]byte, error) {
 	}
 
 	info := &loadedImageInfoJSON{
-		Format:         i.Format,
 		Description:    i.Description,
 		LoadOptionName: i.LoadOptionName,
 		DevicePath: devicePathJSON{
@@ -667,7 +645,6 @@ func (i *LoadedImageInfo) UnmarshalJSON(data []byte) error {
 	}
 
 	*i = LoadedImageInfo{
-		Format:         info.Format,
 		Description:    info.Description,
 		LoadOptionName: info.LoadOptionName,
 		DevicePath:     path,
@@ -685,16 +662,8 @@ func (i *LoadedImageInfo) String() string {
 	} else {
 		io.WriteString(&b, "[no description]")
 	}
-	if len(i.DevicePath) > 0 {
-		fmt.Fprintf(&b, " path=%s", i.DevicePath)
-	}
-	switch i.Format {
-	case LoadedImageFormatPE:
-		io.WriteString(&b, " authenticode-digest")
-	default:
-		io.WriteString(&b, " digest")
-	}
-	fmt.Fprintf(&b, "=%v:%x", i.DigestAlg, i.Digest)
+	fmt.Fprintf(&b, " path=%s", i.DevicePath)
+	fmt.Fprintf(&b, " authenticode-digest=%v:%x", i.DigestAlg, i.Digest)
 	if i.LoadOptionName != "" {
 		fmt.Fprintf(&b, " load-option=%s", i.LoadOptionName)
 	}

--- a/efi/preinstall/errors_test.go
+++ b/efi/preinstall/errors_test.go
@@ -64,7 +64,6 @@ func (s *errorsSuite) TestJoinErrorOneError(c *C) {
 
 func (s *errorsSuite) TestLoadedImageInfoMarshalJSON1(c *C) {
 	info := &LoadedImageInfo{
-		Format: LoadedImageFormatPE,
 		DevicePath: efi.DevicePath{
 			&efi.ACPIDevicePathNode{
 				HID: 0x0a0341d0,
@@ -89,24 +88,11 @@ func (s *errorsSuite) TestLoadedImageInfoMarshalJSON1(c *C) {
 
 	data, err := json.Marshal(info)
 	c.Check(err, IsNil)
-	c.Check(data, DeepEquals, []byte(`{"format":"pe","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x2,0x1c)\\Pci(0x0,0x0)\\Offset(0x38,0x11dff)","bytes":"AgEMANBBAwoAAAAAAQEGABwCAQEGAAAABAgYAAAAAAA4AAAAAAAAAP8dAQAAAAAAf/8EAA=="},"digest-alg":"sha256","digest":"HpSq7SrVmkQJ8yMNyirYwD744/3nfMR9x7gbuLJC8+Y="}`))
+	c.Check(data, DeepEquals, []byte(`{"device-path":{"string":"\\PciRoot(0x0)\\Pci(0x2,0x1c)\\Pci(0x0,0x0)\\Offset(0x38,0x11dff)","bytes":"AgEMANBBAwoAAAAAAQEGABwCAQEGAAAABAgYAAAAAAA4AAAAAAAAAP8dAQAAAAAAf/8EAA=="},"digest-alg":"sha256","digest":"HpSq7SrVmkQJ8yMNyirYwD744/3nfMR9x7gbuLJC8+Y="}`))
 }
 
 func (s *errorsSuite) TestLoadedImageInfoMarshalJSON2(c *C) {
 	info := &LoadedImageInfo{
-		Format:    LoadedImageFormatBlob,
-		DigestAlg: tpm2.HashAlgorithmSHA256,
-		Digest:    testutil.DecodeHexString(c, "111ae52b17b2487348b3dabc80b895bc25e457ab0559270acaf34601a007729d"),
-	}
-
-	data, err := json.Marshal(info)
-	c.Check(err, IsNil)
-	c.Check(data, DeepEquals, []byte(`{"format":"blob","device-path":{"string":"","bytes":"f/8EAA=="},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="}`))
-}
-
-func (s *errorsSuite) TestLoadedImageInfoMarshalJSON3(c *C) {
-	info := &LoadedImageInfo{
-		Format:         LoadedImageFormatPE,
 		Description:    "Mock sysprep app",
 		LoadOptionName: "SysPrep0001",
 		DevicePath: efi.DevicePath{
@@ -136,7 +122,7 @@ func (s *errorsSuite) TestLoadedImageInfoMarshalJSON3(c *C) {
 
 	data, err := json.Marshal(info)
 	c.Check(err, IsNil)
-	c.Check(data, DeepEquals, []byte(`{"format":"pe","description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}`))
+	c.Check(data, DeepEquals, []byte(`{"description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}`))
 }
 
 func (s *errorsSuite) TestLoadedImageInfoUnmashalJSON1(c *C) {
@@ -145,7 +131,6 @@ func (s *errorsSuite) TestLoadedImageInfoUnmashalJSON1(c *C) {
 	var info *LoadedImageInfo
 	c.Check(json.Unmarshal(data, &info), IsNil)
 	c.Check(info, DeepEquals, &LoadedImageInfo{
-		Format: LoadedImageFormatPE,
 		DevicePath: efi.DevicePath{
 			&efi.ACPIDevicePathNode{
 				HID: 0x0a0341d0,
@@ -170,24 +155,11 @@ func (s *errorsSuite) TestLoadedImageInfoUnmashalJSON1(c *C) {
 }
 
 func (s *errorsSuite) TestLoadedImageInfoUnmashalJSON2(c *C) {
-	data := []byte(`{"format":"blob","device-path":{"string":"","bytes":"f/8EAA=="},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="}`)
+	data := []byte(`{"description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}`)
 
 	var info *LoadedImageInfo
 	c.Check(json.Unmarshal(data, &info), IsNil)
 	c.Check(info, DeepEquals, &LoadedImageInfo{
-		Format:    LoadedImageFormatBlob,
-		DigestAlg: tpm2.HashAlgorithmSHA256,
-		Digest:    testutil.DecodeHexString(c, "111ae52b17b2487348b3dabc80b895bc25e457ab0559270acaf34601a007729d"),
-	})
-}
-
-func (s *errorsSuite) TestLoadedImageInfoUnmashalJSON3(c *C) {
-	data := []byte(`{"format":"pe","description":"Mock sysprep app","load-option-name":"SysPrep0001","device-path":{"string":"\\PciRoot(0x0)\\Pci(0x1d,0x0)\\Pci(0x0,0x0)\\NVMe(0x1,00-00-00-00-00-00-00-00)\\HD(1,GPT,66de947b-fdb2-4525-b752-30d66bb2b960)\\\\EFI\\Dell\\sysprep.efi","bytes":"AgEMANBBAwoAAAAAAQEGAAAdAQEGAAAAAxcQAAEAAAAAAAAAAAAAAAQBKgABAAAAAAgAAAAAAAAAABAAAAAAAHuU3may/SVFt1Iw1muyuWACAgQEMABcAEUARgBJAFwARABlAGwAbABcAHMAeQBzAHAAcgBlAHAALgBlAGYAaQAAAH//BAA="},"digest-alg":"sha384","digest":"EaTQODPa+g+Zuo2YPFKzXQsm7ZfZYAMTunwn++zab8y6Ch8KlMmXDnPOdZbTpL9E"}`)
-
-	var info *LoadedImageInfo
-	c.Check(json.Unmarshal(data, &info), IsNil)
-	c.Check(info, DeepEquals, &LoadedImageInfo{
-		Format:         LoadedImageFormatPE,
 		Description:    "Mock sysprep app",
 		LoadOptionName: "SysPrep0001",
 		DevicePath: efi.DevicePath{
@@ -217,14 +189,14 @@ func (s *errorsSuite) TestLoadedImageInfoUnmashalJSON3(c *C) {
 }
 
 func (s *errorsSuite) TestLoadedImageInfoUnmashalErrInvalidValue(c *C) {
-	data := []byte(`{"format":"blob","device-path":{"string":"","bytes":"f/8EAA=="},"digest-alg":"","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="}`)
+	data := []byte(`{"device-path":{"string":"\\PciRoot(0x0)\\Pci(0x2,0x1c)\\Pci(0x0,0x0)\\Offset(0x38,0x11dff)","bytes":"AgEMANBBAwoAAAAAAQEGABwCAQEGAAAABAgYAAAAAAA4AAAAAAAAAP8dAQAAAAAAf/8EAA=="},"digest-alg":"","digest":"HpSq7SrVmkQJ8yMNyirYwD744/3nfMR9x7gbuLJC8+Y="}`)
 
 	var info *LoadedImageInfo
 	c.Check(json.Unmarshal(data, &info), ErrorMatches, `unrecognized hash algorithm`)
 }
 
 func (s *errorsSuite) TestLoadedImageInfoUnmashalErrInvalidDevicePath(c *C) {
-	data := []byte(`{"format":"blob","device-path":{"string":"","bytes":""},"digest-alg":"sha256","digest":"ERrlKxeySHNIs9q8gLiVvCXkV6sFWScKyvNGAaAHcp0="}`)
+	data := []byte(`{"device-path":{"string":"","bytes":""},"digest-alg":"sha256","digest":"HpSq7SrVmkQJ8yMNyirYwD744/3nfMR9x7gbuLJC8+Y="}`)
 
 	var info *LoadedImageInfo
 	c.Check(json.Unmarshal(data, &info), ErrorMatches, `cannot decode device path: cannot decode node 0: unexpected EOF`)
@@ -232,7 +204,6 @@ func (s *errorsSuite) TestLoadedImageInfoUnmashalErrInvalidDevicePath(c *C) {
 
 func (s *errorsSuite) TestLoadedImageInfoMarshalString1(c *C) {
 	info := &LoadedImageInfo{
-		Format: LoadedImageFormatPE,
 		DevicePath: efi.DevicePath{
 			&efi.ACPIDevicePathNode{
 				HID: 0x0a0341d0,
@@ -260,17 +231,6 @@ func (s *errorsSuite) TestLoadedImageInfoMarshalString1(c *C) {
 
 func (s *errorsSuite) TestLoadedImageInfoMarshalString2(c *C) {
 	info := &LoadedImageInfo{
-		Format:    LoadedImageFormatBlob,
-		DigestAlg: tpm2.HashAlgorithmSHA256,
-		Digest:    testutil.DecodeHexString(c, "111ae52b17b2487348b3dabc80b895bc25e457ab0559270acaf34601a007729d"),
-	}
-
-	c.Check(info.String(), Equals, `[no description] digest=TPM_ALG_SHA256:111ae52b17b2487348b3dabc80b895bc25e457ab0559270acaf34601a007729d`)
-}
-
-func (s *errorsSuite) TestLoadedImageInfoMarshalString3(c *C) {
-	info := &LoadedImageInfo{
-		Format:         LoadedImageFormatPE,
 		Description:    "Mock sysprep app",
 		LoadOptionName: "SysPrep0001",
 		DevicePath: efi.DevicePath{

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -76,6 +76,7 @@ var (
 	DetectVirtualization                                  = detectVirtualization
 	ErrInvalidLockoutAuthValueSupplied                    = errInvalidLockoutAuthValueSupplied
 	InsertActionProceed                                   = insertActionProceed
+	IsLaunchedFromFirmwareVolume                          = isLaunchedFromFirmwareVolume
 	IsLaunchedFromLoadOption                              = isLaunchedFromLoadOption
 	IsPPIActionAvailable                                  = isPPIActionAvailable
 	IsTPMDiscrete                                         = isTPMDiscrete


### PR DESCRIPTION
The point of returning an error when addon drivers are detected is to
notify the user of the presence of code that is authenticated with a
secure boot authority that we have marked as not trusted to do so (which
is all of them today because we only detect the Microsoft UEFI CAs).

With this in mind, we want to ignore any drivers that are not
authenticated using the secure boot authorized signature database. This
means that we can ignore firmware blobs (as these would have to be
verified using some trust anchor embedded directly in the platform
firmware). For PE images, the platform firmware will contain some policy
that determines whether secure boot image verification is required, based
on the source of the image (eg, flash volume, internal storage, removable
storage, option ROM). Whilst we can't determine this policy directly, it
will generally be configured for no image verification from flash volumes
(as flash volumes are verified earlier on during the PEI phase), and
configured to require image verification from internal storage, removable
storage and option ROMs. This means that we can ignore drivers that are
loaded from flash volumes. In any case, these drivers are not really addon
drivers because they are loaded from the SPI flash, but some firmware
implementations are measuring the launch of drivers for things like onboard
network interfaces that are loaded from a flash volume.

This should reduce a bit of noise.

Fixes: FR-12185