### PR TITLE
Add user-auth-unavailable keyslot error enum

### DIFF
--- a/activate_state.go
+++ b/activate_state.go
@@ -52,6 +52,7 @@ const (
 	KeyslotErrorInvalidKeyData         KeyslotErrorType = "invalid-key-data"         // The keyslot metadata is invalid.
 	KeyslotErrorInvalidPrimaryKey      KeyslotErrorType = "invalid-primary-key"      // The keyslot's primary key failed the primary key crosscheck.
 	KeyslotErrorIncorrectUserAuth      KeyslotErrorType = "incorrect-user-auth"      // An incorrect user authorization was provided.
+	KeyslotErrorUserAuthUnavailable    KeyslotErrorType = "user-auth-unavailable"    // User authorization was not attempted because it is unavailable.
 	KeyslotErrorPlatformFailure        KeyslotErrorType = "platform-failure"         // There was an error with the platform device.
 	KeyslotErrorUnknown                KeyslotErrorType = "unknown"
 )
@@ -77,6 +78,11 @@ func errorToKeyslotError(err error) KeyslotErrorType {
 
 	if errors.Is(err, ErrInvalidPassphrase) || errors.Is(err, ErrInvalidPIN) || errors.Is(err, errInvalidRecoveryKey) {
 		return KeyslotErrorIncorrectUserAuth
+	}
+
+	var uauErr *UserAuthUnavailableError
+	if errors.As(err, &uauErr) {
+		return KeyslotErrorUserAuthUnavailable
 	}
 
 	var (

--- a/activate_state_test.go
+++ b/activate_state_test.go
@@ -55,6 +55,10 @@ func (*activateStateSuite) TestErrorToKeyslotErrorInvalidRecoveryKey(c *C) {
 	c.Check(ErrorToKeyslotError(fmt.Errorf("%w", ErrInvalidRecoveryKey)), Equals, KeyslotErrorIncorrectUserAuth)
 }
 
+func (*activateStateSuite) TestErrorToKeyslotErrorUserAuthUnavailable(c *C) {
+	c.Check(ErrorToKeyslotError(fmt.Errorf("%w", NewUserAuthUnavailableError(errors.New("some error")))), Equals, KeyslotErrorUserAuthUnavailable)
+}
+
 func (*activateStateSuite) TestErrorToKeyslotErrorPlatformUninitialized(c *C) {
 	c.Check(ErrorToKeyslotError(fmt.Errorf("%w", NewPlatformUninitializedError(errors.New("some error")))), Equals, KeyslotErrorPlatformFailure)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -347,6 +347,10 @@ func NewIncompatibleKeyDataRoleParamsError(err error) *IncompatibleKeyDataRolePa
 	return &IncompatibleKeyDataRoleParamsError{err: err}
 }
 
+func NewUserAuthUnavailableError(err error) *UserAuthUnavailableError {
+	return &UserAuthUnavailableError{err: err}
+}
+
 func NewPlatformUninitializedError(err error) *PlatformUninitializedError {
 	return &PlatformUninitializedError{err: err}
 }

--- a/keydata.go
+++ b/keydata.go
@@ -132,6 +132,26 @@ func (e *PlatformDeviceUnavailableError) Unwrap() error {
 	return e.err
 }
 
+// UserAuthUnavailableError is returned from KeyData methods that
+// require knowledge of a PIN or passphrase but the platform indicates
+// that user authorization is currently unavailable.
+type UserAuthUnavailableError struct {
+	err error
+}
+
+func (e *UserAuthUnavailableError) Error() string {
+	return fmt.Sprintf("user authorization is currently unavailable: %v", e.err)
+}
+
+func (e *UserAuthUnavailableError) Unwrap() error {
+	return e.err
+}
+
+func isUserAuthUnavailableError(err error) bool {
+	var uauErr *UserAuthUnavailableError
+	return errors.As(err, &uauErr)
+}
+
 // DiskUnlockKey is the key used to unlock a LUKS volume.
 type DiskUnlockKey []byte
 
@@ -466,6 +486,8 @@ func processPlatformHandlerError(err error, authMode AuthMode) error {
 			case AuthModePIN:
 				return ErrInvalidPIN
 			}
+		case PlatformHandlerErrorUserAuthUnavailable:
+			return &UserAuthUnavailableError{pe.Err}
 		case PlatformHandlerErrorIncompatibleRole:
 			return &IncompatibleKeyDataRoleParamsError{pe.Err}
 		}

--- a/platform.go
+++ b/platform.go
@@ -48,7 +48,13 @@ const (
 	// PlatformHandlerErrorInvalidAuthKey indicates that an action could not
 	// be performed by PlatformKeyDataHandler because the supplied
 	// authorization key was incorrect.
+	// TODO: Rename this to PlatformHandlerErrorInvalidUserAuthKey
 	PlatformHandlerErrorInvalidAuthKey
+
+	// PlatformHandlerErrorUserAuthUnavailable indicates that an action could
+	// not be performed by PlatformKeyDataHandler because user authorization
+	// is currently unavailable.
+	PlatformHandlerErrorUserAuthUnavailable
 
 	// PlatformHandlerErrorIncompatibleRole indicates that an action could
 	// not be performed by PlatformKeyDataHandler because they key data's


### PR DESCRIPTION
A passphrase or PIN keyslot that cannot be used because of a TPM lockout
may not require any remedial action beyond resetting the TPM's DA
counter, which snapd does on a successful boot. In order to be able to
detect this error separately from other errors (eg,
`incorrect-user-auth`), introduce a new keyslot error enum that is
specific to this condition.

Note that the new error will not overwrite an existing
`incorrect-user-auth` error. If a keyslot fails because of an incorrect
passphrase or PIN and that results in a TPM lockout, then the error will
be `incorrect-user-auth` even though the tpm2 platform will return an
error associated with a TPM lockout on the next attempt. In this case, a
reprovision may be recommended. If no keyslots can be used because the
system boots with the TPM already locked out, then the error will be
`user-auth-unavailable` instead.

Corresponding changes to the tpm2 platform will be in another PR.

Fixes: FR-12369