### PR TITLE
tpm2: Return InvalidRoleParams error for invalid PCR policies

### DIFF
--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -41,6 +41,7 @@ var (
 	ComputeV3PcrPolicyCounterAuthPolicies   = computeV3PcrPolicyCounterAuthPolicies
 	ComputeV3PcrPolicyRef                   = computeV3PcrPolicyRef
 	DeriveV3PolicyAuthKey                   = deriveV3PolicyAuthKey
+	ErrPcrPolicyNotAuthorized               = errPcrPolicyNotAuthorized
 	ErrSessionDigestNotFound                = errSessionDigestNotFound
 	IsPCRPolicyDataError                    = isPCRPolicyDataError
 	IsPolicyDataError                       = isPolicyDataError

--- a/tpm2/platform.go
+++ b/tpm2/platform.go
@@ -83,7 +83,7 @@ func (h *platformKeyDataHandler) recoverKeysCommon(data *secboot.PlatformKeyData
 		var e InvalidKeyDataError
 		var p *PCRPolicyDataError
 		switch {
-		case xerrors.As(err, &e):
+		case errors.As(err, &e):
 			return nil, &secboot.PlatformHandlerError{
 				Type: secboot.PlatformHandlerErrorInvalidData,
 				Err:  errors.New(e.msg)}
@@ -99,9 +99,13 @@ func (h *platformKeyDataHandler) recoverKeysCommon(data *secboot.PlatformKeyData
 			return nil, &secboot.PlatformHandlerError{
 				Type: secboot.PlatformHandlerErrorInvalidAuthKey,
 				Err:  err}
-		case errors.As(err, &p):
+		case errors.Is(err, errPcrPolicyNotAuthorized):
 			return nil, &secboot.PlatformHandlerError{
 				Type: secboot.PlatformHandlerErrorIncompatibleRole,
+				Err:  err}
+		case errors.As(err, &p):
+			return nil, &secboot.PlatformHandlerError{
+				Type: secboot.PlatformHandlerErrorInvalidRoleParams,
 				Err:  err}
 		}
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -667,7 +667,7 @@ func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingInvalidPCRProfile(c *C
 	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
 	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorIncompatibleRole)
 	c.Check(err, ErrorMatches, "invalid PCR policy data: cannot complete authorization policy assertions: "+
-		"cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+		"the PCR policy is not authorized for the current configuration")
 }
 
 func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingRevokedPolicy(c *C) {
@@ -687,8 +687,8 @@ func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingRevokedPolicy(c *C) {
 		return ""
 	})
 	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
-	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorInvalidData)
-	c.Check(err, ErrorMatches, "cannot complete authorization policy assertions: "+
+	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorInvalidRoleParams)
+	c.Check(err, ErrorMatches, "invalid PCR policy data: cannot complete authorization policy assertions: "+
 		"the PCR policy has been revoked")
 }
 
@@ -700,7 +700,7 @@ func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingSealedKeyAccessLocked(
 	c.Assert(err, testutil.ConvertibleTo, &secboot.PlatformHandlerError{})
 	c.Check(err.(*secboot.PlatformHandlerError).Type, Equals, secboot.PlatformHandlerErrorIncompatibleRole)
 	c.Check(err, ErrorMatches, "invalid PCR policy data: cannot complete authorization policy assertions: "+
-		"cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+		"the PCR policy is not authorized for the current configuration")
 }
 
 func (s *platformSuite) TestRecoverKeysUnsealErrorHandlingProvisioningError(c *C) {

--- a/tpm2/policy.go
+++ b/tpm2/policy.go
@@ -517,7 +517,10 @@ func isPCRPolicyDataError(err error) bool {
 	return errors.As(err, &e)
 }
 
-var errSessionDigestNotFound = errors.New("current session digest not found in policy data")
+var (
+	errPcrPolicyNotAuthorized = errors.New("the PCR policy is not authorized for the current configuration")
+	errSessionDigestNotFound  = errors.New("current session digest not found in policy data")
+)
 
 // executeAssertions executes one or more PolicyOR assertions in order to support
 // compound policies with more than 8 conditions. It starts by searching for the

--- a/tpm2/policy_v3_test.go
+++ b/tpm2/policy_v3_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"errors"
 	"math/rand"
 	"strconv"
 
@@ -834,7 +835,8 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidSelection1(c *C)
 		},
 	})
 	c.Check(IsPCRPolicyDataError(err), testutil.IsTrue)
-	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+	c.Check(errors.Is(err, ErrPcrPolicyNotAuthorized), testutil.IsTrue)
+	c.Check(err, ErrorMatches, "the PCR policy is not authorized for the current configuration")
 }
 
 func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidSelection2(c *C) {
@@ -1139,7 +1141,8 @@ func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingPCRMismatch(c *C) {
 		fn: func(data *KeyDataPolicy_v3, _ secboot.PrimaryKey) {},
 	})
 	c.Check(IsPCRPolicyDataError(err), testutil.IsTrue)
-	c.Check(err, ErrorMatches, "cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+	c.Check(errors.Is(err, ErrPcrPolicyNotAuthorized), testutil.IsTrue)
+	c.Check(err, ErrorMatches, "the PCR policy is not authorized for the current configuration")
 }
 
 func (s *policyV3Suite) TestExecutePCRPolicyErrorHandlingInvalidPCRPolicyCounterHandle1(c *C) {

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -152,8 +152,8 @@ func (s *sealSuite) testProtectKeyWithTPM(c *C, params *ProtectKeyParams) {
 		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
 		c.Check(err, IsNil)
 		_, _, err = k.RecoverKeys()
-		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization "+
-			"policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization policy assertions: "+
+			"the PCR policy is not authorized for the current configuration")
 	}
 
 	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
