### PR TITLE
efi, efi/preinstall: Allow opt-in to secure boot being in user mode

### DIFF
--- a/efi/pcr_profile_test.go
+++ b/efi/pcr_profile_test.go
@@ -1377,3 +1377,67 @@ func (s *pcrProfileSuite) TestAddPCRProfileUC20WithDbxUpdateWithAllowInsufficien
 	}, WithSecureBootPolicyProfile(), WithBootManagerCodeProfile(), WithKernelConfigProfile(), WithSignatureDBUpdates(&SignatureDBUpdate{Name: Dbx, Data: msDbxUpdate2}), WithAllowInsufficientDmaProtection())
 	c.Check(err, IsNil)
 }
+
+func (s *pcrProfileSuite) TestAddPCRProfileUC20WithAllowSecureBootUserMode(c *C) {
+	shim := newMockUbuntuShimImage15_7(c)
+	grub := newMockUbuntuGrubImage3(c)
+	recoverKernel := newMockUbuntuKernelImage2(c)
+	runKernel := newMockUbuntuKernelImage3(c)
+
+	err := s.testAddPCRProfile(c, &testAddPCRProfileData{
+		vars: makeMockVars(c, withMsSecureBootConfig(), withSbatLevel([]byte("sbat,1,2022052400\ngrub,2\n")), withDeployedModeDisabled()),
+		log: efitest.NewLog(c, &efitest.LogOptions{
+			Algorithms: []tpm2.HashAlgorithmId{tpm2.HashAlgorithmSHA256, tpm2.HashAlgorithmSHA1},
+		}),
+		alg: tpm2.HashAlgorithmSHA256,
+		loadSequences: NewImageLoadSequences(
+			SnapModelParams(testutil.MakeMockCore20ModelAssertion(c, map[string]interface{}{
+				"authority-id": "fake-brand",
+				"series":       "16",
+				"brand-id":     "fake-brand",
+				"model":        "fake-model",
+				"grade":        "secured",
+			}, "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij")),
+		).Append(
+			NewImageLoadActivity(shim).Loads(
+				NewImageLoadActivity(grub, KernelCommandlineParams("console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=recover")).Loads(
+					NewImageLoadActivity(grub, KernelCommandlineParams("console=ttyS0 console=tty1 panic=-1 systemd.gpt_auto=0 snapd_recovery_mode=run")).Loads(
+						NewImageLoadActivity(runKernel),
+					),
+					NewImageLoadActivity(recoverKernel),
+				),
+			),
+		),
+		expected: []tpm2.PCRValues{
+			{
+				tpm2.HashAlgorithmSHA256: {
+					4:  testutil.DecodeHexString(c, "bec6121586508581e08a41244944292ef452879f8e19c7f93d166e912c6aac5e"),
+					7:  testutil.DecodeHexString(c, "3d65dbe406e9427d402488ea4f87e07e8b584c79c578a735d48d21a6405fc8bb"),
+					12: testutil.DecodeHexString(c, "fd1000c6f691c3054e2ff5cfacb39305820c9f3534ba67d7894cb753aa85074b"),
+				},
+			},
+			{
+				tpm2.HashAlgorithmSHA256: {
+					4:  testutil.DecodeHexString(c, "c731a39b7fc6475c7d8a9264e704902157c7cee40c22f59fa1690ea99ff70c67"),
+					7:  testutil.DecodeHexString(c, "3d65dbe406e9427d402488ea4f87e07e8b584c79c578a735d48d21a6405fc8bb"),
+					12: testutil.DecodeHexString(c, "5b354c57a61bb9f71fcf596d7e9ef9e2e0d6f4ad8151c9f358e6f0aaa7823756"),
+				},
+			},
+			{
+				tpm2.HashAlgorithmSHA256: {
+					4:  testutil.DecodeHexString(c, "bec6121586508581e08a41244944292ef452879f8e19c7f93d166e912c6aac5e"),
+					7:  testutil.DecodeHexString(c, "d6a99cb0ea5ac9290b65b8847bb48613fc504a798229fb37e88b7b33337f4c60"),
+					12: testutil.DecodeHexString(c, "fd1000c6f691c3054e2ff5cfacb39305820c9f3534ba67d7894cb753aa85074b"),
+				},
+			},
+			{
+				tpm2.HashAlgorithmSHA256: {
+					4:  testutil.DecodeHexString(c, "c731a39b7fc6475c7d8a9264e704902157c7cee40c22f59fa1690ea99ff70c67"),
+					7:  testutil.DecodeHexString(c, "d6a99cb0ea5ac9290b65b8847bb48613fc504a798229fb37e88b7b33337f4c60"),
+					12: testutil.DecodeHexString(c, "5b354c57a61bb9f71fcf596d7e9ef9e2e0d6f4ad8151c9f358e6f0aaa7823756"),
+				},
+			},
+		},
+	}, WithSecureBootPolicyProfile(), WithBootManagerCodeProfile(), WithKernelConfigProfile(), WithAllowSecureBootUserMode())
+	c.Check(err, IsNil)
+}

