### PR TITLE
fix: check stderr output deactivating luks volume

### DIFF
--- a/internal/luks2/activate.go
+++ b/internal/luks2/activate.go
@@ -60,7 +60,7 @@ func Deactivate(volumeName string) error {
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SYSTEMD_LOG_TARGET=console")
 
-	if output, err := cmd.CombinedOutput(); err != nil {
+	if output, err := cmd.CombinedOutput(); err != nil || len(output) > 0 {
 		return fmt.Errorf("systemd-cryptsetup failed with: %v", osutil.OutputErr(output, err))
 	}
 


### PR DESCRIPTION
`systemd-cryptsetup` behaves unexpectedly when trying to unmount a volume that doesn't exist or is already inactive. Even though it fails and prints `Device is not active` to stderr, it still returns an exit code `0`, consequentially the `Deactivate` function doesn't return an error and the operation is reported as successful by `snap-tpmctl`.

I've updated the check to ensure that if there is any output in stderr, it's treated as an error even if the exit code is `0`.

<img width="412" height="110" alt="image" src="https://github.com/user-attachments/assets/1760d3c2-351f-4496-99b6-33b93fb5ef5d" />