@@ -472,8 +472,8 @@ func (s *sealSuite) testPassphraseProtectKeyWithTPM(c *C, params *PassphraseProt
 		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
 		c.Check(err, IsNil)
 		_, _, err = k.RecoverKeysWithPassphrase(passphrase)
-		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization "+
-			"policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization policy assertions: "+
+			"the PCR policy is not authorized for the current configuration")
 	}
 
 	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
@@ -602,7 +602,7 @@ func (s *sealSuite) testPINProtectKeyWithTPM(c *C, params *PINProtectKeyParams, 
 		c.Check(err, IsNil)
 		_, _, err = k.RecoverKeysWithPIN(pin)
 		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization policy assertions: "+
-			"cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+			"the PCR policy is not authorized for the current configuration")
 	}
 
 	if params.PCRPolicyCounterHandle != tpm2.HandleNull {
@@ -705,8 +705,8 @@ func (s *sealSuite) testProtectKeyWithExternalStorageKey(c *C, params *ProtectKe
 		_, err := s.TPM().PCREvent(s.TPM().PCRHandleContext(23), []byte("foo"), nil)
 		c.Check(err, IsNil)
 		_, _, err = k.RecoverKeys()
-		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization "+
-			"policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization policy assertions: "+
+			"the PCR policy is not authorized for the current configuration")
 	}
 }
 

--- a/tpm2/unseal.go
+++ b/tpm2/unseal.go
@@ -20,7 +20,6 @@
 package tpm2
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/canonical/go-tpm2"
@@ -186,7 +185,7 @@ func (k *sealedKeyDataBase) unsealDataFromTPM(tpm *tpm2.TPMContext, authValue []
 	case tpm2.IsTPMWarning(err, tpm2.WarningLockout, tpm2.CommandUnseal):
 		return nil, ErrTPMLockout
 	case tpm2.IsTPMSessionError(err, tpm2.ErrorPolicyFail, tpm2.CommandUnseal, 1):
-		return nil, &PCRPolicyDataError{errors.New("the authorization policy check failed during unsealing")}
+		return nil, InvalidKeyDataError{"the authorization policy check failed during unsealing"}
 	case err != nil:
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
 	}

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -77,7 +77,7 @@ func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRPro
 
 	_, _, err = k.RecoverKeys()
 	c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization "+
-		"policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+		"policy assertions: the PCR policy is not authorized for the current configuration")
 
 	restore()
 
@@ -96,7 +96,7 @@ func (s *updateSuite) testUpdatePCRProtectionPolicy(c *C, data *testUpdatePCRPro
 	c.Check(err, IsNil)
 	_, _, err = k.RecoverKeys()
 	c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization "+
-		"policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+		"policy assertions: the PCR policy is not authorized for the current configuration")
 }
 
 func (s *updateSuite) TestUpdatePCRProtectionPolicyWithPCRPolicyCounter(c *C) {
@@ -171,7 +171,7 @@ func (s *updateSuite) TestRevokeOldPCRProtectionPoliciesWithPCRPolicyCounter(c *
 	err := s.testRevokeOldPCRProtectionPolicies(c, &ProtectKeyParams{
 		PCRProfile:             tpm2test.NewPCRProfileFromCurrentValues(tpm2.HashAlgorithmSHA256, []int{7, 23}),
 		PCRPolicyCounterHandle: s.NextAvailableHandle(c, 0x01810000)})
-	c.Check(err, ErrorMatches, "invalid key data: cannot complete authorization policy assertions: the PCR policy has been revoked")
+	c.Check(err, ErrorMatches, "invalid key data role params: invalid PCR policy data: cannot complete authorization policy assertions: the PCR policy has been revoked")
 }
 
 func (s *updateSuite) TestRevokeOldPCRProtectionPoliciesWithoutPCRPolicyCounter(c *C) {
@@ -201,7 +201,7 @@ func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy(c *C) {
 		restore := s.CloseMockConnection(c)
 		_, _, err = k.RecoverKeys()
 		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization "+
-			"policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+			"policy assertions: the PCR policy is not authorized for the current configuration")
 		restore()
 
 		keys = append(keys, k)
@@ -223,6 +223,6 @@ func (s *updateSuite) TestUpdateKeyDataPCRProtectionPolicy(c *C) {
 	for _, k := range keys {
 		_, _, err := k.RecoverKeys()
 		c.Check(err, ErrorMatches, "incompatible key data role params: invalid PCR policy data: cannot complete authorization "+
-			"policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertions: current session digest not found in policy data")
+			"policy assertions: the PCR policy is not authorized for the current configuration")
 	}
 }


### PR DESCRIPTION
This makes the tpm2 platform return the
`PlatformHandlerErrorInvalidRoleParams` error type when a PCR policy is
invalid, so that the `KeyData` API returns the appropriate
`InvalidKeyDataRoleParamsError`and the `ActivateState` contains the new
`invalid-role-params` keyslot error enum. The existing
`PlatformHandlerErrorIncompatibleRole` is only returned in the case where
the PCR policy is not authorized for the current configuration, but is
otherwise valid.

Fixes: FR-12368