--- a/efi/preinstall/errors.go
+++ b/efi/preinstall/errors.go
@@ -926,10 +926,8 @@ var (
 	ErrNoSecureBoot = errors.New("secure boot should be enabled in order to generate secure boot profiles")
 
 	// ErrNoDeployedMode is returned wrapped in SecureBootPolicyPCRError to indicate
-	// that deployed mode is not enabled. In the future, this package will permit
-	// generation of profiles on systems that implement UEFI >= 2.5 that are in user
-	// mode, but this is not the case today.
-	ErrNoDeployedMode = errors.New("deployed mode should be enabled in order to generate secure boot profiles")
+	// that deployed mode is not enabled.
+	ErrNoDeployedMode = errors.New("secure boot is enabled but not in deployed mode")
 
 	// ErrWeakSecureBootAlgorithmDetected is returned wrapped in a type that implements CompoundError and
 	// indicates that weak algorithms were detected during secure boot verification, such as authenticating

--- a/efi/preinstall/export_test.go
+++ b/efi/preinstall/export_test.go
@@ -58,6 +58,7 @@ const (
 	InsufficientDMAProtectionDetected           = insufficientDMAProtectionDetected
 	SecureBootIncludesWeakAlg                   = secureBootIncludesWeakAlg
 	SecureBootPreOSVerificationIncludesDigest   = secureBootPreOSVerificationIncludesDigest
+	SecureBootNoDeployedMode                    = secureBootNoDeployedMode
 	StartupLocalityNotProtected                 = startupLocalityNotProtected
 )
 

--- a/efi/preinstall/profile.go
+++ b/efi/preinstall/profile.go
@@ -474,6 +474,11 @@ func (o *pcrProfileAutoSetPcrsOption) ApplyOptionTo(visitor internal_efi.PCRProf
 			return fmt.Errorf("cannot add DMA allow insufficient protection profile option: %w", err)
 		}
 	}
+	if _, permitted := o.result.AcceptedErrors[ErrorKindInvalidSecureBootMode]; permitted {
+		if err := secboot_efi.WithAllowSecureBootUserMode().ApplyOptionTo(visitor); err != nil {
+			return fmt.Errorf("cannot add profile option for secure boot user mode: %w", err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
The preinstall checks currently require a system to be in deployed mode
(for UEFI versions >= 2.5). Relax this to allow an opt-in to user mode
for systems that run UEFI versions >= 2.5 but where the firmware
settings don't permit enabling deployed mode.

To support this, a new `WithSecureBootUserMode` option is added for
`AddPCRProfile`. If this option is supplied on a system that is in user
mode, 2 branches will be created. One of these will include the user
mode related measurements and the other branch will be for deployed
mode, which allows a system to transition from user mode to deployed
mode without requiring a recovery key.

This is an opt-in rather than automatic to avoid the scenario where a
system is initially in deployed mode but a later firmware configuration
change reverts to user mode, the user enters their recovery key on the
next boot and then snapd automatically repairs with a PCR profile that
includes the newly degraded setting. In this case, we want the user to
explicitly opt-in to this as an acknowledgement that the firmware
configuration has been changed.

Fixes: FR-12184
Fixes: https://github.com/canonical/secboot/issues/502