### PR TITLE
Make AuthRequestor indicate the returned credential type

### DIFF
--- a/auth_requestor.go
+++ b/auth_requestor.go
@@ -46,5 +46,7 @@ type AuthRequestor interface {
 	// and can be supplied via the ActivateContext API using the
 	// WithAuthRequestorUserVisibleName option. The authTypes argument is used
 	// to indicate what types of credential are being requested.
-	RequestUserCredential(ctx context.Context, name, path string, authTypes UserAuthType) (string, error)
+	// The implementation returns the requested credential and its type, which
+	// may be a subset of the requested credential types.
+	RequestUserCredential(ctx context.Context, name, path string, authTypes UserAuthType) (string, UserAuthType, error)
 }

--- a/auth_requestor_plymouth_test.go
+++ b/auth_requestor_plymouth_test.go
@@ -102,9 +102,10 @@ func (s *authRequestorPlymouthSuite) testRequestUserCredential(c *C, params *tes
 	requestor, err := NewPlymouthAuthRequestor(new(mockPlymouthAuthRequestorStringer))
 	c.Assert(err, IsNil)
 
-	passphrase, err := requestor.RequestUserCredential(params.ctx, params.name, params.path, params.authTypes)
+	passphrase, passphraseType, err := requestor.RequestUserCredential(params.ctx, params.name, params.path, params.authTypes)
 	c.Check(err, IsNil)
 	c.Check(passphrase, Equals, params.passphrase)
+	c.Check(passphraseType, Equals, params.authTypes)
 
 	c.Check(s.mockPlymouth.Calls(), HasLen, 1)
 	c.Check(s.mockPlymouth.Calls()[0], DeepEquals, []string{"plymouth", "ask-for-password", "--prompt", params.expectedMsg})
@@ -231,7 +232,7 @@ func (s *authRequestorPlymouthSuite) TestRequestUserCredentialObtainFormatString
 	})
 	c.Assert(err, IsNil)
 
-	_, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
+	_, _, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
 	c.Check(err, ErrorMatches, `cannot request format string for requested auth types: some error`)
 }
 
@@ -239,7 +240,7 @@ func (s *authRequestorPlymouthSuite) TestRequestUserCredentialFailure(c *C) {
 	requestor, err := NewPlymouthAuthRequestor(new(mockPlymouthAuthRequestorStringer))
 	c.Assert(err, IsNil)
 
-	_, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
+	_, _, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
 	c.Check(err, ErrorMatches, "cannot execute plymouth ask-for-password: exit status 1")
 }
 
@@ -252,7 +253,7 @@ func (s *authRequestorPlymouthSuite) TestRequestUserCredentialCanceledContext(c 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err = requestor.RequestUserCredential(ctx, "data", "/dev/sda1", UserAuthTypePassphrase)
+	_, _, err = requestor.RequestUserCredential(ctx, "data", "/dev/sda1", UserAuthTypePassphrase)
 	c.Check(err, ErrorMatches, "cannot execute plymouth ask-for-password: context canceled")
 	c.Check(errors.Is(err, context.Canceled), testutil.IsTrue)
 }

--- a/auth_requestor_systemd_test.go
+++ b/auth_requestor_systemd_test.go
@@ -93,9 +93,10 @@ func (s *authRequestorSystemdSuite) testRequestUserCredential(c *C, params *test
 	})
 	c.Assert(err, IsNil)
 
-	passphrase, err := requestor.RequestUserCredential(params.ctx, params.name, params.path, params.authTypes)
+	passphrase, passphraseType, err := requestor.RequestUserCredential(params.ctx, params.name, params.path, params.authTypes)
 	c.Check(err, IsNil)
 	c.Check(passphrase, Equals, params.passphrase)
+	c.Check(passphraseType, Equals, params.authTypes)
 
 	c.Check(s.mockSdAskPassword.Calls(), HasLen, 1)
 	c.Check(s.mockSdAskPassword.Calls()[0], DeepEquals, []string{"systemd-ask-password", "--icon", "drive-harddisk",
@@ -223,7 +224,7 @@ func (s *authRequestorSystemdSuite) TestRequestUserCredentialObtainFormatStringE
 	})
 	c.Assert(err, IsNil)
 
-	_, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
+	_, _, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
 	c.Check(err, ErrorMatches, `cannot request format string for requested auth types: some error`)
 }
 
@@ -235,7 +236,7 @@ func (s *authRequestorSystemdSuite) TestRequestUserCredentialInvalidResponse(c *
 	})
 	c.Assert(err, IsNil)
 
-	_, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
+	_, _, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
 	c.Check(err, ErrorMatches, "systemd-ask-password output is missing terminating newline")
 }
 
@@ -245,7 +246,7 @@ func (s *authRequestorSystemdSuite) TestRequestUserCredentialFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	_, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
+	_, _, err = requestor.RequestUserCredential(context.Background(), "data", "/dev/sda1", UserAuthTypePassphrase)
 	c.Check(err, ErrorMatches, "cannot execute systemd-ask-password: exit status 1")
 }
 
@@ -260,7 +261,7 @@ func (s *authRequestorSystemdSuite) TestRequestUserCredentialCanceledContext(c *
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err = requestor.RequestUserCredential(ctx, "data", "/dev/sda1", UserAuthTypePassphrase)
+	_, _, err = requestor.RequestUserCredential(ctx, "data", "/dev/sda1", UserAuthTypePassphrase)
 	c.Check(err, ErrorMatches, "cannot execute systemd-ask-password: context canceled")
 	c.Check(errors.Is(err, context.Canceled), testutil.IsTrue)
 }

--- a/crypt.go
+++ b/crypt.go
@@ -276,7 +276,7 @@ func (s *activateWithKeyDataState) run() (success bool, err error) {
 		// a maximum of 2 keys with passphrases enabled (Ubuntu Core based desktop on
 		// a UEFI+TPM platform with run+recovery and recovery-only protectors for
 		// ubuntu-data).
-		passphrase, err := s.authRequestor.RequestUserCredential(context.Background(), s.volumeName, s.sourceDevicePath, UserAuthTypePassphrase)
+		passphrase, _, err := s.authRequestor.RequestUserCredential(context.Background(), s.volumeName, s.sourceDevicePath, UserAuthTypePassphrase)
 		if err != nil {
 			passphraseErr = xerrors.Errorf("cannot obtain passphrase: %w", err)
 			continue
@@ -329,7 +329,7 @@ func activateWithRecoveryKey(volumeName, sourceDevicePath string, authRequestor 
 	for ; tries > 0; tries-- {
 		lastErr = nil
 
-		keyString, err := authRequestor.RequestUserCredential(context.Background(), volumeName, sourceDevicePath, UserAuthTypeRecoveryKey)
+		keyString, _, err := authRequestor.RequestUserCredential(context.Background(), volumeName, sourceDevicePath, UserAuthTypeRecoveryKey)
 		if err != nil {
 			lastErr = xerrors.Errorf("cannot obtain recovery key: %w", err)
 			continue


### PR DESCRIPTION
This extends `AuthRequestor.RequestUserCredential` to indicate the type of
the returned credential. Whilst the existing systemd and plymouth
implementations of `AuthRequestor` will always return the requested
credential types (as we don't know what the user intended to enter), a
future boot UI may provide a way for the user to decide whether to enter
a passphrase, PIN or recovery key and for this to be communicated back
to us.

Whilst this isn't particularly useful right now, I wanted to add the
logic to `ActivateContext` because it will affects the logic of a follow-up
PR for sending error messages to Plymouth.

Fixes: FR-12439