### PR TITLE
fix: update systemd-cryptsetup path for snap environments

### DIFF
--- a/internal/luks2/activate.go
+++ b/internal/luks2/activate.go
@@ -25,28 +25,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 
 	"github.com/snapcore/snapd/osutil"
 )
 
 var (
-	systemdCryptsetupPath string
-	once                  sync.Once
-
 	// getSystemdCryptsetupPath is internal and can be overridden by tests.
 	getSystemdCryptsetupPath = defaultSystemdCryptsetupPath
 )
 
 func defaultSystemdCryptsetupPath() string {
-	once.Do(func() {
-		systemdCryptsetupPath = "/lib/systemd/systemd-cryptsetup"
-		if snapPath := os.Getenv("SNAP"); snapPath != "" {
-			systemdCryptsetupPath = filepath.Join(snapPath, "usr/bin/systemd-cryptsetup")
-		}
-	})
+	root := "/"
+	if p := os.Getenv("SNAP"); p != "" {
+		root = p
+	}
 
-	return systemdCryptsetupPath
+	return filepath.Join(root, "lib", "systemd", "systemd-cryptsetup")
 }
 
 // Activate unlocks the LUKS device at sourceDevicePath using systemd-cryptsetup and creates a device

--- a/internal/luks2/export_test.go
+++ b/internal/luks2/export_test.go
@@ -73,10 +73,10 @@ func MockDataDeviceInfo(stMock *unix.Stat_t) (restore func()) {
 }
 
 func MockSystemdCryptsetupPath(path string) (restore func()) {
-	origFn := getSystemdCryptsetupPath
+	orig := getSystemdCryptsetupPath
 	getSystemdCryptsetupPath = func() string { return path }
 	return func() {
-		getSystemdCryptsetupPath = origFn
+		getSystemdCryptsetupPath = orig
 	}
 }
 


### PR DESCRIPTION
In `snap-tpmctl`, the application run within a strictly confined snap, making the hardcoded path to `systemd-cryptsetup` inaccessible. While this was [previously addressed](https://github.com/canonical/snap-tpmctl/blob/2e92953ebadecb27d385c5a1fb33304a38c861f5/internal/tpm/tpm.go#L16) with a workaround, this PR implements a cleaner and more robust solution to resolve the binary path dinamically.