### PR TITLE
tpm2: Make EnsureProvisioned accept a variable length set of options

### DIFF
--- a/internal/compattest/v0_test.go
+++ b/internal/compattest/v0_test.go
@@ -62,7 +62,7 @@ func (s *compatTestV0Suite) TestUnseal2(c *C) {
 
 func (s *compatTestV0Suite) TestUnsealAfterReprovision(c *C) {
 	// Test that reprovisioning doesn't touch the legacy lock NV index if it is valid
-	c.Assert(s.TPM().EnsureProvisioned(secboot_tpm2.ProvisionModeWithoutLockout, nil), IsNil)
+	c.Assert(s.TPM().EnsureProvisioned(secboot_tpm2.ProvisionWithoutLockout()), IsNil)
 	s.testUnseal(c, s.absPath("pcrSequence.1"))
 }
 

--- a/internal/compattest/v1_test.go
+++ b/internal/compattest/v1_test.go
@@ -51,7 +51,7 @@ func (s *compatTestV1Suite) TestUnseal2(c *C) {
 
 func (s *compatTestV1Suite) TestUnsealAfterReprovision(c *C) {
 	// This should still work because the primary key doesn't change.
-	c.Assert(s.TPM().EnsureProvisioned(secboot_tpm2.ProvisionModeWithoutLockout, nil), IsNil)
+	c.Assert(s.TPM().EnsureProvisioned(secboot_tpm2.ProvisionWithoutLockout()), IsNil)
 	s.testUnseal(c, s.absPath("pcrSequence.1"))
 }
 

--- a/tools/gen-compattest-data/main.go
+++ b/tools/gen-compattest-data/main.go
@@ -167,7 +167,7 @@ func run() int {
 	}
 	defer tpm.Close()
 
-	if err := tpm.EnsureProvisioned(secboot_tpm2.ProvisionModeFull, []byte("1234")); err != nil {
+	if err := tpm.EnsureProvisioned(secboot_tpm2.WithProvisionNewLockoutAuthValue([]byte("1234"))); err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot provision TPM: %v\n", err)
 		return 1
 	}

--- a/tpm2/export_test.go
+++ b/tpm2/export_test.go
@@ -27,9 +27,12 @@ import (
 
 // Export constants for testing
 const (
-	LockNVHandle          = lockNVHandle
-	ResetPcrPolicyVersion = resetPcrPolicyVersion
-	SrkTemplateHandle     = srkTemplateHandle
+	LockNVHandle                = lockNVHandle
+	ProvisionModeWithoutLockout = provisionModeWithoutLockout
+	ProvisionModeFull           = provisionModeFull
+	ProvisionModeClear          = provisionModeClear
+	ResetPcrPolicyVersion       = resetPcrPolicyVersion
+	SrkTemplateHandle           = srkTemplateHandle
 )
 
 // Export variables and unexported functions for testing
@@ -145,6 +148,20 @@ func NewPcrPolicyData_v3(v2 *PcrPolicyData_v2) *PcrPolicyData_v3 {
 }
 
 type PlatformKeyDataHandler = platformKeyDataHandler
+
+type ProvisionMode = provisionMode
+
+func (m ProvisionMode) Option() EnsureProvisionedOption {
+	switch m {
+	case provisionModeWithoutLockout:
+		return ProvisionWithoutLockout()
+	case provisionModeClear:
+		return WithClearBeforeProvision()
+	default:
+		return func(_ *ensureProvisionedParams) {}
+	}
+}
+
 type SealedKeyDataBase = sealedKeyDataBase
 type SnapModelHasher = snapModelHasher
 type StaticPolicyData_v0 = staticPolicyData_v0

--- a/tpm2/key_sealer_test.go
+++ b/tpm2/key_sealer_test.go
@@ -50,7 +50,7 @@ func (s *sealedObjectKeySealerSuite) SetUpSuite(c *C) {
 func (s *sealedObjectKeySealerSuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 
-	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 

--- a/tpm2/platform_legacy_test.go
+++ b/tpm2/platform_legacy_test.go
@@ -49,7 +49,7 @@ func (s *platformLegacySuite) SetUpSuite(c *C) {
 func (s *platformLegacySuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil), Equals, ErrTPMProvisioningRequiresLockout)
+	c.Check(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()), Equals, ErrTPMProvisioningRequiresLockout)
 }
 
 var _ = Suite(&platformLegacySuite{})

--- a/tpm2/platform_test.go
+++ b/tpm2/platform_test.go
@@ -59,7 +59,7 @@ func (s *platformSuite) SetUpSuite(c *C) {
 func (s *platformSuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil), Equals, ErrTPMProvisioningRequiresLockout)
+	c.Check(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()), Equals, ErrTPMProvisioningRequiresLockout)
 
 	s.lastEncryptedPayload = nil
 	s.AddCleanup(MockSecbootNewKeyData(func(params *secboot.KeyParams) (*secboot.KeyData, error) {

--- a/tpm2/provisioning.go
+++ b/tpm2/provisioning.go
@@ -51,22 +51,22 @@ const (
 	srkTemplateHandle tpm2.Handle = 0x01810001
 )
 
-// ProvisionMode is used to control the behaviour of Connection.EnsureProvisioned.
-type ProvisionMode int
+// provisionMode is used to control the behaviour of Connection.EnsureProvisioned.
+type provisionMode int
 
 const (
-	// ProvisionModeWithoutLockout specifies that the TPM should be refreshed without performing operations that require the use of the
+	// provisionModeWithoutLockout specifies that the TPM should be refreshed without performing operations that require the use of the
 	// lockout hierarchy. Operations that won't be performed in this mode are disabling owner clear, configuring the dictionary attack
 	// parameters, and setting the authorization value for the lockout hierarchy.
-	ProvisionModeWithoutLockout ProvisionMode = iota
+	provisionModeWithoutLockout provisionMode = iota
 
-	// ProvisionModeFull specifies that the TPM should be fully provisioned without clearing it. This requires use of the lockout
+	// provisionModeFull specifies that the TPM should be fully provisioned without clearing it. This requires use of the lockout
 	// hierarchy.
-	ProvisionModeFull
+	provisionModeFull
 
-	// ProvisionModeClear specifies that the TPM should be fully provisioned after clearing it. This requires use of the lockout
+	// provisionModeClear specifies that the TPM should be fully provisioned after clearing it. This requires use of the lockout
 	// hierarchy.
-	ProvisionModeClear
+	provisionModeClear
 )
 
 // provisionPrimaryKey provisions a primary key in the specified hierarchy at the specified persistent
@@ -194,14 +194,119 @@ func removeStoredSrkTemplate(tpm *tpm2.TPMContext, session tpm2.SessionContext) 
 	return nil
 }
 
-func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAuth []byte, srkTemplate *tpm2.Public, useExistingSrkTemplate bool) error {
+type ensureProvisionedParams struct {
+	mode                   provisionMode
+	newLockoutAuthValue    []byte
+	srkTemplate            *tpm2.Public
+	useExistingSrkTemplate bool
+}
+
+type EnsureProvisionedOption func(*ensureProvisionedParams)
+
+// ProvisionModeWithoutLockout tells [Connection.EnsureProvisioned] to not perform any actions
+// that require use of the TPM's lockout hierarchy. If the TPM indicates that use of the lockout
+// hierarchy is required to fully provision the TPM (eg, to disable owner clear, set the lockout
+// hierarchy authorization value or configure the DA lockout parameters), then a
+// [ErrTPMProvisioningRequiresLockout] error will be returned. In this scenario,
+// [Connection.EnsureProvisioned] will complete all operations that can be completed without using
+// the lockout hierarchy, but it should be called again without this option.
+func ProvisionWithoutLockout() EnsureProvisionedOption {
+	return func(p *ensureProvisionedParams) {
+		if p.mode == provisionModeClear {
+			panic("ProvisionWithoutLockout conflicts with WithClearBeforeProvision")
+		}
+		p.mode = provisionModeWithoutLockout
+	}
+}
+
+// WithClearBeforeProvision tells [Connection.EnsureProvisioned] to clear the TPM before provisioning
+// it. If owner clear has been disabled (which will be the case if the TPM has previously been provisioned
+// with this function), then [ErrTPMClearRequiresPPI] will be returned. In this case, the TPM must be cleared
+// via the physical presence interface by calling [RequestTPMClearUsingPPI] and performing a system restart.
+// Note that clearing the TPM makes all previously sealed keys permanently unrecoverable. This option should
+// normally be used when resetting a device to factory settings (ie, performing a new installation).
+func WithClearBeforeProvision() EnsureProvisionedOption {
+	return func(p *ensureProvisionedParams) {
+		if p.mode == provisionModeWithoutLockout {
+			panic("WithClearBeforeProvision conflicts with ProvisionWithoutLockout")
+		}
+		p.mode = provisionModeClear
+	}
+}
+
+// WithProvisionNewLockoutAuthValue supplies the value to set the TPM's lockout hierarchy authorization
+// value to. If this option is not supplied and [ProvisionWithoutLockout] is not supplied, then
+// [Connection.EnsureProvisioned] will set it to an empty value. If [ProvisionWithoutLockout] is supplied,
+// then this option has no effect.
+func WithProvisionNewLockoutAuthValue(authValue []byte) EnsureProvisionedOption {
+	return func(p *ensureProvisionedParams) {
+		p.newLockoutAuthValue = authValue
+	}
+}
+
+// WithCustomSRKTemplate tells [Connection.EnsureProvisioned] to create the storage root key using the supplied
+// custom template rather than the one defined in the "TCG TPM v2.0 Provisioning Guidance" spec. The template will
+// be persisted in a NV index and will be used in future calls to [Connection.EnsureProvisioned] if called
+// without this option.
+func WithCustomSRKTemplate(template *tpm2.Public) EnsureProvisionedOption {
+	return func(p *ensureProvisionedParams) {
+		p.srkTemplate = template
+		p.useExistingSrkTemplate = false
+	}
+}
+
+// EnsureProvisioned prepares the TPM for full disk encryption. The mode parameter specifies the behaviour of this function.
+//
+// This function will create and persist both a storage root key and an endorsement key. Both of these will be persisted
+// at the handles specied in the "TCG TPM v2.0 Provisioning Guidance" specification. The endorsement key will be created
+// using the RSA template defined in the "TCG EK Credential Profile for TPM Family 2.0" specification. The storage root
+// key will be created using the RSA template defined in the "TCG TPM v2.0 Provisioning Guidance" specification unless the
+// TPM has previously been provisioned with a custom SRK template using the [WithProvisionCustomSRKTemplate] option and the
+// [WithClearBeforeProvision] option isn't supplied, in which case, the originally supplied template will be used instead. If
+// there are any objects already stored at the locations required for either primary key, then this function will evict them
+// automatically from the TPM. These operations both require the use of the storage and endorsement hierarchies. If the
+// [WithClearBeforeProvision] option is not supplied, then knowledge of the authorization values for these hierarchies is
+// required. Whilst these will be empty after clearing the TPM, if they have been set since clearing the TPM then they will
+// need to be provided by calling Connection.EndorsementHandleContext().SetAuthValue() and
+// Connection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the wrong value is provided for either
+// authorization, then a [AuthFailError] error will be returned. If the correct authorization values are not known, then the
+// only way to recover from this is to clear the TPM either by calling this function with the [WithClearBeforeProvision]
+// option (and providing the correct authorization value for the lockout hierarchy), or by using the physical presence interface.
+//
+// If the [ProvisionWithoutLockout] option is not supplied, then owner clear will be disabled, and the parameters of the TPM's
+// dictionary attack logic will be configured to appropriate values. The authorization value for the lockout hierarchy will
+// be set to the value supplied to [WithProvisionNewLockoutAuthValue], or the empty value if not supplied.
+//
+// If the [ProvisionWithoutLockout] option is not supplied, this function performs operations that require the use of the lockout
+// hierarchy (detailed above), and knowledge of the lockout hierarchy's authorization value. This must be provided by calling
+// Connection.LockoutHandleContext().SetAuthValue() prior to this call. If the wrong lockout hierarchy authorization value is
+// provided, then a [AuthFailError] error will be returned. If this happens, the TPM will have entered dictionary attack lockout
+// mode for the lockout hierarchy. Further calls will result in a [ErrTPMLockout] error being returned. The only way to recover
+// from this is to either wait for the pre-programmed recovery time to expire, or to clear the TPM via the physical presence
+// interface by calling [RequestTPMClearUsingPPI]. If the lockout hierarchy authorization value is not known then the
+// [ProvisionWithoutLockout] option should be supplied, with the caveat that this mode cannot fully provision the TPM.
+//
+// If [WithClearBeforeProvision] is not supplied, this function will not affect the ability to recover sealed keys that
+// can currently be recovered.
+func (t *Connection) EnsureProvisioned(options ...EnsureProvisionedOption) error {
+	params := &ensureProvisionedParams{
+		mode:                   provisionModeFull,
+		useExistingSrkTemplate: true,
+	}
+	for _, opt := range options {
+		opt(params)
+	}
+	if params.srkTemplate != nil && !params.srkTemplate.IsStorageParent() {
+		return errors.New("supplied SRK template is not valid for a parent key")
+	}
+
 	session := t.HmacSession()
 
 	val, err := t.GetCapabilityTPMProperty(tpm2.PropertyPermanent)
 	if err != nil {
-		return xerrors.Errorf("cannot fetch permanent properties: %w", err)
+		return fmt.Errorf("cannot fetch permanent properties: %w", err)
 	}
-	if mode == ProvisionModeClear {
+	if params.mode == provisionModeClear {
 		if tpm2.PermanentAttributes(val)&tpm2.AttrDisableClear > 0 {
 			return ErrTPMClearRequiresPPI
 		}
@@ -214,7 +319,7 @@ func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAut
 			case tpm2.IsTPMWarning(err, tpm2.WarningLockout, tpm2.CommandClear):
 				return ErrTPMLockout
 			}
-			return xerrors.Errorf("cannot clear the TPM: %w", err)
+			return fmt.Errorf("cannot clear the TPM: %w", err)
 		}
 	}
 
@@ -226,30 +331,30 @@ func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAut
 		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
 			return AuthFailError{tpm2.HandleEndorsement}
 		default:
-			return xerrors.Errorf("cannot provision endorsement key: %w", err)
+			return fmt.Errorf("cannot provision endorsement key: %w", err)
 		}
 	}
 
 	// Reinitialize the connection, which creates a new session that's salted with a value protected with the newly provisioned EK.
 	// This will have a symmetric algorithm for parameter encryption during HierarchyChangeAuth.
 	if err := t.init(); err != nil {
-		return xerrors.Errorf("cannot reinitialize TPM connection after provisioning endorsement key: %w", err)
+		return fmt.Errorf("cannot reinitialize TPM connection after provisioning endorsement key: %w", err)
 	}
 	session = t.HmacSession()
 
 	// Provision a storage root key
-	if !useExistingSrkTemplate && mode != ProvisionModeClear {
+	if !params.useExistingSrkTemplate && params.mode != provisionModeClear {
 		// If we're not reusing the existing custom template, remove it. We don't
-		// need to do this if mode == ProvisionModeClear because it will have already
+		// need to do this if mode == provisionModeClear because it will have already
 		// been removed.
 		if err := removeStoredSrkTemplate(t.TPMContext, session); err != nil {
-			return xerrors.Errorf("cannot remove stored custom SRK template: %w", err)
+			return fmt.Errorf("cannot remove stored custom SRK template: %w", err)
 		}
 	}
-	if srkTemplate != nil {
+	if params.srkTemplate != nil {
 		// Persist the new custom template
-		if err := storeSrkTemplate(t.TPMContext, srkTemplate, session); err != nil {
-			return xerrors.Errorf("cannot store custom SRK template: %w", err)
+		if err := storeSrkTemplate(t.TPMContext, params.srkTemplate, session); err != nil {
+			return fmt.Errorf("cannot store custom SRK template: %w", err)
 		}
 	}
 
@@ -259,15 +364,15 @@ func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAut
 		case isAuthFailError(err, tpm2.AnyCommandCode, 1):
 			return AuthFailError{tpm2.HandleOwner}
 		default:
-			return xerrors.Errorf("cannot provision storage root key: %w", err)
+			return fmt.Errorf("cannot provision storage root key: %w", err)
 		}
 	}
 	t.provisionedSrk = srk
 
-	if mode == ProvisionModeWithoutLockout {
+	if params.mode == provisionModeWithoutLockout {
 		val, err := t.GetCapabilityTPMProperty(tpm2.PropertyPermanent)
 		if err != nil {
-			return xerrors.Errorf("cannot fetch permanent properties to determine if lockout hierarchy is required: %w", err)
+			return fmt.Errorf("cannot fetch permanent properties to determine if lockout hierarchy is required: %w", err)
 		}
 		required := tpm2.AttrLockoutAuthSet | tpm2.AttrDisableClear
 		mask := required | tpm2.AttrInLockout
@@ -277,7 +382,7 @@ func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAut
 
 		props, err := t.GetCapabilityTPMProperties(tpm2.PropertyMaxAuthFail, 3)
 		if err != nil {
-			return xerrors.Errorf("cannot fetch DA parameters to determine if lockout hierarchy is required: %w", err)
+			return fmt.Errorf("cannot fetch DA parameters to determine if lockout hierarchy is required: %w", err)
 		}
 		if props[0].Property != tpm2.PropertyMaxAuthFail || props[1].Property != tpm2.PropertyLockoutInterval || props[2].Property != tpm2.PropertyLockoutRecovery {
 			return errors.New("TPM returned values for the wrong properties")
@@ -300,7 +405,7 @@ func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAut
 		case tpm2.IsTPMWarning(err, tpm2.WarningLockout, tpm2.CommandDictionaryAttackParameters):
 			return ErrTPMLockout
 		}
-		return xerrors.Errorf("cannot configure dictionary attack parameters: %w", err)
+		return fmt.Errorf("cannot configure dictionary attack parameters: %w", err)
 	}
 
 	// Clear any lockout if there is one. This has to happen after setting the DA parameters
@@ -319,124 +424,16 @@ func (t *Connection) ensureProvisionedInternal(mode ProvisionMode, newLockoutAut
 	// value for the lockout hierarchy.
 	if err := t.ClearControl(t.LockoutHandleContext(), true, session); err != nil {
 		// Lockout auth failure or lockout mode would have been caught by DictionaryAttackParameters
-		return xerrors.Errorf("cannot disable owner clear: %w", err)
+		return fmt.Errorf("cannot disable owner clear: %w", err)
 	}
 
 	// Set the lockout hierarchy authorization. Use command parameter encryption here for the new value.
 	// Note that this only offers protections against passive interposers.
-	if err := t.HierarchyChangeAuth(t.LockoutHandleContext(), newLockoutAuth, session.IncludeAttrs(tpm2.AttrCommandEncrypt)); err != nil {
+	if err := t.HierarchyChangeAuth(t.LockoutHandleContext(), params.newLockoutAuthValue, session.IncludeAttrs(tpm2.AttrCommandEncrypt)); err != nil {
 		return xerrors.Errorf("cannot set the lockout hierarchy authorization value: %w", err)
 	}
 
 	return nil
-}
-
-// EnsureProvisionedWithCustomSRK prepares the TPM for full disk encryption. The mode parameter specifies the behaviour of this
-// function.
-//
-// EnsureProvisioned is generally preferred over this function.
-//
-// If mode is ProvisionModeClear, this function will attempt to clear the TPM before provisioning it. If owner clear has been
-// disabled (which will be the case if the TPM has previously been provisioned with this function), then ErrTPMClearRequiresPPI
-// will be returned. In this case, the TPM must be cleared via the physical presence interface by calling RequestTPMClearUsingPPI
-// and performing a system restart. Note that clearing the TPM makes all previously sealed keys permanently unrecoverable. This
-// mode should normally be used when resetting a device to factory settings (ie, performing a new installation).
-//
-// If mode is ProvisionModeClear or ProvisionModeFull, then the authorization value for the lockout hierarchy will be set to
-// newLockoutAuth, owner clear will be disabled, and the parameters of the TPM's dictionary attack logic will be configured to
-// appropriate values.
-//
-// If mode is ProvisionModeClear or ProvisionModeFull, this function performs operations that require the use of the lockout
-// hierarchy (detailed above), and knowledge of the lockout hierarchy's authorization value. This must be provided by calling
-// Connection.LockoutHandleContext().SetAuthValue() prior to this call. If the wrong lockout hierarchy authorization value is
-// provided, then a AuthFailError error will be returned. If this happens, the TPM will have entered dictionary attack lockout mode
-// for the lockout hierarchy. Further calls will result in a ErrTPMLockout error being returned. The only way to recover from this is
-// to either wait for the pre-programmed recovery time to expire, or to clear the TPM via the physical presence interface by calling
-// RequestTPMClearUsingPPI. If the lockout hierarchy authorization value is not known then mode should be set to
-// ProvisionModeWithoutLockout, with the caveat that this mode cannot fully provision the TPM.
-//
-// If mode is ProvisionModeFull or ProvisionModeWithoutLockout, this function will not affect the ability to recover sealed keys that
-// can currently be recovered.
-//
-// In all modes, this function will create and persist both a storage root key and an endorsement key. Both of these will be
-// persisted at the handles specied in the "TCG TPM v2.0 Provisioning Guidance" specification. The endorsement key will be
-// created using the RSA template defined in the "TCG EK Credential Profile for TPM Family 2.0" specification. The storage root
-// key will be created using the RSA template defined in the "TCG TPM v2.0 Provisioning Guidance" specification unless the
-// srkTemplate argument is supplied, in which case, this template will be used instead. If there are any objects already stored
-// at the locations required for either primary key, then this function will evict them automatically from the TPM. These
-// operations both require the use of the storage and endorsement hierarchies. If mode is ProvisionModeFull or
-// ProvisionModeWithoutLockout, then knowledge of the authorization values for these hierarchies is required. Whilst these will be
-// empty after clearing the TPM, if they have been set since clearing the TPM then they will need to be provided by calling
-// Connection.EndorsementHandleContext().SetAuthValue() and Connection.OwnerHandleContext().SetAuthValue() prior to calling
-// this function. If the wrong value is provided for either authorization, then a AuthFailError error will be returned. If the
-// correct authorization values are not known, then the only way to recover from this is to clear the TPM either by calling this
-// function with mode set to ProvisionModeClear (and providing the correct authorization value for the lockout hierarchy), or by
-// using the physical presence interface.
-//
-// If srkTemplate is supplied, it will be persisted inside the TPM. Future calls to EnsureProvisioned will use this template
-// unless mode is set to ProvisionModeClear. The template will also be used to recreate the storage root key during device
-// activation if the initial unsealing fails.
-//
-// If mode is ProvisionModeWithoutLockout but the TPM indicates that use of the lockout hierarchy is required to fully provision the
-// TPM (eg, to disable owner clear, set the lockout hierarchy authorization value or configure the DA lockout parameters), then a
-// ErrTPMProvisioningRequiresLockout error will be returned. In this scenario, the function will complete all operations that can be
-// completed without using the lockout hierarchy, but the function should be called again either with mode set to ProvisionModeFull
-// (if the authorization value for the lockout hierarchy is known), or ProvisionModeClear.
-func (t *Connection) EnsureProvisionedWithCustomSRK(mode ProvisionMode, newLockoutAuth []byte, srkTemplate *tpm2.Public) error {
-	if srkTemplate != nil && !srkTemplate.IsStorageParent() {
-		return errors.New("supplied SRK template is not valid for a parent key")
-	}
-
-	return t.ensureProvisionedInternal(mode, newLockoutAuth, srkTemplate, false)
-}
-
-// EnsureProvisioned prepares the TPM for full disk encryption. The mode parameter specifies the behaviour of this function.
-//
-// If mode is ProvisionModeClear, this function will attempt to clear the TPM before provisioning it. If owner clear has been
-// disabled (which will be the case if the TPM has previously been provisioned with this function), then ErrTPMClearRequiresPPI
-// will be returned. In this case, the TPM must be cleared via the physical presence interface by calling RequestTPMClearUsingPPI
-// and performing a system restart. Note that clearing the TPM makes all previously sealed keys permanently unrecoverable. This
-// mode should normally be used when resetting a device to factory settings (ie, performing a new installation).
-//
-// If mode is ProvisionModeClear or ProvisionModeFull, then the authorization value for the lockout hierarchy will be set to
-// newLockoutAuth, owner clear will be disabled, and the parameters of the TPM's dictionary attack logic will be configured to
-// appropriate values.
-//
-// If mode is ProvisionModeClear or ProvisionModeFull, this function performs operations that require the use of the lockout
-// hierarchy (detailed above), and knowledge of the lockout hierarchy's authorization value. This must be provided by calling
-// Connection.LockoutHandleContext().SetAuthValue() prior to this call. If the wrong lockout hierarchy authorization value is
-// provided, then a AuthFailError error will be returned. If this happens, the TPM will have entered dictionary attack lockout mode
-// for the lockout hierarchy. Further calls will result in a ErrTPMLockout error being returned. The only way to recover from this is
-// to either wait for the pre-programmed recovery time to expire, or to clear the TPM via the physical presence interface by calling
-// RequestTPMClearUsingPPI. If the lockout hierarchy authorization value is not known then mode should be set to
-// ProvisionModeWithoutLockout, with the caveat that this mode cannot fully provision the TPM.
-//
-// If mode is ProvisionModeFull or ProvisionModeWithoutLockout, this function will not affect the ability to recover sealed keys that
-// can currently be recovered.
-//
-// In all modes, this function will create and persist both a storage root key and an endorsement key. Both of these will be
-// persisted at the handles specied in the "TCG TPM v2.0 Provisioning Guidance" specification. The endorsement key will be
-// created using the RSA template defined in the "TCG EK Credential Profile for TPM Family 2.0" specification. The storage root
-// key will be created using the RSA template defined in the "TCG TPM v2.0 Provisioning Guidance" specification unless the
-// TPM has previously been provisioned with a custom SRK template using the EnsureProvisionedWithCustomSRK function and mode is
-// not ProvisionModeClear, in which case, the originally supplied template will be used instead. If there are any objects already
-// stored at the locations required for either primary key, then this function will evict them automatically from the TPM. These
-// operations both require the use of the storage and endorsement hierarchies. If mode is ProvisionModeFull or
-// ProvisionModeWithoutLockout, then knowledge of the authorization values for these hierarchies is required. Whilst these will be
-// empty after clearing the TPM, if they have been set since clearing the TPM then they will need to be provided by calling
-// Connection.EndorsementHandleContext().SetAuthValue() and Connection.OwnerHandleContext().SetAuthValue() prior to calling
-// this function. If the wrong value is provided for either authorization, then a AuthFailError error will be returned. If the
-// correct authorization values are not known, then the only way to recover from this is to clear the TPM either by calling this
-// function with mode set to ProvisionModeClear (and providing the correct authorization value for the lockout hierarchy), or by
-// using the physical presence interface.
-//
-// If mode is ProvisionModeWithoutLockout but the TPM indicates that use of the lockout hierarchy is required to fully provision the
-// TPM (eg, to disable owner clear, set the lockout hierarchy authorization value or configure the DA lockout parameters), then a
-// ErrTPMProvisioningRequiresLockout error will be returned. In this scenario, the function will complete all operations that can be
-// completed without using the lockout hierarchy, but the function should be called again either with mode set to ProvisionModeFull
-// (if the authorization value for the lockout hierarchy is known), or ProvisionModeClear.
-func (t *Connection) EnsureProvisioned(mode ProvisionMode, newLockoutAuth []byte) error {
-	return t.ensureProvisionedInternal(mode, newLockoutAuth, nil, true)
 }
 
 // RequestTPMClearUsingPPI submits a request to the firmware to clear the TPM on the next reboot. This is the only way to clear

--- a/tpm2/provisioning_test.go
+++ b/tpm2/provisioning_test.go
@@ -102,7 +102,7 @@ type testProvisionNewTPMData struct {
 func (s *provisioningSimulatorSuite) testProvisionNewTPM(c *C, data *testProvisionNewTPMData) {
 	origHmacSession := s.TPM().HmacSession()
 
-	c.Check(s.TPM().EnsureProvisioned(data.mode, data.lockoutAuth), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(data.mode.Option(), WithProvisionNewLockoutAuthValue(data.lockoutAuth)), IsNil)
 	s.AddCleanup(func() {
 		// github.com/canonical/go-tpm2/testutil cannot restore this because
 		// EnsureProvisioned uses command parameter encryption. We have to do
@@ -196,7 +196,7 @@ func (s *provisioningSimulatorSuite) testProvisionErrorHandling(c *C, mode Provi
 		// else the test fixture fails the test.
 		s.ClearTPMUsingPlatformHierarchy(c)
 	}()
-	return s.TPM().EnsureProvisioned(mode, nil)
+	return s.TPM().EnsureProvisioned(mode.Option())
 }
 
 func (s *provisioningSuite) testProvisionErrorHandling(c *C, mode ProvisionMode) error {
@@ -206,7 +206,7 @@ func (s *provisioningSuite) testProvisionErrorHandling(c *C, mode ProvisionMode)
 		// else the test fixture fails the test.
 		s.ClearTPMUsingPlatformHierarchy(c)
 	}()
-	return s.TPM().EnsureProvisioned(mode, nil)
+	return s.TPM().EnsureProvisioned(mode.Option())
 }
 
 func (s *provisioningSuite) TestProvisionErrorHandlingClearRequiresPPI(c *C) {
@@ -328,7 +328,7 @@ func (s *provisioningSimulatorSuite) TestProvisionErrorHandlingRequiresLockout5(
 func (s *provisioningSuite) testProvisionRecreateEK(c *C, mode ProvisionMode) {
 	lockoutAuth := []byte("1234")
 
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeFull, lockoutAuth), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(WithProvisionNewLockoutAuthValue(lockoutAuth)), IsNil)
 	s.AddCleanup(func() {
 		// github.com/canonical/go-tpm2/testutil cannot restore this because
 		// EnsureProvisioned uses command parameter encryption. We have to do
@@ -342,7 +342,7 @@ func (s *provisioningSuite) testProvisionRecreateEK(c *C, mode ProvisionMode) {
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, ek, ek.Handle())
 
-	c.Check(s.TPM().EnsureProvisioned(mode, lockoutAuth), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(mode.Option(), WithProvisionNewLockoutAuthValue(lockoutAuth)), IsNil)
 
 	s.validateEK(c)
 	s.validateSRK(c)
@@ -364,7 +364,7 @@ func (s *provisioningSuite) TestRecreateEKWithoutLockout(c *C) {
 func (s *provisioningSuite) testProvisionRecreateSRK(c *C, mode ProvisionMode) {
 	lockoutAuth := []byte("1234")
 
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeFull, lockoutAuth), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(WithProvisionNewLockoutAuthValue(lockoutAuth)), IsNil)
 	s.AddCleanup(func() {
 		// github.com/canonical/go-tpm2/testutil cannot restore this because
 		// EnsureProvisioned uses command parameter encryption. We have to do
@@ -377,7 +377,7 @@ func (s *provisioningSuite) testProvisionRecreateSRK(c *C, mode ProvisionMode) {
 	expectedName := srk.Name()
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
-	c.Check(s.TPM().EnsureProvisioned(mode, lockoutAuth), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(mode.Option(), WithProvisionNewLockoutAuthValue(lockoutAuth)), IsNil)
 
 	s.validateEK(c)
 	s.validateSRK(c)
@@ -398,7 +398,7 @@ func (s *provisioningSuite) TestProvisionRecreateSRKWithoutLockout(c *C) {
 func (s *provisioningSuite) TestProvisionWithEndorsementAuth(c *C) {
 	s.HierarchyChangeAuth(c, tpm2.HandleEndorsement, []byte("1234"))
 
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Check(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 
 	s.validateEK(c)
@@ -408,7 +408,7 @@ func (s *provisioningSuite) TestProvisionWithEndorsementAuth(c *C) {
 func (s *provisioningSuite) TestProvisionWithOwnerAuth(c *C) {
 	s.HierarchyChangeAuth(c, tpm2.HandleOwner, []byte("1234"))
 
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Check(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 
 	s.validateEK(c)
@@ -430,7 +430,7 @@ func (s *provisioningSuite) testProvisionWithCustomSRKTemplate(c *C, mode Provis
 				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
 				KeyBits:  2048,
 				Exponent: 0}}}
-	c.Check(s.TPM().EnsureProvisionedWithCustomSRK(mode, nil, &template), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(mode.Option(), WithCustomSRKTemplate(&template)), IsNil)
 
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, &template)
 
@@ -469,7 +469,7 @@ func (s *provisioningSuite) TestProvisionWithInvalidCustomSRKTemplate(c *C) {
 				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
 				KeyBits:  2048,
 				Exponent: 0}}}
-	err := s.TPM().EnsureProvisionedWithCustomSRK(ProvisionModeFull, nil, &template)
+	err := s.TPM().EnsureProvisioned(WithCustomSRKTemplate(&template))
 	c.Check(err, ErrorMatches, "supplied SRK template is not valid for a parent key")
 }
 
@@ -490,7 +490,7 @@ func (s *provisioningSuite) testProvisionDefaultPreservesCustomSRKTemplate(c *C,
 				Exponent: 0}}}
 
 	lockoutAuth := []byte("1234")
-	c.Check(s.TPM().EnsureProvisionedWithCustomSRK(ProvisionModeFull, lockoutAuth, &template), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(WithProvisionNewLockoutAuthValue(lockoutAuth), WithCustomSRKTemplate(&template)), IsNil)
 	s.AddCleanup(func() {
 		// github.com/canonical/go-tpm2/testutil cannot restore this because
 		// EnsureProvisioned uses command parameter encryption. We have to do
@@ -502,7 +502,7 @@ func (s *provisioningSuite) testProvisionDefaultPreservesCustomSRKTemplate(c *C,
 	c.Assert(err, IsNil)
 	s.EvictControl(c, tpm2.HandleOwner, srk, srk.Handle())
 
-	c.Check(s.TPM().EnsureProvisioned(mode, lockoutAuth), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(mode.Option(), WithProvisionNewLockoutAuthValue(lockoutAuth)), IsNil)
 
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, &template)
 }
@@ -530,11 +530,11 @@ func (s *provisioningSuite) TestProvisionDefaultClearRemovesCustomSRKTemplate(c 
 				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
 				KeyBits:  2048,
 				Exponent: 0}}}
-	c.Check(s.TPM().EnsureProvisionedWithCustomSRK(ProvisionModeWithoutLockout, nil, &template),
+	c.Check(s.TPM().EnsureProvisioned(ProvisionWithoutLockout(), WithCustomSRKTemplate(&template)),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, &template)
 
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeClear, nil), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(WithClearBeforeProvision()), IsNil)
 	s.validateSRK(c)
 }
 
@@ -553,7 +553,7 @@ func (s *provisioningSuite) TestProvisionWithCustomSRKTemplateOverwritesExisting
 				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
 				KeyBits:  2048,
 				Exponent: 0}}}
-	c.Check(s.TPM().EnsureProvisionedWithCustomSRK(ProvisionModeFull, nil, &template1), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(WithCustomSRKTemplate(&template1)), IsNil)
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, &template1)
 
 	template2 := tpm2.Public{
@@ -570,7 +570,7 @@ func (s *provisioningSuite) TestProvisionWithCustomSRKTemplateOverwritesExisting
 				Scheme:   tpm2.RSAScheme{Scheme: tpm2.RSASchemeNull},
 				KeyBits:  2048,
 				Exponent: 0}}}
-	c.Check(s.TPM().EnsureProvisionedWithCustomSRK(ProvisionModeFull, nil, &template2), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(WithCustomSRKTemplate(&template2)), IsNil)
 	s.validatePrimaryKeyAgainstTemplate(c, tpm2.HandleOwner, tcg.SRKHandle, &template2)
 
 	nv, err := s.TPM().NewResourceContext(0x01810001)

--- a/tpm2/seal_legacy_test.go
+++ b/tpm2/seal_legacy_test.go
@@ -56,7 +56,7 @@ func (s *sealLegacySuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
-	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 

--- a/tpm2/seal_test.go
+++ b/tpm2/seal_test.go
@@ -83,7 +83,7 @@ func (s *sealSuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
-	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 	origKdf := secboot.SetArgon2KDF(&testutil.MockArgon2KDF{})
 	s.AddCleanup(func() { secboot.SetArgon2KDF(origKdf) })

--- a/tpm2/tpm_test.go
+++ b/tpm2/tpm_test.go
@@ -104,7 +104,7 @@ func (s *tpmSuitePlatform) TestConnectionLockoutAuthSet(c *C) {
 	c.Check(s.TPM().LockoutAuthSet(), testutil.IsFalse)
 
 	// FullProvising of the TPM puts it in DA lockout mode
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeFull, []byte("1234")), IsNil)
+	c.Check(s.TPM().EnsureProvisioned(WithProvisionNewLockoutAuthValue([]byte("1234"))), IsNil)
 	s.AddCleanup(func() {
 		c.Check(s.TPM().HierarchyChangeAuth(s.TPM().LockoutHandleContext(), nil, nil), IsNil)
 	})
@@ -139,7 +139,7 @@ func (s *tpmSuiteSimulator) TestConnectToDefaultTPMUnprovisioned(c *C) {
 }
 
 func (s *tpmSuite) TestConnectToDefaultTPMProvisioned(c *C) {
-	c.Check(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Check(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 	s.AddCleanup(s.CloseMockConnection(c))
 	s.testConnectToDefaultTPM(c, true)

--- a/tpm2/unseal_legacy_test.go
+++ b/tpm2/unseal_legacy_test.go
@@ -48,7 +48,7 @@ func (s *unsealSuite) SetUpSuite(c *C) {
 
 func (s *unsealSuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
-	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 

--- a/tpm2/update_legacy_test.go
+++ b/tpm2/update_legacy_test.go
@@ -53,7 +53,7 @@ func (s *updateLegacySuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
-	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 

--- a/tpm2/update_test.go
+++ b/tpm2/update_test.go
@@ -49,7 +49,7 @@ func (s *updateSuite) SetUpTest(c *C) {
 	s.TPMTest.SetUpTest(c)
 
 	s.primaryKeyMixin.tpmTest = &s.TPMTest.TPMTest
-	c.Assert(s.TPM().EnsureProvisioned(ProvisionModeWithoutLockout, nil),
+	c.Assert(s.TPM().EnsureProvisioned(ProvisionWithoutLockout()),
 		testutil.InSlice(Equals), []error{ErrTPMProvisioningRequiresLockout, nil})
 }
 


### PR DESCRIPTION
Future PRs are going to introduce additional parameters to this function
and change its behaviour. Having it accept a variable length set of
options is going to scale better than the current API.

This PR doesn't change any of its behaviour yet.