### PR TITLE
Add invalid-role-params keyslot error enum

### DIFF
--- a/activate_state.go
+++ b/activate_state.go
@@ -49,6 +49,7 @@ type KeyslotErrorType string
 const (
 	KeyslotErrorNone                   KeyslotErrorType = ""
 	KeyslotErrorIncompatibleRoleParams KeyslotErrorType = "incompatible-role-params" // The role parameters for the keyslot are not compatible with the current boot configuration.
+	KeyslotErrorInvalidRoleParams      KeyslotErrorType = "invalid-role-params"      // The role parameters for the keyslot are invalid.
 	KeyslotErrorInvalidKeyData         KeyslotErrorType = "invalid-key-data"         // The keyslot metadata is invalid.
 	KeyslotErrorInvalidPrimaryKey      KeyslotErrorType = "invalid-primary-key"      // The keyslot's primary key failed the primary key crosscheck.
 	KeyslotErrorIncorrectUserAuth      KeyslotErrorType = "incorrect-user-auth"      // An incorrect user authorization was provided.
@@ -66,31 +67,46 @@ func errorToKeyslotError(err error) KeyslotErrorType {
 		return KeyslotErrorInvalidPrimaryKey
 	}
 
-	var ikdErr *InvalidKeyDataError
-	if errors.As(err, &ikdErr) {
-		return KeyslotErrorInvalidKeyData
+	{
+		var e *InvalidKeyDataError
+		if errors.As(err, &e) {
+			return KeyslotErrorInvalidKeyData
+		}
 	}
 
-	var ikdrErr *IncompatibleKeyDataRoleParamsError
-	if errors.As(err, &ikdrErr) {
-		return KeyslotErrorIncompatibleRoleParams
+	{
+		var e *IncompatibleKeyDataRoleParamsError
+		if errors.As(err, &e) {
+			return KeyslotErrorIncompatibleRoleParams
+		}
+	}
+
+	{
+		var e *InvalidKeyDataRoleParamsError
+		if errors.As(err, &e) {
+			return KeyslotErrorInvalidRoleParams
+		}
 	}
 
 	if errors.Is(err, ErrInvalidPassphrase) || errors.Is(err, ErrInvalidPIN) || errors.Is(err, errInvalidRecoveryKey) {
 		return KeyslotErrorIncorrectUserAuth
 	}
 
-	var uauErr *UserAuthUnavailableError
-	if errors.As(err, &uauErr) {
-		return KeyslotErrorUserAuthUnavailable
+	{
+		var e *UserAuthUnavailableError
+		if errors.As(err, &e) {
+			return KeyslotErrorUserAuthUnavailable
+		}
 	}
 
-	var (
-		puErr  *PlatformUninitializedError
-		pduErr *PlatformDeviceUnavailableError
-	)
-	if errors.As(err, &puErr) || errors.As(err, &pduErr) {
-		return KeyslotErrorPlatformFailure
+	{
+		var (
+			pue  *PlatformUninitializedError
+			pdue *PlatformDeviceUnavailableError
+		)
+		if errors.As(err, &pue) || errors.As(err, &pdue) {
+			return KeyslotErrorPlatformFailure
+		}
 	}
 
 	return KeyslotErrorUnknown

--- a/activate_state_test.go
+++ b/activate_state_test.go
@@ -47,6 +47,10 @@ func (*activateStateSuite) TestErrorToKeyslotErrorIncompatibleKeyDataRoleParams(
 	c.Check(ErrorToKeyslotError(fmt.Errorf("%w", NewIncompatibleKeyDataRoleParamsError(errors.New("some error")))), Equals, KeyslotErrorIncompatibleRoleParams)
 }
 
+func (*activateStateSuite) TestErrorToKeyslotErrorInvalidKeyDataRoleParams(c *C) {
+	c.Check(ErrorToKeyslotError(fmt.Errorf("%w", NewInvalidKeyDataRoleParamsError(errors.New("some error")))), Equals, KeyslotErrorInvalidRoleParams)
+}
+
 func (*activateStateSuite) TestErrorToKeyslotErrorInvalidPassphrase(c *C) {
 	c.Check(ErrorToKeyslotError(fmt.Errorf("%w", ErrInvalidPassphrase)), Equals, KeyslotErrorIncorrectUserAuth)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -347,6 +347,10 @@ func NewIncompatibleKeyDataRoleParamsError(err error) *IncompatibleKeyDataRolePa
 	return &IncompatibleKeyDataRoleParamsError{err: err}
 }
 
+func NewInvalidKeyDataRoleParamsError(err error) *InvalidKeyDataRoleParamsError {
+	return &InvalidKeyDataRoleParamsError{err: err}
+}
+
 func NewUserAuthUnavailableError(err error) *UserAuthUnavailableError {
 	return &UserAuthUnavailableError{err: err}
 }

--- a/keydata.go
+++ b/keydata.go
@@ -91,7 +91,7 @@ func (e *InvalidKeyDataError) Unwrap() error {
 
 // IncompatibleKeyDataRoleParamsError is returned from KeyData methods when
 // trying to recover keys if the data that associates the metadata with
-// a role is invalid or incompatible with the current boot settings.
+// a role is incompatible with the current boot settings.
 type IncompatibleKeyDataRoleParamsError struct {
 	err error
 }
@@ -101,6 +101,21 @@ func (e *IncompatibleKeyDataRoleParamsError) Error() string {
 }
 
 func (e *IncompatibleKeyDataRoleParamsError) Unwrap() error {
+	return e.err
+}
+
+// InvalidKeyDataRoleParamsError is returned from KeyData methods when
+// trying to recover keys if the data that associates the metadata with
+// a role is invalid.
+type InvalidKeyDataRoleParamsError struct {
+	err error
+}
+
+func (e *InvalidKeyDataRoleParamsError) Error() string {
+	return fmt.Sprintf("invalid key data role params: %v", e.err)
+}
+
+func (e *InvalidKeyDataRoleParamsError) Unwrap() error {
 	return e.err
 }
 
@@ -490,6 +505,8 @@ func processPlatformHandlerError(err error, authMode AuthMode) error {
 			return &UserAuthUnavailableError{pe.Err}
 		case PlatformHandlerErrorIncompatibleRole:
 			return &IncompatibleKeyDataRoleParamsError{pe.Err}
+		case PlatformHandlerErrorInvalidRoleParams:
+			return &InvalidKeyDataRoleParamsError{pe.Err}
 		}
 	}
 

--- a/platform.go
+++ b/platform.go
@@ -57,9 +57,14 @@ const (
 	PlatformHandlerErrorUserAuthUnavailable
 
 	// PlatformHandlerErrorIncompatibleRole indicates that an action could
-	// not be performed by PlatformKeyDataHandler because they key data's
+	// not be performed by PlatformKeyDataHandler because the key data's
 	// role is incompatible with the current boot configuration.
 	PlatformHandlerErrorIncompatibleRole
+
+	// PlatformHandlerInvalidRoleParams indicates that an action could
+	// not be performed by PlatformKeyDataHandler because the key data's
+	// role parameters are invalid.
+	PlatformHandlerErrorInvalidRoleParams
 )
 
 // PlatformHandlerError is returned from a PlatformKeyDataHandler implementation when


### PR DESCRIPTION
This error is distinct from the existing `incompatible-role-params` error
in the sense that it means that the keyslot needs repairing, whereas the
existing error could mean either that the keyslot needs repairing (if it
was expected to work with the current boot configuration) or that the
keyslot is not expected to work with the current boot configuration (in
which case, a repairable error cannot be communicated).

Fixes: FR-12367