### PR TITLE
cmd/test_efi_fde_compat: Update error messaging

### DIFF
--- a/cmd/test_efi_fde_compat/main.go
+++ b/cmd/test_efi_fde_compat/main.go
@@ -156,6 +156,7 @@ func main() {
 			fmt.Fprintln(os.Stderr)
 			errs := unwrapCompoundError(err)
 			fixable := true
+		ErrLoop:
 			for _, err := range errs {
 				e, ok := err.(*preinstall.WithKindAndActionsError)
 				if !ok {
@@ -166,12 +167,11 @@ func main() {
 					fixable = false
 					break
 				}
-			ActionLoop:
 				for _, action := range e.Actions {
 					switch action {
 					case preinstall.ActionContactOEM, preinstall.ActionContactOSVendor:
 						fixable = false
-						break ActionLoop
+						break ErrLoop
 					}
 				}
 			}


### PR DESCRIPTION
The command prints "not suitable for FDE" on any error, but this is not
necessarily the case if the returned errors can be rectified in some
way.