### PR TITLE
Remove flags field from NewAtomicFile calls

### DIFF
--- a/keydata_file.go
+++ b/keydata_file.go
@@ -69,7 +69,7 @@ type FileKeyDataWriter struct {
 }
 
 func (w *FileKeyDataWriter) Commit() error {
-	f, err := osutil.NewAtomicFile(w.path, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
+	f, err := osutil.NewAtomicFile(w.path, 0600, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
 	if err != nil {
 		return xerrors.Errorf("cannot create new atomic file: %w", err)
 	}

--- a/tpm2/keydata_legacy.go
+++ b/tpm2/keydata_legacy.go
@@ -194,7 +194,7 @@ type FileSealedKeyObjectWriter struct {
 }
 
 func (w *FileSealedKeyObjectWriter) Commit() (err error) {
-	f, err := osutil.NewAtomicFile(w.path, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
+	f, err := osutil.NewAtomicFile(w.path, 0600, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `osutil.AtomicWriteFlags` has had its only flag value removed from snapd, as that flag had been unused since 2016. Now, since all the `flags osutil.AtomicWriteFlags` fields were ignored, we want to remove those fields from snapd as well. However, snapd vendors secboot, and secboot uses `osutil.NewAtomicFile` from snapd, so we can't make the change in snapd without first making the change in secboot.

Once this secboot change lands and a new secboot build is available, then we can bump the secboot version used by snapd within the PR which changes the `osutil` function signatures. Then, after that PR within snapd lands, we can bump the snapd version which secboot builds against.

That PR within snapd is https://github.com/canonical/snapd/pull/17129